### PR TITLE
fix: split "Extra args" into separate argv tokens

### DIFF
--- a/src/renderer/components/AgentLauncher.tsx
+++ b/src/renderer/components/AgentLauncher.tsx
@@ -60,7 +60,7 @@ import { useData, useUi, usePersonas, useTeams, sortProjectsAlphabetically } fro
 import { profileIcon, personaIcon } from '../util/profileIcon';
 import { resolveIcon } from '../util/resolveIcon';
 import { PromptComposer, type PromptComposerHandle } from './PromptComposer';
-import { ChipField } from './settings/FormFields';
+import { TextArgsField } from './settings/FormFields';
 import { ClaudeSessionsList } from './ClaudeSessionsList';
 import { titleFromPrompt } from '../util/promptTitle';
 import { useDialogFocusTrap } from '../util/useDialogFocusTrap';
@@ -2042,11 +2042,11 @@ export const AgentLauncher = memo(function AgentLauncher({
 
               {family && (
                 <div className="launch-extra-args" id="agent-launcher-extra-args">
-                  <ChipField
+                  <TextArgsField
                     key={family.id}
                     label="Extra args"
                     values={extraArgsFor(family.id)}
-                    placeholder="--plugin-dir"
+                    placeholder="--plugin-dir /path/to/plugin"
                     onChange={(vals) => setExtraArgsForFamily(family.id, vals)}
                   />
                 </div>

--- a/src/renderer/components/settings/FormFields.tsx
+++ b/src/renderer/components/settings/FormFields.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 
 export function Section({
@@ -178,6 +178,93 @@ export function ChipField({
           aria-label={`Add ${label}`}
         />
       </div>
+      {help && <p className="settings-help">{help}</p>}
+    </div>
+  );
+}
+
+/**
+ * Tokenize a single argv-style line into tokens: split on whitespace, with
+ * quoted segments (`"..."` / `'...'`) kept as one token so a path containing
+ * a space can still be entered without being torn in two. Pure — exported for
+ * direct unit testing.
+ */
+export function tokenizeArgsLine(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  const tokens: string[] = [];
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(trimmed))) {
+    const token = match[1] ?? match[2] ?? match[3];
+    if (token) tokens.push(token);
+  }
+  return tokens;
+}
+
+/**
+ * Plain-text alternative to `ChipField` for argv-shaped settings ("Extra
+ * args") — one text box, space-separated, exactly like typing flags on a
+ * command line. Avoids the chip UI's parsing ambiguity: a chip is one
+ * visually discrete unit, so users naturally typed a whole `--flag value`
+ * pair into one chip, which then got spliced into argv as a single
+ * malformed token (`unknown option '--plugin-dir /some/path'`). A plain text
+ * field carries no such expectation — `tokenizeArgsLine` splits it on
+ * whitespace on blur/commit, same as a shell would.
+ *
+ * `values` (the stored `string[]`) is joined with spaces for display; typing
+ * re-tokenizes on blur so the stored array stays the single source of truth
+ * every launch path already consumes.
+ */
+export function TextArgsField({
+  label,
+  help,
+  values,
+  placeholder,
+  onChange
+}: {
+  label: string;
+  help?: React.ReactNode;
+  values: string[];
+  placeholder?: string;
+  onChange: (vals: string[]) => void;
+}) {
+  const [input, setInput] = useState(values.join(' '));
+  const focused = useRef(false);
+
+  // The callers of this field (project/global settings) don't remount when
+  // their underlying record swaps (e.g. switching the selected project) —
+  // resync the draft from the live `values` whenever it changes, UNLESS the
+  // user is actively typing, so an in-flight edit is never clobbered.
+  useEffect(() => {
+    if (!focused.current) setInput(values.join(' '));
+  }, [values]);
+
+  const commit = (raw: string) => {
+    const tokens = tokenizeArgsLine(raw);
+    onChange(tokens);
+    setInput(tokens.join(' '));
+  };
+
+  return (
+    <div className="settings-field settings-field--mono">
+      <span className="settings-label">{label}</span>
+      <input
+        type="text"
+        className="settings-input-full"
+        value={input}
+        placeholder={placeholder}
+        onFocus={() => { focused.current = true; }}
+        onChange={(e) => setInput(e.target.value)}
+        onBlur={(e) => { focused.current = false; commit(e.target.value); }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            commit(input);
+          }
+        }}
+        spellCheck={false}
+      />
       {help && <p className="settings-help">{help}</p>}
     </div>
   );

--- a/src/renderer/components/settings/HarnessTab.tsx
+++ b/src/renderer/components/settings/HarnessTab.tsx
@@ -4,7 +4,7 @@ import type { AppConfig, HarnessFamily, HarnessVerifyResult, LaunchProfileId } f
 import type { HarnessAdapterDescriptor } from '@shared/harness-adapter';
 import { useData } from '../../store';
 import { profileIcon } from '../../util/profileIcon';
-import { Section, Field, ToggleSwitch, ChipField } from './FormFields';
+import { Section, Field, ToggleSwitch, ChipField, TextArgsField } from './FormFields';
 import { HarnessOptionSelect } from '../HarnessOptionSelect';
 import { providerUiSchema } from '@shared/launch-provider';
 
@@ -368,11 +368,11 @@ export function HarnessTab({
           placeholder="Optional"
         />
       </Field>
-      <ChipField
+      <TextArgsField
         label="Extra args"
         help="Applied first. If a later Project, Persona, or Agent setting uses the same option, the later setting takes priority."
         values={config.claudeExtraArgs ?? []}
-        placeholder="--verbose"
+        placeholder="--plugin-dir /path/to/plugin"
         onChange={(values) => void onUpdate({ claudeExtraArgs: values.length ? values : undefined })}
       />
       <ChipField

--- a/src/renderer/components/settings/ProjectTab.tsx
+++ b/src/renderer/components/settings/ProjectTab.tsx
@@ -13,7 +13,7 @@ import type {
 import type { HarnessAdapterDescriptor } from '@shared/harness-adapter';
 import { providerUiSchema } from '@shared/launch-provider';
 import { useData, useUi } from '../../store';
-import { Section, Field, ChipField } from './FormFields';
+import { Section, Field, ChipField, TextArgsField } from './FormFields';
 import { HarnessOptionSelect } from '../HarnessOptionSelect';
 import { profileIcon } from '../../util/profileIcon';
 
@@ -759,11 +759,11 @@ function ClaudeProjectLaunchFields({
       </Field>
 
 
-      <ChipField
+      <TextArgsField
         label="Extra args"
         help="Applied after Global args and before Persona and Agent args. Later settings take priority when the same option appears more than once."
         values={settings.extraArgs ?? []}
-        placeholder="--verbose"
+        placeholder="--plugin-dir /path/to/plugin"
         onChange={(vals) => save({ extraArgs: vals.length ? vals : undefined })}
       />
 

--- a/src/renderer/components/settings/__tests__/FormFields.test.tsx
+++ b/src/renderer/components/settings/__tests__/FormFields.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { tokenizeArgsLine } from '../FormFields';
+
+/**
+ * Pins the fix for "Extra args" splicing a whole `--flag value` string into
+ * argv as ONE token (e.g. `claude --plugin-dir /some/path` failing with
+ * `unknown option '--plugin-dir /some/path'`). "Extra args" now uses
+ * `TextArgsField` — a single text box, not a chip-per-token UI — and
+ * `tokenizeArgsLine` is what turns that one line into the `string[]` every
+ * launch path expects, splitting on whitespace like a shell would.
+ */
+describe('tokenizeArgsLine', () => {
+  it('splits a flag and its value into separate tokens', () => {
+    expect(tokenizeArgsLine('--plugin-dir /Users/grebmann/dummy-test-plugin')).toEqual([
+      '--plugin-dir',
+      '/Users/grebmann/dummy-test-plugin'
+    ]);
+  });
+
+  it('splits multiple space-separated flags on one line', () => {
+    expect(tokenizeArgsLine('--verbose --plugin-dir /a/b --add-dir /c/d')).toEqual([
+      '--verbose',
+      '--plugin-dir',
+      '/a/b',
+      '--add-dir',
+      '/c/d'
+    ]);
+  });
+
+  it('keeps a quoted segment with an embedded space as one token', () => {
+    expect(tokenizeArgsLine('--plugin-dir "/Users/grebmann/My Plugin"')).toEqual([
+      '--plugin-dir',
+      '/Users/grebmann/My Plugin'
+    ]);
+  });
+
+  it('collapses repeated whitespace and ignores empty input', () => {
+    expect(tokenizeArgsLine('  --plugin-dir    /a/b  ')).toEqual(['--plugin-dir', '/a/b']);
+    expect(tokenizeArgsLine('   ')).toEqual([]);
+  });
+});

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -3744,6 +3744,13 @@ body.resizing-col {
   resize: vertical;
   line-height: 1.5;
 }
+
+/* Opt-in full-width text input — for fields whose values can run long
+   (argv-style "Extra args" lines, paths), where the default browser input
+   width (~20ch) truncates the view. */
+.settings-input-full {
+  width: 100%;
+}
 .settings-field textarea::placeholder,
 .settings-field input::placeholder {
   color: var(--text-dim);
@@ -19102,7 +19109,8 @@ button.zana-assign-trigger.is-unassigned .zana-assign-caret {
   color: var(--text-muted);
 }
 
-.launch-extra-args .settings-chip-input {
+.launch-extra-args .settings-chip-input,
+.launch-extra-args .settings-input-full {
   grid-column: 2;
 }
 
@@ -19121,6 +19129,7 @@ button.zana-assign-trigger.is-unassigned .zana-assign-caret {
 
   .launch-extra-args .settings-label,
   .launch-extra-args .settings-chip-input,
+  .launch-extra-args .settings-input-full,
   .launch-extra-args .settings-help {
     grid-column: 1;
   }


### PR DESCRIPTION
## Summary
- "Extra args" (Global settings, Project settings, and the Customize Launch dialog) used a comma-only chip input. Typing a flag and its value together, e.g. `--plugin-dir /path/to/plugin`, produced one chip that was spliced into the `claude` CLI's argv as a single token, so it failed with `error: unknown option '--plugin-dir /path/to/plugin'`.
- Replaced the chip field with a plain text field (`TextArgsField`) that tokenizes the line on whitespace — respecting quoted segments — via a new `tokenizeArgsLine` helper, the same way a shell would split the line before exec.
- Added a matching `.settings-input-full` CSS rule and updated the Customize Launch dialog's grid selectors so the new field renders full-width like the other settings fields.

## Test plan
- [x] `tokenizeArgsLine` unit tests added (`src/renderer/components/settings/__tests__/FormFields.test.tsx`) — splitting flag+value, multiple flags, quoted segments with spaces, whitespace collapsing/empty input.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes for the changed files (3 pre-existing, unrelated integration-test failures in this environment — `remote-local-coordination` and `local-extension-hot-reload` — reproduce identically on unmodified `main` and are caused by native `node-pty` spawn/temp-dir fs behavior in the sandbox, not by this change).
- [x] Manually verified in a running dev build: entering `--plugin-dir /path/to/plugin` in each of the three "Extra args" fields now launches `claude` successfully instead of erroring.