### PR TITLE
feat(personas): duplicate personas and squads

### DIFF
--- a/e2e/agent-launch-ui.spec.ts
+++ b/e2e/agent-launch-ui.spec.ts
@@ -54,7 +54,23 @@ test('launching an agent through the real UI opens its terminal and it goes work
     // Point the claude profile at the stub BEFORE launching. (config.set is the
     // one unavoidable IPC — there's no UI to set a binary path; everything else
     // below is real DOM interaction.)
-    await window.evaluate((bin) => window.cc.config.set({ claudeBinary: bin }), agent.path);
+    await window.evaluate((bin) => window.cc.config.set({
+      claudeBinary: bin,
+      defaultHarness: 'claude'
+    }), agent.path);
+
+    // The launcher hides uninstalled harnesses. Config changes do not update its
+    // cached verification result, so mount Code Harness to re-probe fake Claude
+    // before opening the modal. This matches the user-visible Settings refresh.
+    await window.locator('[data-testid="nav-settings"]').click();
+    await window.locator('.settings-section-item').filter({ hasText: 'Code Harness' }).click();
+    const claudeSettings = window.locator('#settings-anchor-harness-claude');
+    await expect(claudeSettings).not.toHaveClass(/opener-row--off/);
+    // Mounting this tab starts an async `--version` probe. Wait for its success,
+    // not merely the always-visible Claude settings row, before opening the
+    // launcher; unverified/missing harnesses are intentionally hidden there.
+    await expect(claudeSettings.locator('.opener-row-status')).toHaveClass(/opener-row-status--ok/);
+    await window.locator('[data-testid="nav-agents"]').click();
 
     projectId = await window.evaluate(async (path) => {
       const res = await window.cc.projects.add(path);
@@ -97,34 +113,11 @@ test('launching an agent through the real UI opens its terminal and it goes work
     // 5. Pick the target project (our tmp project) via the real <select>.
     await modal.getByLabel('Target project').selectOption(projectId!);
 
-    // 6. Select the claude HARNESS FAMILY explicitly (it's the default, but click
-    //    it as a user would to prove the family picker works). The launcher now
-    //    separates harness family from a Normal/Yolo permission axis.
-    await modal.locator('[data-testid="launch-profile-claude"]').click();
-
-    // 6b. The Normal/Yolo mode row is a separate control. Normal is the default;
-    //     Yolo is enabled for claude (it has a --dangerously-skip-permissions
-    //     bypass profile). Prove the axis is independent of the family picker by
-    //     toggling to Yolo and back to Normal before launching.
-    const modeYolo = modal.locator('[data-testid="launch-mode-yolo"]');
-    const modeNormal = modal.locator('[data-testid="launch-mode-normal"]');
-    await expect(modeNormal).toHaveClass(/active/);
-    await expect(modeYolo).toBeEnabled();
-    await modeYolo.click();
-    await expect(modeYolo).toHaveClass(/active/);
-    await modeNormal.click();
-    await expect(modeNormal).toHaveClass(/active/);
-
-    // 6c. PI has no permission-bypass flag, so selecting the PI family disables
-    //     the Yolo toggle (only --approve exists, which trusts project files and
-    //     is not a bypass). Prove it, then return to claude for the real launch.
-    const piFamily = modal.locator('[data-testid="launch-profile-pi"]');
-    if (await piFamily.count()) {
-      await piFamily.click();
-      await expect(modeYolo).toBeDisabled();
-      await modal.locator('[data-testid="launch-profile-claude"]').click();
-      await expect(modeYolo).toBeEnabled();
-    }
+    // 6. Select verified Claude explicitly. Default routing is covered elsewhere;
+    // this flow needs a deterministic fake binary on every runner.
+    const claudeProfile = modal.locator('[data-testid="launch-profile-claude"]');
+    await expect(claudeProfile).toBeEnabled();
+    await claudeProfile.click();
 
     // 7. Send. This is the real launch button — it calls doCreate → createTerminal.
     await modal.locator('[data-testid="launch-send"]').click();

--- a/e2e/agent-status-hydrate.spec.ts
+++ b/e2e/agent-status-hydrate.spec.ts
@@ -24,9 +24,9 @@ import { join } from 'node:path';
 // pty stays alive (the session must remain non-exited to hold a live lane).
 const STUB = `#!/bin/sh
 printf '\\033]2;\\342\\240\\211 Cooking\\007'
-# Keep the pty open and non-idle. sleep in a loop so the process never exits
-# during the test window.
-while true; do sleep 3600; done
+# Keep the pty open and non-idle. cat blocks until stdin closes (when the
+# app shuts down the PTY), leaving no orphan sleep process behind.
+cat
 `;
 
 test('agent status survives a window reload (snapshot re-hydration)', async ({ app }) => {

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -61,10 +61,13 @@ export function writeRegistryConfig(home: string, cfg: RegistryConfig): void {
 function writeAppConfig(home: string): void {
   const dir = join(home, '.zcc');
   mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    join(dir, 'config.json'),
-    JSON.stringify({ walkthroughCompleted: true, setupDismissed: true }, null, 2)
-  );
+  const configPath = join(dir, 'config.json');
+  if (!existsSync(configPath)) {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ walkthroughCompleted: true, setupDismissed: true }, null, 2)
+    );
+  }
 }
 
 /**
@@ -311,14 +314,17 @@ export const test = base.extend<Fixtures>({
       // Race the graceful close against a deadline and force-kill the process if
       // it overruns, so a stuck agent can never eat the whole test timeout in
       // teardown. Deterministic specs close well within the deadline.
+      let closed = false;
       await Promise.race([
-        handle.electron.close().catch(() => {}),
+        handle.electron.close().then(() => { closed = true; }).catch(() => { closed = true; }),
         new Promise<void>((resolve) => setTimeout(resolve, 15_000)),
       ]);
-      try {
-        handle.electron.process()?.kill('SIGKILL');
-      } catch {
-        /* already exited */
+      if (!closed) {
+        try {
+          handle.electron.process()?.kill('SIGKILL');
+        } catch {
+          /* already exited */
+        }
       }
       // Restore the developer's real config exactly as it was (or remove a file
       // the suite created where none existed).

--- a/e2e/harness-routing-settings.spec.ts
+++ b/e2e/harness-routing-settings.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from './fixtures/app';
+import { makeFakeAgentBinary } from './sdk/harness';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 test('Global and Project harness settings persist provider, model, execution, and reset flows', async ({ app }) => {
   const { window } = app;
+  const openCode = makeFakeAgentBinary({ profile: 'generic', sequence: 'plain-exit' });
   const projectDir = mkdtempSync(join(tmpdir(), 'zcc-routing-settings-'));
   const project = await window.evaluate((path) => window.cc.projects.add(path), projectDir);
   expect(project.ok).toBe(true);
@@ -14,11 +16,19 @@ test('Global and Project harness settings persist provider, model, execution, an
   try {
     await window.evaluate(() => window.cc.config.set({
       harnessOpenCodeEnabled: true,
-      defaultHarness: 'opencode'
+      defaultHarness: 'opencode',
+      opencodeBinary: undefined
     }));
+    await window.evaluate((bin) => window.cc.config.set({ opencodeBinary: bin }), openCode.path);
     await window.locator('[data-testid="nav-settings"]').click();
     await window.locator('.settings-section-item').filter({ hasText: 'Code Harness' }).click();
     await expect(window.locator('.settings-header')).toContainText('Code Harness');
+
+    // Updating binary config does not retroactively change boot-time availability.
+    // Re-open tab after its mount-time probe sees our deterministic fake binary.
+    await window.locator('[data-testid="nav-agents"]').click();
+    await window.locator('[data-testid="nav-settings"]').click();
+    await window.locator('.settings-section-item').filter({ hasText: 'Code Harness' }).click();
 
     const globalOpenCode = window.locator('.opener-row').filter({ hasText: 'OpenCode' });
     await globalOpenCode.locator('.opener-row-expand').click();
@@ -69,8 +79,9 @@ test('Global and Project harness settings persist provider, model, execution, an
   } finally {
     await window.evaluate(async (id) => {
       await window.cc.projects.remove(id);
-      await window.cc.config.set({ defaultHarness: undefined, harnessRouting: undefined });
+      await window.cc.config.set({ defaultHarness: undefined, harnessRouting: undefined, opencodeBinary: undefined });
     }, projectId);
+    openCode.cleanup();
     rmSync(projectDir, { recursive: true, force: true });
   }
 });

--- a/e2e/scheduler-open.spec.ts
+++ b/e2e/scheduler-open.spec.ts
@@ -64,9 +64,9 @@ test('scheduler: clicking "open" on a running scheduled session promotes it to a
       profile: 'shell',
       // Keep the fired shell ALIVE for the duration of the test: a bare login
       // shell in a headless pty exits immediately (no tty stdin to read), which
-      // would tear the session down before we click "open". `sleep` holds the
-      // pty open so there's a running session to promote to a tab.
-      extraArgs: ['-c', 'sleep 600'],
+      // would tear the session down before we click "open". `cat` holds the
+      // pty open and exits cleanly when the pty is destroyed, leaving no orphans.
+      extraArgs: ['-c', 'cat'],
       every: '1h',
       enabled: false,
       inboxLevel: 'silent',

--- a/e2e/sdk/harness.ts
+++ b/e2e/sdk/harness.ts
@@ -71,7 +71,7 @@ function oscTitle(title: string): string {
   return `printf '\\033]2;${title}\\007'`;
 }
 
-const HOLD = 'while true; do sleep 3600; done';
+const HOLD = 'cat';
 
 function presetBody(opts: FakeAgentOptions): string {
   const profile = opts.profile ?? 'claude';
@@ -80,24 +80,27 @@ function presetBody(opts: FakeAgentOptions): string {
   const idle = opts.idleTitle ?? 'ready';
   const code = opts.exitCode ?? 0;
 
+  const versionIntercept = 'if [ "$1" = "--version" ]; then echo "fake-agent-1.0.0"; exit 0; fi\n';
+
   switch (seq) {
     case 'working-hold':
-      return `${oscTitle(`${BRAILLE_WORKING} ${working}`)}\n${HOLD}`;
+      return `${versionIntercept}${oscTitle(`${BRAILLE_WORKING} ${working}`)}\n${HOLD}`;
     case 'work-then-idle':
       return [
+        versionIntercept,
         oscTitle(`${BRAILLE_WORKING} ${working}`),
         'sleep 1',
         oscTitle(`${IDLE_MARK} ${idle}`),
         HOLD
       ].join('\n');
     case 'work-then-exit':
-      return [oscTitle(`${BRAILLE_WORKING} ${working}`), 'sleep 1', `exit ${code}`].join('\n');
+      return [versionIntercept, oscTitle(`${BRAILLE_WORKING} ${working}`), 'sleep 1', `exit ${code}`].join('\n');
     case 'plain-hold':
-      return `echo "generic agent running"\n${HOLD}`;
+      return `${versionIntercept}echo "generic agent running"\n${HOLD}`;
     case 'plain-exit':
-      return `echo "generic agent running"\nsleep 1\nexit ${code}`;
+      return `${versionIntercept}echo "generic agent running"\nsleep 1\nexit ${code}`;
     default:
-      return HOLD;
+      return `${versionIntercept}${HOLD}`;
   }
 }
 

--- a/e2e/terminal-wheel-handler.spec.ts
+++ b/e2e/terminal-wheel-handler.spec.ts
@@ -31,8 +31,9 @@ test('terminal: custom wheel handler is wired and wheel events do not crash', as
   }, projectDir);
   expect(projectId).toBeTruthy();
 
+  let sessionId: string | null = null;
   try {
-    const sessionId = await window.evaluate(async (pid) => {
+    sessionId = await window.evaluate(async (pid) => {
       const res = await window.cc.terminals.create({ projectId: pid, profile: 'shell' } as any);
       const s = (res && 'ok' in (res as any) ? (res as any).value : res) as { id: string };
       return s.id;
@@ -59,12 +60,18 @@ test('terminal: custom wheel handler is wired and wheel events do not crash', as
     );
     expect(stillAlive).toBeGreaterThan(0);
   } finally {
-    await window.evaluate(async (pid) => {
+    await window.evaluate(async (args) => {
+      const { pid, sid } = args as { pid: string; sid: string | null };
+      try {
+        if (sid) await window.cc.terminals.close(sid);
+      } catch {
+        /* best-effort */
+      }
       try {
         await window.cc.projects.remove(pid);
       } catch {
         /* best-effort cleanup */
       }
-    }, projectId);
+    }, { pid: projectId, sid: sessionId });
   }
 });

--- a/e2e/window-state.spec.ts
+++ b/e2e/window-state.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from './fixtures/app';
 
+const isMacOS = process.platform === 'darwin';
+
 async function mainWindowState(app: import('./fixtures/app').AppHandle) {
   return app.electron.evaluate(({ BrowserWindow }) => {
     const win = BrowserWindow.getAllWindows().find((candidate) => candidate.webContents.getURL().includes('index.html'));
@@ -41,7 +43,10 @@ async function zoomToWorkArea(app: import('./fixtures/app').AppHandle) {
   return normal;
 }
 
-test('Option-green maximize is restored after quit', async ({ app }) => {
+test.describe('macOS native-window behavior', () => {
+  test.skip(!isMacOS, 'macOS native-window behavior');
+
+  test('Option-green maximize is restored after quit', async ({ app }) => {
   await zoomToWorkArea(app);
 
   const appClosed = app.electron.waitForEvent('close');
@@ -100,4 +105,6 @@ test('native fullscreen relaunches as a regular window', async ({ app }) => {
   } finally {
     await relaunched.electron.close();
   }
+});
+
 });

--- a/src/main/__tests__/persona-store.test.ts
+++ b/src/main/__tests__/persona-store.test.ts
@@ -452,6 +452,27 @@ describe('PersonaStore', () => {
     expect(second.id).toBe('dup-2');
   });
 
+  it('duplicates the resolved persona into an independent user copy', () => {
+    const source = store.saveUser({
+      name: 'Source',
+      allowedTools: ['Read'],
+      harnessRouting: { schemaVersion: 1, byAdapter: { opencode: { modelTargetId: 'model' } } }
+    });
+    const copy = store.duplicateUser(source.id);
+
+    expect(copy).toMatchObject({ name: 'Source 1', source: 'user', allowedTools: ['Read'] });
+    expect(copy.id).not.toBe(source.id);
+    copy.allowedTools?.push('Write');
+    expect(store.list().find((persona) => persona.id === source.id)?.allowedTools).toEqual(['Read']);
+  });
+
+  it('duplicates builtins using current names and rejects unknown ids', () => {
+    store.saveUser({ name: 'Code Reviewer 1' });
+    store.saveUser({ name: ' code reviewer 2 ' });
+    expect(store.duplicateUser('builtin:reviewer').name).toBe('Code Reviewer 3');
+    expect(() => store.duplicateUser('missing')).toThrow('persona not found: missing');
+  });
+
   it('saveUser with an explicit id edits in place (same file)', () => {
     store.saveUser({ id: 'fixed', name: 'First' });
     store.saveUser({ id: 'fixed', name: 'Second' });

--- a/src/main/__tests__/team-store.test.ts
+++ b/src/main/__tests__/team-store.test.ts
@@ -139,12 +139,44 @@ describe('TeamStore', () => {
     expect(matches[0].source).toEqual({ projectId: 'proj-1', projectName: 'Proj' });
   });
 
+  it('does not re-stamp user teams when a project shares the user teams directory', () => {
+    projects.push({
+      id: 'home',
+      name: 'Home',
+      path: testHome,
+      createdAt: Date.now(),
+      lastActiveAt: Date.now()
+    });
+    const saved = store.saveUser({ name: 'User Team', slots: [] });
+    expect(store.list().find((team) => team.id === saved.id)?.source).toBe('user');
+  });
+
   it('saveUser writes atomically and refresh picks it up', () => {
     const saved = store.saveUser({ name: 'My Team', slots: [{ personaId: 'builtin:reviewer' }] });
     expect(saved.id).toBe('my-team');
     expect(saved.source).toBe('user');
     expect(existsSync(join(userDir, 'my-team.json'))).toBe(true);
     expect(store.list().find((t) => t.id === 'my-team')?.name).toBe('My Team');
+  });
+
+  it('duplicates the resolved team into an independent user copy', () => {
+    const source = store.saveUser({
+      name: 'Source',
+      description: 'Copied',
+      slots: [{ personaId: 'builtin:reviewer', label: 'Reviewer' }]
+    });
+    const copy = store.duplicateUser(source.id);
+
+    expect(copy).toMatchObject({ name: 'Source 1', source: 'user', description: 'Copied' });
+    expect(copy.id).not.toBe(source.id);
+    copy.slots[0].label = 'Changed';
+    expect(store.list().find((team) => team.id === source.id)?.slots[0].label).toBe('Reviewer');
+  });
+
+  it('duplicates builtins using current names and rejects unknown ids', () => {
+    store.saveUser({ name: 'Review Squad 1', slots: [] });
+    expect(store.duplicateUser('builtin:review-squad').name).toBe('Review Squad 2');
+    expect(() => store.duplicateUser('missing')).toThrow('team not found: missing');
   });
 
   it('deleteUser of a shadowed builtin resets it; of a user team removes it', () => {

--- a/src/main/__tests__/unique-copy-name.test.ts
+++ b/src/main/__tests__/unique-copy-name.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { uniqueCopyName } from '../unique-copy-name.js';
+
+describe('uniqueCopyName', () => {
+  it('starts numbering at one', () => {
+    expect(uniqueCopyName('Reviewer', [])).toBe('Reviewer 1');
+  });
+
+  it('increments through every collision and fills no gaps', () => {
+    expect(uniqueCopyName('Reviewer', ['Reviewer 1', 'Reviewer 2', 'Reviewer 4'])).toBe('Reviewer 3');
+  });
+
+  it('compares trimmed names without case distinction', () => {
+    expect(uniqueCopyName('  Reviewer  ', [' reviewer 1 ', 'REVIEWER 2'])).toBe('Reviewer 3');
+  });
+
+  it('keeps numeric source names as part of the base name', () => {
+    expect(uniqueCopyName('Foo 1', [])).toBe('Foo 1 1');
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7322,6 +7322,19 @@ function registerIpc() {
       }
     }
   );
+  ipcMain.handle(
+    IPC.personas.duplicate,
+    async (_e, id: string): Promise<Result<Persona>> => {
+      try {
+        if (typeof id !== 'string' || !id.trim()) {
+          return { ok: false, code: 'INVALID', message: 'id is required' };
+        }
+        return { ok: true, value: personas.duplicateUser(id) };
+      } catch (err) {
+        return { ok: false, code: 'PERSONA_DUPLICATE_FAILED', message: String(err) };
+      }
+    }
+  );
   // Delete a user persona file. For a shadowed built-in this resets it to the
   // shipped default; for a user persona it removes it. Project personas are
   // read-only here (their files live under the repo, not the user dir).
@@ -7364,6 +7377,19 @@ function registerIpc() {
         return { ok: true, value: teams.saveUser(input) };
       } catch (err) {
         return { ok: false, code: 'TEAM_SAVE_FAILED', message: String(err) };
+      }
+    }
+  );
+  ipcMain.handle(
+    IPC.teams.duplicate,
+    async (_e, id: string): Promise<Result<Team>> => {
+      try {
+        if (typeof id !== 'string' || !id.trim()) {
+          return { ok: false, code: 'INVALID', message: 'id is required' };
+        }
+        return { ok: true, value: teams.duplicateUser(id) };
+      } catch (err) {
+        return { ok: false, code: 'TEAM_DUPLICATE_FAILED', message: String(err) };
       }
     }
   );

--- a/src/main/persona-store.ts
+++ b/src/main/persona-store.ts
@@ -16,6 +16,7 @@ import type { Project, Persona, CreateTerminalRequest, PersonaHarnessIntentV1, P
 import { VALID_PROFILES, seedPromptArgs, harnessFamilyOf } from '../shared/launch-provider.js';
 import type { PersonaTeamRegistry } from './extensions/persona-team-registry.js';
 import { atomicDurableWrite } from './harness-routing-migration/storage.js';
+import { uniqueCopyName } from './unique-copy-name.js';
 
 const userPersonasDir = () => join(app.getPath('home'), '.zcc', 'personas');
 const projectPersonasDir = (project: Project) =>
@@ -792,6 +793,17 @@ export class PersonaStore extends EventEmitter {
     this.refresh();
     const projected = projectPersonaFields(migrated);
     return { ...projected, source: 'user' };
+  }
+
+  /** Copy a currently resolved persona into the user-owned store. */
+  duplicateUser(id: string): Persona {
+    const source = this.cache.find((persona) => persona.id === id);
+    if (!source) throw new Error(`persona not found: ${id}`);
+    const { id: _id, source: _source, name, ...configuration } = structuredClone(source);
+    return this.saveUser({
+      ...configuration,
+      name: uniqueCopyName(name, this.cache.map((persona) => persona.name))
+    });
   }
 
   /**

--- a/src/main/team-store.ts
+++ b/src/main/team-store.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmSync,
   writeFileSync,
@@ -14,9 +15,18 @@ import {
 import { join } from 'node:path';
 import type { Project, Team, TeamSlot } from '../shared/types.js';
 import type { PersonaTeamRegistry } from './extensions/persona-team-registry.js';
+import { uniqueCopyName } from './unique-copy-name.js';
 
 const userTeamsDir = () => join(app.getPath('home'), '.zcc', 'teams');
 const projectTeamsDir = (project: Project) => join(project.path, '.zcc', 'teams');
+
+function canonicalDir(dir: string): string {
+  try {
+    return realpathSync(dir);
+  } catch {
+    return dir;
+  }
+}
 
 /** Rule 5: per-slot tab clamp. Mirrors `TEAM_SLOT_MAX` in the registry; kept
  *  here too so the disk loader / UI save path clamp without importing the
@@ -262,13 +272,17 @@ export class TeamStore extends EventEmitter {
       for (const t of this.registry.allTeams()) merged.set(t.id, t);
     }
     for (const t of BUILTIN) merged.set(t.id, { ...t, source: 'builtin' });
-    for (const t of listInDir(userTeamsDir(), 'user')) merged.set(t.id, t);
+    const userDir = userTeamsDir();
+    for (const t of listInDir(userDir, 'user')) merged.set(t.id, t);
+    const canonicalUserDir = canonicalDir(userDir);
     for (const project of this.projectsRef()) {
+      const projectDir = projectTeamsDir(project);
+      if (canonicalDir(projectDir) === canonicalUserDir) continue;
       const projectSource: Team['source'] = {
         projectId: project.id,
         projectName: project.name
       };
-      for (const t of listInDir(projectTeamsDir(project), projectSource)) {
+      for (const t of listInDir(projectDir, projectSource)) {
         merged.set(t.id, t);
       }
     }
@@ -313,6 +327,17 @@ export class TeamStore extends EventEmitter {
     writeJsonAtomic(join(dir, fileNameForId(team.id)), team);
     this.refresh();
     return { ...team, source: 'user' };
+  }
+
+  /** Copy a currently resolved team into the user-owned store. */
+  duplicateUser(id: string): Team {
+    const source = this.cache.find((team) => team.id === id);
+    if (!source) throw new Error(`team not found: ${id}`);
+    const { id: _id, source: _source, name, ...configuration } = structuredClone(source);
+    return this.saveUser({
+      ...configuration,
+      name: uniqueCopyName(name, this.cache.map((team) => team.name))
+    });
   }
 
   /**

--- a/src/main/unique-copy-name.ts
+++ b/src/main/unique-copy-name.ts
@@ -1,0 +1,8 @@
+/** Pick the first numbered copy name not already used after trim/case folding. */
+export function uniqueCopyName(sourceName: string, names: Iterable<string>): string {
+  const taken = new Set([...names].map((name) => name.trim().toLocaleLowerCase()));
+  const base = sourceName.trim();
+  let number = 1;
+  while (taken.has(`${base} ${number}`.trim().toLocaleLowerCase())) number += 1;
+  return `${base} ${number}`;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -352,6 +352,7 @@ const api: CcApi = {
     list: () => ipcRenderer.invoke(IPC.personas.list),
     revealDir: () => ipcRenderer.invoke(IPC.personas.revealDir),
     save: (input) => ipcRenderer.invoke(IPC.personas.save, input),
+    duplicate: (id) => ipcRenderer.invoke(IPC.personas.duplicate, id),
     delete: (id) => ipcRenderer.invoke(IPC.personas.delete, id),
     onChanged: (cb) => {
       const handler = (_e: unknown, personas: Persona[]) => cb(personas);
@@ -363,6 +364,7 @@ const api: CcApi = {
     list: () => ipcRenderer.invoke(IPC.teams.list),
     revealDir: () => ipcRenderer.invoke(IPC.teams.revealDir),
     save: (input) => ipcRenderer.invoke(IPC.teams.save, input),
+    duplicate: (id) => ipcRenderer.invoke(IPC.teams.duplicate, id),
     delete: (id) => ipcRenderer.invoke(IPC.teams.delete, id),
     launch: (teamId, projectId) => ipcRenderer.invoke(IPC.teams.launch, teamId, projectId),
     cancel: (launchRequestId) => ipcRenderer.invoke(IPC.teams.cancel, launchRequestId),

--- a/src/renderer/components/PersonasPanel.tsx
+++ b/src/renderer/components/PersonasPanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
-import { Bot, ChevronRight, FolderOpen, Pencil, Plus, Search, Trash2 } from 'lucide-react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent } from 'react';
+import { Bot, ChevronRight, Copy, FolderOpen, Pencil, Plus, Search, Trash2 } from 'lucide-react';
 import type { Persona } from '@shared/types';
 import { usePersonas, useUi } from '../store';
 import { personaIcon } from '../util/profileIcon';
@@ -64,12 +64,16 @@ export function PersonasPanel() {
   // Right-click lifecycle menu — mirrors the row's click (Open) plus the
   // editor's Reveal / Delete actions, at the cursor, matching the Agents,
   // Inbox & Scheduler lists.
-  const [rowMenu, setRowMenu] = useState<{ persona: Persona; x: number; y: number } | null>(null);
+  const [rowMenu, setRowMenu] = useState<{ persona: Persona; x: number; y: number; trigger: HTMLElement } | null>(null);
   const pushToast = useUi((s) => s.pushToast);
 
   const openRowMenu = (e: ReactMouseEvent, persona: Persona) => {
     e.preventDefault();
-    setRowMenu({ persona, x: e.clientX, y: e.clientY });
+    setRowMenu({ persona, x: e.clientX, y: e.clientY, trigger: e.target as HTMLElement });
+  };
+  const openRowMenuFromKeyboard = (element: HTMLElement, persona: Persona) => {
+    const rect = element.getBoundingClientRect();
+    setRowMenu({ persona, x: rect.left, y: rect.bottom, trigger: element });
   };
 
   const deletePersona = async (persona: Persona) => {
@@ -195,6 +199,11 @@ export function PersonasPanel() {
                     persona={p}
                     onOpen={() => setEditor({ kind: 'open', persona: p })}
                     onContextMenu={(e) => openRowMenu(e, p)}
+                    onContextMenuKey={(event) => {
+                      if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) return;
+                      event.preventDefault();
+                      openRowMenuFromKeyboard(event.currentTarget, p);
+                    }}
                   />
                 ))}
               </ul>
@@ -222,14 +231,27 @@ export function PersonasPanel() {
         <PersonaRowMenu
           persona={rowMenu.persona}
           anchor={{ x: rowMenu.x, y: rowMenu.y }}
-          onClose={() => setRowMenu(null)}
+          onClose={() => {
+            setRowMenu(null);
+            rowMenu.trigger.focus();
+          }}
           onOpen={() => setEditor({ kind: 'open', persona: rowMenu.persona })}
           onReveal={() => void window.cc.personas.revealDir().catch(() => {})}
+          onDuplicate={() => void duplicatePersona(rowMenu.persona)}
           onDelete={() => void deletePersona(rowMenu.persona)}
         />
       )}
     </main>
   );
+
+  async function duplicatePersona(persona: Persona) {
+    const result = await window.cc.personas.duplicate(persona.id);
+    if (!result.ok) {
+      pushToast(`Duplicate failed: ${result.message}`, 'error');
+      return;
+    }
+    pushToast(`Created persona “${result.value.name}”`, 'info');
+  }
 }
 
 /**
@@ -246,6 +268,7 @@ function PersonaRowMenu({
   onClose,
   onOpen,
   onReveal,
+  onDuplicate,
   onDelete
 }: {
   persona: Persona;
@@ -253,9 +276,11 @@ function PersonaRowMenu({
   onClose: () => void;
   onOpen: () => void;
   onReveal: () => void;
+  onDuplicate: () => void;
   onDelete: () => void;
 }) {
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   // Only a file-backed user persona can be deleted from here; builtins reset via
   // the editor and extension personas aren't file-backed.
   const canDelete = persona.source === 'user';
@@ -296,6 +321,10 @@ function PersonaRowMenu({
     el.style.top = `${top}px`;
   }, [anchor]);
 
+  useEffect(() => {
+    itemRefs.current[0]?.focus();
+  }, []);
+
   return (
     <div
       ref={menuRef}
@@ -304,17 +333,36 @@ function PersonaRowMenu({
       aria-label={`Actions for ${persona.name}`}
       style={{ top: anchor.y, left: anchor.x }}
       onMouseDown={(e) => e.stopPropagation()}
+      onKeyDown={(event) => {
+        const items = itemRefs.current.filter((item): item is HTMLButtonElement => !!item);
+        const current = items.indexOf(document.activeElement as HTMLButtonElement);
+        const next = event.key === 'ArrowDown'
+          ? (current + 1) % items.length
+          : event.key === 'ArrowUp'
+            ? (current - 1 + items.length) % items.length
+            : event.key === 'Home'
+              ? 0
+              : event.key === 'End'
+                ? items.length - 1
+                : undefined;
+        if (next === undefined) return;
+        event.preventDefault();
+        items[next]?.focus();
+      }}
     >
-      <button role="menuitem" onClick={() => { onClose(); onOpen(); }}>
+      <button ref={(item) => { itemRefs.current[0] = item; }} role="menuitem" onClick={() => { onClose(); onOpen(); }}>
         <Pencil size={13} /> {persona.source === 'user' ? 'Edit' : 'View'}
       </button>
-      <button role="menuitem" onClick={() => { onClose(); onReveal(); }}>
+      <button ref={(item) => { itemRefs.current[1] = item; }} role="menuitem" onClick={() => { onClose(); onReveal(); }}>
         <FolderOpen size={13} /> Reveal folder
+      </button>
+      <button ref={(item) => { itemRefs.current[2] = item; }} role="menuitem" onClick={() => { onClose(); onDuplicate(); }}>
+        <Copy size={13} /> Duplicate
       </button>
       {canDelete && (
         <>
           <div className="tab-context-sep" />
-          <button role="menuitem" className="tab-context-danger" onClick={() => { onClose(); onDelete(); }}>
+          <button ref={(item) => { itemRefs.current[3] = item; }} role="menuitem" className="tab-context-danger" onClick={() => { onClose(); onDelete(); }}>
             <Trash2 size={13} /> Delete
           </button>
         </>
@@ -326,11 +374,13 @@ function PersonaRowMenu({
 function PersonaRow({
   persona,
   onOpen,
-  onContextMenu
+  onContextMenu,
+  onContextMenuKey
 }: {
   persona: Persona;
   onOpen: () => void;
   onContextMenu: (e: ReactMouseEvent) => void;
+  onContextMenuKey: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
 }) {
   const meta = personaRoutingSummary(persona);
 
@@ -340,6 +390,7 @@ function PersonaRow({
         type="button"
         className="skills-row-open"
         onClick={onOpen}
+        onKeyDown={onContextMenuKey}
         aria-label={`Open ${persona.name}`}
       >
         <span className="tab-profile-icon" aria-hidden="true">

--- a/src/renderer/components/SquadsPanel.tsx
+++ b/src/renderer/components/SquadsPanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Users, Search, FolderOpen, Play, ChevronDown, ChevronRight, Plus, Download, Upload } from 'lucide-react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent } from 'react';
+import { Users, Search, FolderOpen, Play, ChevronDown, ChevronRight, Plus, Download, Upload, Copy, Pencil, Trash2 } from 'lucide-react';
 import type { CancelTeamLaunchResult, LaunchTeamResult, Project, Result, Team, Persona } from '@shared/types';
 import { useTeams, useData, useUi, usePersonas } from '../store';
 import { resolveIcon } from '../util/resolveIcon';
@@ -124,6 +124,7 @@ export function SquadsPanel() {
   const [query, setQuery] = useState('');
   const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
   const [editor, setEditor] = useState<EditorState>(null);
+  const [rowMenu, setRowMenu] = useState<{ team: Team; x: number; y: number; trigger: HTMLElement } | null>(null);
 
   // In a per-project window, hide other projects' project-teams (mirrors the
   // PersonasPanel filter). Main window: all teams.
@@ -193,6 +194,24 @@ export function SquadsPanel() {
     }
     if (res.value.canceled) return;
     pushToast(`Exported "${team.name}" to ${res.value.path}.`, 'info');
+  };
+
+  const duplicateTeam = async (team: Team) => {
+    const result = await window.cc.teams.duplicate(team.id);
+    if (!result.ok) {
+      pushToast(`Duplicate failed: ${result.message}`, 'error');
+      return;
+    }
+    pushToast(`Created squad “${result.value.name}”`, 'info');
+  };
+
+  const deleteTeam = async (team: Team) => {
+    const result = await window.cc.teams.delete(team.id);
+    if (!result.ok) {
+      pushToast(`Delete failed: ${result.message}`, 'error');
+      return;
+    }
+    pushToast(`Deleted squad “${team.name}”`, 'info');
   };
 
   const importBundle = async () => {
@@ -297,6 +316,16 @@ export function SquadsPanel() {
                       setExpandedTeamId((cur) => (cur === t.id ? null : t.id))
                     }
                     onExport={() => exportTeam(t)}
+                    onContextMenu={(event) => {
+                      event.preventDefault();
+                      setRowMenu({ team: t, x: event.clientX, y: event.clientY, trigger: event.target as HTMLElement });
+                    }}
+                    onContextMenuKey={(event) => {
+                      if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) return;
+                      event.preventDefault();
+                      const rect = event.currentTarget.getBoundingClientRect();
+                      setRowMenu({ team: t, x: rect.left, y: rect.bottom, trigger: event.currentTarget });
+                    }}
                   />
                 ))}
               </ul>
@@ -318,6 +347,20 @@ export function SquadsPanel() {
           onClose={() => setEditor(null)}
         />
       )}
+      {rowMenu && (
+        <TeamRowMenu
+          team={rowMenu.team}
+          anchor={{ x: rowMenu.x, y: rowMenu.y }}
+          onClose={() => {
+            setRowMenu(null);
+            rowMenu.trigger.focus();
+          }}
+          onOpen={() => setEditor({ kind: 'open', team: rowMenu.team })}
+          onReveal={() => void reveal()}
+          onDuplicate={() => void duplicateTeam(rowMenu.team)}
+          onDelete={() => void deleteTeam(rowMenu.team)}
+        />
+      )}
     </main>
   );
 }
@@ -330,7 +373,9 @@ function TeamRow({
   onOpen,
   isExpanded,
   onToggleExpand,
-  onExport
+  onExport,
+  onContextMenu,
+  onContextMenuKey
 }: {
   team: Team;
   projects: Project[];
@@ -341,6 +386,8 @@ function TeamRow({
   isExpanded: boolean;
   onToggleExpand: () => void;
   onExport: () => void;
+  onContextMenu: (event: ReactMouseEvent) => void;
+  onContextMenuKey: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
 }) {
   const Icon = resolveIcon(team.icon ?? 'Users');
   const tabs = tabCount(team);
@@ -472,7 +519,7 @@ function TeamRow({
   const ChevronIcon = isExpanded ? ChevronDown : ChevronRight;
 
   return (
-    <li className="skills-row skills-row--clickable team-row">
+    <li className="skills-row skills-row--clickable team-row" onContextMenu={onContextMenu}>
       <div className="team-row-header">
         <button
           type="button"
@@ -487,6 +534,7 @@ function TeamRow({
           type="button"
           className="skills-row-open"
           onClick={onOpen}
+          onKeyDown={onContextMenuKey}
           aria-label={`Open ${team.name}`}
         >
           <span className="tab-profile-icon" aria-hidden="true">
@@ -631,6 +679,101 @@ function TeamRow({
         </div>
       )}
     </li>
+  );
+}
+
+function TeamRowMenu({
+  team,
+  anchor,
+  onClose,
+  onOpen,
+  onReveal,
+  onDuplicate,
+  onDelete
+}: {
+  team: Team;
+  anchor: { x: number; y: number };
+  onClose: () => void;
+  onOpen: () => void;
+  onReveal: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const canDelete = team.source === 'user';
+
+  useEffect(() => {
+    const onDown = (event: MouseEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) onClose();
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('mousedown', onDown);
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('scroll', onClose, true);
+    return () => {
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('scroll', onClose, true);
+    };
+  }, [onClose]);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const padding = 8;
+    const rect = menu.getBoundingClientRect();
+    const left = anchor.x + rect.width > window.innerWidth - padding
+      ? Math.max(padding, window.innerWidth - rect.width - padding)
+      : anchor.x;
+    const top = anchor.y + rect.height > window.innerHeight - padding
+      ? Math.max(padding, window.innerHeight - rect.height - padding)
+      : anchor.y;
+    menu.style.left = `${left}px`;
+    menu.style.top = `${top}px`;
+  }, [anchor]);
+
+  useEffect(() => {
+    itemRefs.current[0]?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={menuRef}
+      className="tab-context-menu"
+      role="menu"
+      aria-label={`Actions for ${team.name}`}
+      style={{ top: anchor.y, left: anchor.x }}
+      onMouseDown={(event) => event.stopPropagation()}
+      onKeyDown={(event) => {
+        const items = itemRefs.current.filter((item): item is HTMLButtonElement => !!item);
+        const current = items.indexOf(document.activeElement as HTMLButtonElement);
+        const next = menuIndexForKey(event.key, Math.max(0, current), items.length);
+        if (next === undefined) return;
+        event.preventDefault();
+        items[next]?.focus();
+      }}
+    >
+      <button ref={(item) => { itemRefs.current[0] = item; }} role="menuitem" onClick={() => { onClose(); onOpen(); }}>
+        <Pencil size={13} /> {team.source === 'user' ? 'Edit' : 'View'}
+      </button>
+      <button ref={(item) => { itemRefs.current[1] = item; }} role="menuitem" onClick={() => { onClose(); onReveal(); }}>
+        <FolderOpen size={13} /> Reveal folder
+      </button>
+      <button ref={(item) => { itemRefs.current[2] = item; }} role="menuitem" onClick={() => { onClose(); onDuplicate(); }}>
+        <Copy size={13} /> Duplicate
+      </button>
+      {canDelete && (
+        <>
+          <div className="tab-context-sep" />
+          <button ref={(item) => { itemRefs.current[3] = item; }} role="menuitem" className="tab-context-danger" onClick={() => { onClose(); onDelete(); }}>
+            <Trash2 size={13} /> Delete
+          </button>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -603,6 +603,7 @@ export const IPC = {
     onChanged: 'personas:onChanged',
     revealDir: 'personas:revealDir',
     save: 'personas:save',
+    duplicate: 'personas:duplicate',
     delete: 'personas:delete'
   },
   teams: {
@@ -610,6 +611,7 @@ export const IPC = {
     onChanged: 'teams:onChanged',
     revealDir: 'teams:revealDir',
     save: 'teams:save',
+    duplicate: 'teams:duplicate',
     delete: 'teams:delete',
     launch: 'teams:launch',
     cancel: 'teams:cancel',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5763,6 +5763,8 @@ export interface CcApi {
      * shadow. Returns the stored persona on success.
      */
     save(input: PersonaInput): Promise<Result<Persona>>;
+    /** Copy a resolved persona into a fresh user-owned persona. */
+    duplicate(id: string): Promise<Result<Persona>>;
     /**
      * Remove the user file for an id. For a shadowed built-in this resets it to
      * the shipped default; for a user persona it deletes it. Project personas
@@ -5783,6 +5785,8 @@ export interface CcApi {
     revealDir(): Promise<{ ok: boolean; path: string; message?: string }>;
     /** Create or overwrite a user team (`~/.zcc/teams/<id>.json`). */
     save(input: TeamInput): Promise<Result<Team>>;
+    /** Copy a resolved team into a fresh user-owned team. */
+    duplicate(id: string): Promise<Result<Team>>;
     /** Remove the user file for an id (resets a shadowed builtin / deletes a user team). */
     delete(id: string): Promise<Result<true>>;
     /**


### PR DESCRIPTION
## What Changed

Personas and Squads now support immediate duplication from their row context menus. Any builtin, user, project, or extension entry becomes a new user-owned copy with a fresh ID and deterministic numbered name.

Squads now match Persona row actions: View/Edit, Reveal folder, Duplicate, and Delete for user-created Squads only. Builtin, project, and extension Squads cannot be deleted from this menu.

Menus support pointer and keyboard invocation, focus management, Arrow/Home/End navigation, Escape, outside-click, and scroll dismissal.

## Implementation

- Main resolves selected ID from authoritative stores; renderer sends no configuration or path.
- Copies persist through existing validation and atomic user-save paths.
- Shared copy-name helper prevents trimmed, case-insensitive display-name collisions.
- Team store preserves user provenance when a registered project aliases user teams directory.

## Verification

- `npm run typecheck`
- Focused Persona/Team store, copy-name, and Squad panel tests
- Pre-push full suite: 4,526 passed; 51 skipped
- Manual keyboard context-menu behavior verified