### PR TITLE
chore: publish releases from zana

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
 
       - name: Build app
         run: npm run build
+        env:
+          # The renderer bundle includes Monaco and exceeds Node's default heap
+          # on GitHub-hosted runners.
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: E2E tests
         run: xvfb-run -a npm run test:e2e:only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,7 +422,7 @@ The few that matter. (Fuller rationale: `docs/review-consensus-2026-06.md`.)
   integration points. An environment-specific integration belongs in a separately
   distributed extension, never in the app source tree.
 
-- **Release artifacts are published to the PUBLIC repo github.com/grebmann1/zcc-releases.**
+- **Release artifacts are published to the PUBLIC repo github.com/salesforce/zana.**
   The auto-updater reads that public feed anonymously (no token, no VPN). When
   cutting a release, publish the new build there (`npm run release:mac` builds,
   notarizes, and publishes) so the auto-updater can offer it. See

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Zana Command Center is a desktop app (Electron) that turns Claude Code from a si
 ![Zana Command Center — orchestrating Claude Code sessions across projects](docs/assets/zana-command-center-demo.gif)
 
 <p align="center">
-  <a href="https://github.com/grebmann1/zcc-releases/releases/latest">
+  <a href="https://github.com/salesforce/zana/releases/latest">
     <img alt="Download the latest release" src="https://img.shields.io/badge/⬇_Download-Latest_Release-2ea44f?style=for-the-badge">
   </a>
 </p>
@@ -17,7 +17,7 @@ Zana Command Center is a desktop app (Electron) that turns Claude Code from a si
 ## Install
 
 > 💡 **Easiest path:** grab the installer from the
-> **[latest GitHub Release](https://github.com/grebmann1/zcc-releases/releases/latest)**
+> **[latest GitHub Release](https://github.com/salesforce/zana/releases/latest)**
 > (button above) and open the `.dmg`. No build step.
 
 **Recommended:** download and install the app from the **latest GitHub Release**

--- a/docs/auto-update-setup.md
+++ b/docs/auto-update-setup.md
@@ -7,7 +7,7 @@ GitHub Releases, signed with an Apple Developer ID certificate and notarized.
 ## How it works
 
 - electron-builder publishes `latest-mac.yml` + a `.zip` + `.dmg` to the public
-  GitHub Release repo **github.com/grebmann1/zcc-releases** for each `v*` tag
+  GitHub Release repo **github.com/salesforce/zana** for each `v*` tag
   (`publish:` block in `electron-builder.yml`).
 - On launch (and from **Settings → About → Check for updates**), the packaged
   app fetches `latest-mac.yml` from that public repo **anonymously** (no token,
@@ -72,10 +72,8 @@ base64 -i ZCC-DeveloperID.p12 | pbcopy
 
 ## One-time: add GitHub repo secrets
 
-You must configure these secrets in the **grebmann1/zcc-releases** GitHub repo
-(or your own fork if building locally) for CI publishing. The app SOURCE CODE
-repo does NOT need these secrets since the RELEASE ARTIFACTS are published to
-the separate public releases repo.
+You must configure these secrets in the **salesforce/zana** GitHub repository
+(or your own fork if building locally) for CI publishing.
 
 ### Finding your secrets
 
@@ -111,7 +109,7 @@ The password you set when exporting the .p12.
 
 ### Adding secrets to GitHub
 
-In the **grebmann1/zcc-releases** repo (on `github.com`):
+In the **salesforce/zana** repo (on `github.com`):
 
 1. Settings → Secrets and variables → Actions
 2. Click "New repository secret" for each:

--- a/docs/release-hosting.md
+++ b/docs/release-hosting.md
@@ -1,13 +1,9 @@
 # Release hosting — auto-updater feed + extension marketplace
 
-**Status:** As of 2026-07, release artifacts are published to the PUBLIC repo
-**github.com/grebmann1/zcc-releases** via electron-builder's github publish
-provider. The auto-updater reads `latest-mac.yml` + artifacts from that repo's
-GitHub Releases anonymously — no token or VPN required.
-
-The app SOURCE CODE lives on a separate public GitHub repo — only the RELEASE
-ARTIFACTS (the installable binaries, not the source) are published to the
-dedicated releases repo above.
+**Status:** Release artifacts are published to the public
+**github.com/salesforce/zana** repository via electron-builder's GitHub publish
+provider. The auto-updater reads `latest-mac.yml` and artifacts from that
+repository's GitHub Releases anonymously — no token or VPN required.
 
 ## Public release architecture
 
@@ -57,7 +53,7 @@ invariant):
 
 - **Updater** (`src/main/updater.ts`): if `ZCC_UPDATE_FEED_URL` (HTTPS) is set,
   the updater calls `autoUpdater.setFeedURL({ provider: 'generic', url })`,
-  overriding the GHE `publish` block. Unset → unchanged GHE behavior. Non-HTTPS →
+  overriding the GitHub `publish` block. Unset → unchanged GitHub behavior. Non-HTTPS →
   ignored (logged), never silently insecure.
 - **Marketplace** (`src/main/extension-registry.ts`): `ZCC_EXTENSION_REGISTRY_URL`
   supplies `registryUrl` when `~/.zcc/extension-registry.json` opts in
@@ -69,7 +65,7 @@ app's config seam) once the base URL exists.
 
 ## Publishing a release (runbook)
 
-Releases are built **locally** and published to **github.com/grebmann1/zcc-releases**
+Releases are built **locally** and published to **github.com/salesforce/zana**
 via electron-builder's `github` publish provider. No CI secrets required — you
 authenticate with your personal GitHub token (set as `GH_TOKEN` env var).
 
@@ -99,7 +95,7 @@ current version's file is shown in the auto-modal; the About screen can show the
 full history.)
 
 ```sh
-# Build, sign, notarize, and publish to github.com/grebmann1/zcc-releases
+# Build, sign, notarize, and publish to github.com/salesforce/zana
 # (release:mac runs the notes guard first, so a missing notes file stops here).
 export GH_TOKEN=<your-github-personal-access-token>
 npm run release:mac
@@ -108,7 +104,7 @@ npm run release:mac
 This produces `dist/latest-mac.yml` + `dist/*.zip` + `dist/*.dmg` (signed +
 notarized) and uploads them to the GitHub Release for the current version tag.
 **IMPORTANT:** After the release workflow completes, go to
-github.com/grebmann1/zcc-releases/releases and **mark the Release as published**
+github.com/salesforce/zana/releases and **mark the Release as published**
 (not draft) so the auto-updater can see it. The updater reads that repo
 anonymously, so a draft Release is invisible to it.
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -81,13 +81,13 @@ extraResources:
 # host/owner/repo are explicit (not derived from package.json) so a stale
 # `homepage` can't point the updater at the wrong repo.
 #
-# The release feed is the public github.com repo grebmann1/zcc-releases.
+# The release feed is the public github.com repo salesforce/zana.
 # electron-updater's `GitHubProvider` reads latest-mac.yml and artifacts
 # anonymously (no token, no VPN). Omitting `host:` defaults to public github.com.
 publish:
   provider: github
-  owner: grebmann1
-  repo: zcc-releases
+  owner: salesforce
+  repo: zana
 
 asar: true
 asarUnpack:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "zana-command-center",
       "version": "1.0.9",
+      "license": "MIT",
       "workspaces": [
         "packages/*",
         "website"
@@ -2503,9 +2504,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2521,9 +2519,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2541,9 +2536,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2559,9 +2551,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2579,9 +2568,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2597,9 +2583,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2617,9 +2600,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2636,9 +2616,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2654,9 +2631,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2680,9 +2654,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2704,9 +2675,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2730,9 +2698,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2754,9 +2719,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2780,9 +2742,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2805,9 +2764,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2829,9 +2785,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3412,9 +3365,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3434,9 +3384,6 @@
       "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3458,9 +3405,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3481,9 +3425,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3503,9 +3444,6 @@
       "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3624,9 +3562,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3642,9 +3577,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3662,9 +3594,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3680,9 +3609,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4711,9 +4637,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4729,9 +4652,6 @@
       "integrity": "sha512-9yo6/G454L8ebzZP1qMxjIXRD3zJqQ68w2p9Ust7B7MOj5hr+VyuVZ0kYjSJAc4GSI0fno2xQe5z2tp5ynk78A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -13506,6 +13426,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15913,6 +15834,474 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
@@ -15938,6 +16327,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/src/main/__tests__/git-commit-push.test.ts
+++ b/src/main/__tests__/git-commit-push.test.ts
@@ -34,6 +34,11 @@ describe('Git workflow primitives', () => {
     repo = realpathSync(await mkdtemp(join(tmpdir(), 'zcc-git-')));
     remote = realpathSync(await mkdtemp(join(tmpdir(), 'zcc-git-remote-')));
     await git(repo, 'init', '-b', 'main');
+    // The implementation invokes git without test-only environment overrides.
+    // Keep the fixture self-contained instead of depending on a developer's
+    // global Git identity.
+    await git(repo, 'config', 'user.name', 'Test');
+    await git(repo, 'config', 'user.email', 'test@example.com');
     await writeFile(join(repo, 'file.txt'), 'one\n');
     await git(repo, 'add', '.');
     await git(repo, 'commit', '-m', 'initial');

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -306,7 +306,7 @@ export function createUpdater(deps: UpdaterDeps): Updater {
   }
 
   // Feed host is config, not code: the `publish` block in electron-builder.yml
-  // defaults to the public github.com release repo (grebmann1/zcc-releases), so
+  // defaults to the public github.com release repo (salesforce/zana), so
   // electron-updater's built-in `GitHubProvider` works anonymously with no token
   // or VPN. When `ZCC_UPDATE_FEED_URL` is set, point the updater at that static
   // HTTPS base via electron-updater's `generic` provider instead — it reads

--- a/src/renderer/components/settings/AboutTab.tsx
+++ b/src/renderer/components/settings/AboutTab.tsx
@@ -76,7 +76,7 @@ function updateStatusView(
 }
 
 /** Public release feed — the About tab links here for full release notes. */
-const RELEASE_NOTES_URL = 'https://github.com/grebmann1/zcc-releases/releases';
+const RELEASE_NOTES_URL = 'https://github.com/salesforce/zana/releases';
 
 /**
  * The update-status "card": a status-first surface (icon + title + detail on the

--- a/website/content/docs/release-hosting.md
+++ b/website/content/docs/release-hosting.md
@@ -1,13 +1,9 @@
 # Release hosting — auto-updater feed + extension marketplace
 
-**Status:** As of 2026-07, release artifacts are published to the PUBLIC repo
-**github.com/grebmann1/zcc-releases** via electron-builder's github publish
-provider. The auto-updater reads `latest-mac.yml` + artifacts from that repo's
-GitHub Releases anonymously — no token or VPN required.
-
-The app SOURCE CODE lives on a separate public GitHub repo — only the RELEASE
-ARTIFACTS (the installable binaries, not the source) are published to the
-dedicated releases repo above.
+**Status:** Release artifacts are published to the public
+**github.com/salesforce/zana** repository via electron-builder's GitHub publish
+provider. The auto-updater reads `latest-mac.yml` and artifacts from that
+repository's GitHub Releases anonymously — no token or VPN required.
 
 ## Public release architecture
 
@@ -57,7 +53,7 @@ invariant):
 
 - **Updater** (`src/main/updater.ts`): if `ZCC_UPDATE_FEED_URL` (HTTPS) is set,
   the updater calls `autoUpdater.setFeedURL({ provider: 'generic', url })`,
-  overriding the GHE `publish` block. Unset → unchanged GHE behavior. Non-HTTPS →
+  overriding the GitHub `publish` block. Unset → unchanged GitHub behavior. Non-HTTPS →
   ignored (logged), never silently insecure.
 - **Marketplace** (`src/main/extension-registry.ts`): `ZCC_EXTENSION_REGISTRY_URL`
   supplies `registryUrl` when `~/.zcc/extension-registry.json` opts in
@@ -69,7 +65,7 @@ app's config seam) once the base URL exists.
 
 ## Publishing a release (runbook)
 
-Releases are built **locally** and published to **github.com/grebmann1/zcc-releases**
+Releases are built **locally** and published to **github.com/salesforce/zana**
 via electron-builder's `github` publish provider. No CI secrets required — you
 authenticate with your personal GitHub token (set as `GH_TOKEN` env var).
 
@@ -99,7 +95,7 @@ current version's file is shown in the auto-modal; the About screen can show the
 full history.)
 
 ```sh
-# Build, sign, notarize, and publish to github.com/grebmann1/zcc-releases
+# Build, sign, notarize, and publish to github.com/salesforce/zana
 # (release:mac runs the notes guard first, so a missing notes file stops here).
 export GH_TOKEN=<your-github-personal-access-token>
 npm run release:mac
@@ -108,7 +104,7 @@ npm run release:mac
 This produces `dist/latest-mac.yml` + `dist/*.zip` + `dist/*.dmg` (signed +
 notarized) and uploads them to the GitHub Release for the current version tag.
 **IMPORTANT:** After the release workflow completes, go to
-github.com/grebmann1/zcc-releases/releases and **mark the Release as published**
+github.com/salesforce/zana/releases and **mark the Release as published**
 (not draft) so the auto-updater can see it. The updater reads that repo
 anonymously, so a draft Release is invisible to it.
 

--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -4,10 +4,8 @@ export const site = {
   tagline: 'Run and orchestrate many Claude Code sessions across all your projects from one window.',
   repo: 'https://github.com/salesforce/zana',
   /** PUBLIC release feed (github.com) — where the notarized artifacts +
-   *  latest-mac.yml live and the auto-updater reads anonymously. Separate from
-   *  `repo` (the SOURCE) so the download button points at the public
-   *  releases while `git clone` still targets the source repo. */
-  releasesRepo: 'https://github.com/grebmann1/zcc-releases',
+   *  latest-mac.yml live and the auto-updater reads anonymously. */
+  releasesRepo: 'https://github.com/salesforce/zana',
   /** Canonical README on the repo host — the docs "Getting started" links here
    *  rather than re-rendering a copy that drifts from the source. */
   readmeUrl: 'https://github.com/salesforce/zana/blob/main/README.md',


### PR DESCRIPTION
## Summary
- publish Electron update artifacts from `salesforce/zana`
- route download, release notes, and documentation links to the unified repository
- update release-secret guidance for the unified release workflow

## Verification
- `npm run typecheck`
- `npx vitest run src/main/updater.test.ts` (28 passed)
- pre-push suite: 386 passed, 5 skipped; 4,496 passed, 51 skipped