### PR TITLE
fix(e2e): Add local Docker CI to E2E testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,9 @@ and issue reports are welcome.
    npm test
    ```
 
+   Electron E2E changes can also use the optional Linux CI reproduction described
+   in [`e2e/README.md`](e2e/README.md#optional-linux-ci-reproduction).
+
 5. Open a pull request against `main`. Explain the problem, the solution, and
    how you tested it. Link any related issue.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,6 +13,36 @@ npx playwright test smoke # a single spec
 npx playwright show-trace test-results/<…>/trace.zip   # post-mortem a failure
 ```
 
+## Optional Linux CI reproduction
+
+Use Docker to run the same Node 22, Ubuntu 24.04, Linux x64, build, Xvfb, and
+Playwright sequence used by `.github/workflows/ci.yml`. GitHub pins Python 3.11;
+the Ubuntu 24.04 image uses Python 3.12, which is sufficient when native package
+prebuilds resolve and is the one known userspace difference:
+
+```sh
+npm run test:e2e:docker
+npm run test:e2e:docker -- e2e/agent-launch-ui.spec.ts
+```
+
+Prerequisite: Docker Desktop running with at least 8 GB available memory. On
+Apple Silicon this intentionally emulates `linux/amd64`, matching GitHub's
+standard `ubuntu-latest` runner rather than testing different ARM native modules.
+First build and dependency install are slow.
+
+The wrapper builds `e2e/docker/Dockerfile`, copies a filtered checkout into a
+temporary container, runs `npm ci`, installs Playwright's Chromium system
+dependencies, builds, and executes the suite under `xvfb-run`. It excludes VCS
+data, local credentials, host `node_modules`, `out`, and native binaries;
+container-generated files do not change ownership in the host checkout. The
+container is removed on exit. Set
+`ZCC_E2E_DOCKER_IMAGE` to override the local image tag or
+`ZCC_E2E_DOCKER_PLATFORM` for diagnostic runs on another architecture.
+
+This reproduces CI's Linux userspace and commands, not GitHub's Azure VM kernel.
+If a failure remains hosted-runner-only, download `playwright-report` and
+`test-results` from the failed Actions run before changing test lifecycle code.
+
 ## Why these exist (and what they cover)
 
 The marketplace's pure engine (`src/main/extension-registry.ts`) is already

--- a/e2e/agent-launch-ui.spec.ts
+++ b/e2e/agent-launch-ui.spec.ts
@@ -10,8 +10,8 @@
  *     → launcher modal (data-testid="launch-modal")
  *         → instruction textarea (data-testid="launch-instruction")
  *         → target project select (aria-label="Target project")
- *         → profile button (data-testid="launch-profile-claude")
- *         → Send (data-testid="launch-send")
+ *         → harness select (aria-label="Launch harness")
+ *         → Launch agent (aria-label="Launch agent")
  *     → agent-inspector modal (data-testid="agent-terminal-modal")
  *         → live state chip (data-testid="agent-modal-state", data-state=…)
  *
@@ -115,12 +115,12 @@ test('launching an agent through the real UI opens its terminal and it goes work
 
     // 6. Select verified Claude explicitly. Default routing is covered elsewhere;
     // this flow needs a deterministic fake binary on every runner.
-    const claudeProfile = modal.locator('[data-testid="launch-profile-claude"]');
-    await expect(claudeProfile).toBeEnabled();
-    await claudeProfile.click();
+    const harnessSelect = modal.getByLabel('Launch harness');
+    await expect(harnessSelect).toBeEnabled();
+    await harnessSelect.selectOption('claude');
 
     // 7. Send. This is the real launch button — it calls doCreate → createTerminal.
-    await modal.locator('[data-testid="launch-send"]').click();
+    await modal.getByLabel('Launch agent').click();
 
     // 8. The launcher closes and the agent-inspector modal opens on the new
     //    session (AgentsView.onLauncherLaunched → openAgentModal).

--- a/e2e/docker/Dockerfile
+++ b/e2e/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
+
+ARG NODE_VERSION=22.23.2
+ARG NODE_LINUX_X64_SHA256=d60acfe00a2932254bb0ad20e01b0d74397a0875595de719654b214f4b03f307
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl git python3 xvfb build-essential libgtk-3-0t64 xz-utils zsh \
+  && curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+  && echo "${NODE_LINUX_X64_SHA256}  node-v${NODE_VERSION}-linux-x64.tar.xz" | sha256sum -c - \
+  && tar -xJf "node-v${NODE_VERSION}-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v${NODE_VERSION}-linux-x64.tar.xz" \
+  && rm -rf /var/lib/apt/lists/* \
+  && node --version \
+  && python3 --version
+
+WORKDIR /workspace

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "npm run build && playwright test",
+    "test:e2e:docker": "bash scripts/e2e-docker.sh",
     "test:e2e:only": "playwright test",
     "test:e2e:headed": "npm run build && playwright test --headed",
     "test:smoke": "npm run build && playwright test e2e/smoke.spec.ts",

--- a/scripts/e2e-docker.sh
+++ b/scripts/e2e-docker.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+IMAGE=${ZCC_E2E_DOCKER_IMAGE:-zana-e2e:playwright-1.62.1-node22}
+PLATFORM=${ZCC_E2E_DOCKER_PLATFORM:-linux/amd64}
+CONTAINER="zana-e2e-${RANDOM}-$$"
+
+if ! command -v docker >/dev/null 2>&1; then
+  printf 'Docker is required. Install and start Docker Desktop, then retry.\n' >&2
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  printf 'Docker daemon is not available. Start Docker Desktop, then retry.\n' >&2
+  exit 1
+fi
+
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+docker build \
+  --platform "$PLATFORM" \
+  --tag "$IMAGE" \
+  --file "$ROOT/e2e/docker/Dockerfile" \
+  "$ROOT/e2e/docker"
+
+docker create \
+  --name "$CONTAINER" \
+  --platform "$PLATFORM" \
+  --init \
+  --shm-size 2g \
+  --env CI=1 \
+  --env NODE_OPTIONS=--max-old-space-size=6144 \
+  --workdir /workspace \
+  "$IMAGE" \
+  sleep infinity \
+  >/dev/null
+
+# Copying instead of bind-mounting keeps Linux native modules and root-owned
+# build artifacts out of the macOS checkout. Exclusions prevent stale host
+# builds, dependencies, VCS data, and local credentials entering the container.
+docker start "$CONTAINER" >/dev/null
+tar \
+  --exclude='.git' \
+  --exclude='node_modules' \
+  --exclude='*/node_modules' \
+  --exclude='out' \
+  --exclude='dist' \
+  --exclude='*/dist' \
+  --exclude='test-results' \
+  --exclude='playwright-report' \
+  --exclude='.env' \
+  --exclude='.env.*' \
+  --exclude='.zcc' \
+  --exclude='.claude' \
+  -C "$ROOT" -cf - . | docker exec -i "$CONTAINER" tar -C /workspace -xf -
+docker exec "$CONTAINER" bash -lc 'npm ci && npx playwright install-deps chromium && npm run build && xvfb-run -a npm run test:e2e:only -- "$@"' bash "$@"


### PR DESCRIPTION
## Summary

Adds an optional Docker-based runner for reproducing GitHub Actions Electron E2E tests locally in a Linux x64 environment. This gives contributors a closer CI match when failures do not reproduce on macOS, especially for Linux-native dependencies, Xvfb, and Electron process behavior.

## How to use

Run the full E2E suite:

```sh
npm run test:e2e:docker
```

Run one spec:

```sh
npm run test:e2e:docker -- e2e/smoke.spec.ts
```

The runner builds a pinned Ubuntu image with Node 22, copies a filtered checkout into a temporary container, installs dependencies, builds the app, and runs Playwright under Xvfb. The container is removed afterward and does not write Linux build artifacts into the host checkout.

See `e2e/README.md` for prerequisites, architecture overrides, and known differences from hosted GitHub runners.

## Verification

- `npm run typecheck`
- `npm run test:e2e:docker -- e2e/smoke.spec.ts`
- pre-push test suite: 4,527 passed, 51 skipped