### PR TITLE
fix(launch): run AI recovery in ZCC workspace

### DIFF
--- a/src/main/__tests__/create-terminal-confined.test.ts
+++ b/src/main/__tests__/create-terminal-confined.test.ts
@@ -33,17 +33,19 @@ const CONFIG: AppConfig = {
 };
 
 const PROJECT_SETTINGS: ProjectSettings = {} as ProjectSettings;
+let projects: Project[] = [PROJECT];
 
 // Capture every ptys.create() call so we can assert what reaches the pty layer.
-const createCalls: Array<{ extraArgs?: string[]; profile: string; persona: unknown }> = [];
+const createCalls: Array<{ cwd: string; extraArgs?: string[]; profile: string; persona: unknown }> = [];
 
 vi.mock('../pty.js', () => {
   class PtyManager {
     setMcpBaseUrl() {}
     setProjectRoots() {}
     setRulesResolver() {}
-    create(opts: { extraArgs?: string[]; profile: string; persona: unknown }) {
+    create(opts: { cwd: string; extraArgs?: string[]; profile: string; persona: unknown }) {
       createCalls.push({
+        cwd: opts.cwd,
         extraArgs: opts.extraArgs,
         profile: opts.profile,
         persona: opts.persona
@@ -65,7 +67,7 @@ vi.mock('../pty.js', () => {
 
 vi.mock('../store.js', () => ({
   store: {
-    listProjects: () => [PROJECT],
+    listProjects: () => projects,
     getConfig: () => CONFIG,
     getProjectSettings: () => PROJECT_SETTINGS,
     createScratchSubfolder: () => '/tmp/proj/scratch'
@@ -166,6 +168,7 @@ function lastCreate() {
 describe('createTerminalConfined — main-side denylist enforcement', () => {
   beforeEach(() => {
     createCalls.length = 0;
+    projects = [PROJECT];
   });
 
   it('strips a denied flag while preserving benign flags (--flag value form)', () => {
@@ -221,6 +224,19 @@ describe('createTerminalConfined — main-side denylist enforcement', () => {
     });
     expect(res.ok).toBe(true);
     expect(lastCreate().extraArgs ?? []).toEqual([]);
+  });
+
+  it('uses the Quick Agent workspace root when scratch isolation is not requested', () => {
+    const quickAgentProject = { ...PROJECT, path: '/tmp/zcc-workspace', quickAgent: true };
+    projects = [quickAgentProject];
+    const res = createTerminalConfined({
+      projectId: quickAgentProject.id,
+      profile: 'claude-yolo',
+      cols: 80,
+      rows: 24
+    });
+    expect(res.ok).toBe(true);
+    expect(lastCreate().cwd).toBe('/tmp/zcc-workspace');
   });
 
   it('resolves a seeded launch through the configured global harness', () => {

--- a/src/renderer/components/AgentLauncher.tsx
+++ b/src/renderer/components/AgentLauncher.tsx
@@ -1466,20 +1466,30 @@ export const AgentLauncher = memo(function AgentLauncher({
   // "Fix with AI" — spawns a narrowly-scoped repair agent seeded with the raw
   // launch-failure text (mirrors Settings → Doctor's spawn path: claude-yolo so
   // it can inspect/repair local tooling without a permission prompt per step).
-  // Runs in the same target project as the failed launch when one is resolved,
-  // otherwise falls back to the scratch anchor — either way it redirects into
-  // the new agent's terminal so the user can follow along.
+  // Always runs at the managed ~/zcc-workspace root rather than the failed
+  // project: a missing or stale project cwd is itself a common launch failure,
+  // and would prevent the repair agent from starting if reused here.
   const fixWithAi = async () => {
-    if (!launchError || fixingWithAi || !target) return;
+    if (!launchError || fixingWithAi) return;
     setFixingWithAi(true);
     try {
-      const session = await createTerminal(target.id, 'claude-yolo', 80, 24, {
-        ...buildLaunchArgs(buildFixWithAiPrompt(launchError), 'Fix with AI'),
-        isolateScratch: scratchIsTarget ? 'Fix with AI' : undefined
+      const anchorRes = await window.cc.projects.ensureQuickAgent();
+      if (!anchorRes.ok) {
+        setLaunchError(anchorRes.message);
+        return;
+      }
+      const anchor = anchorRes.value;
+      const session = await createTerminal(anchor.id, 'claude-yolo', 80, 24, {
+        ...buildLaunchArgs(buildFixWithAiPrompt(launchError), 'Fix with AI')
       });
       if (session) {
         setLaunchError(null);
-        afterLaunch(session);
+        clearDraft();
+        const ui = useUi.getState();
+        ui.setNav('projects');
+        ui.selectProject(anchor.id);
+        ui.selectTab(anchor.id, session.id);
+        onClose();
       }
     } finally {
       setFixingWithAi(false);

--- a/src/renderer/components/__tests__/AgentLauncher.test.tsx
+++ b/src/renderer/components/__tests__/AgentLauncher.test.tsx
@@ -52,6 +52,16 @@ describe('buildLaunchArgs', () => {
   });
 });
 
+describe('Fix with AI recovery launch', () => {
+  it('uses the managed scratch workspace root instead of retrying a failed project cwd', () => {
+    const source = readFileSync(new URL('../AgentLauncher.tsx', import.meta.url), 'utf8');
+    const fixWithAi = source.slice(source.indexOf('const fixWithAi = async'));
+    expect(fixWithAi).toContain('window.cc.projects.ensureQuickAgent()');
+    expect(fixWithAi).toContain("createTerminal(anchor.id, 'claude-yolo'");
+    expect(fixWithAi).not.toContain('isolateScratch:');
+  });
+});
+
 /**
  * `frameworkOptionsFrom` is the decoupling seam for Advanced view: it derives
  * selectable framework presets from installed extension entries generically —


### PR DESCRIPTION
## Summary
- launch Fix with AI from the managed `~/zcc-workspace` Quick Agent root
- avoid reusing a failed project cwd or creating an isolated scratch subdirectory
- cover the renderer recovery selection and main launch cwd behavior

## Verification
- `npx vitest run src/main/__tests__/create-terminal-confined.test.ts src/renderer/components/__tests__/AgentLauncher.test.tsx`
- `npm run typecheck`
- Full pre-push suite: 4,502 passed; one unrelated flaky failure in `install-from-git.e2e.test.ts`, which passed on isolated rerun.