### PR TITLE
Fix remote launch attachments

### DIFF
--- a/src/main/__tests__/pty-tmux.test.ts
+++ b/src/main/__tests__/pty-tmux.test.ts
@@ -275,7 +275,7 @@ describe('pty tmux wrapping (remote)', () => {
   });
 
   it('per-project remotePath overrides the global remoteDefaultPath', () => {
-    ptys.create({
+    const session = ptys.create({
       projectId: 'p1',
       profile: 'shell',
       config: cfg({ remoteDefaultPath: '/opt/workspace/core-public' }),
@@ -285,6 +285,8 @@ describe('pty tmux wrapping (remote)', () => {
     const remoteCmd = spawned[0].args.at(-1) as string;
     expect(remoteCmd).toContain("cd '/work/p1' &&");
     expect(remoteCmd).not.toContain('/opt/workspace/core-public');
+    // TerminalView uses session.cwd as the remote upload destination.
+    expect(session.cwd).toBe('/work/p1');
   });
 
   it('no cd prefix when neither remotePath nor remoteDefaultPath is set', () => {

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -1958,6 +1958,10 @@ export class PtyManager extends EventEmitter {
     resume?: boolean;
   }): TerminalSession {
     const { remote } = opts;
+    // The session record is consumed by the renderer for remote file drops. It
+    // must name the remote login directory, not the local placeholder project
+    // directory that createTerminalConfined passes through as opts.cwd.
+    const remoteCwd = remote.remotePath || opts.config.remoteDefaultPath || '.';
     // Same live-session cap as the local path — a remote ssh pty is still a
     // local subprocess + fd held in this.live, so it counts identically.
     this.assertCapacity(opts.config);
@@ -2177,7 +2181,7 @@ export class PtyManager extends EventEmitter {
       projectId: opts.projectId,
       title: opts.title ?? `${remoteProvider.title(opts.profile)} · ${remote.host}`,
       profile: opts.profile,
-      cwd: opts.cwd,
+      cwd: remoteCwd,
       pid: proc.pid,
       status: 'running',
       createdAt: Date.now(),

--- a/src/renderer/components/AgentLauncher.tsx
+++ b/src/renderer/components/AgentLauncher.tsx
@@ -22,6 +22,7 @@ import {
   Trash2,
   ShieldCheck,
   Boxes,
+  FolderGit2,
   type LucideIcon
 } from 'lucide-react';
 import type {
@@ -68,6 +69,7 @@ import { effectivePersonaRouting } from '../util/personaRouting';
 import { HarnessOptionSelect } from './HarnessOptionSelect';
 import { LauncherModelPicker } from './LauncherModelPicker';
 import { buildFixWithAiPrompt } from '../util/fixWithAiPrompt';
+import type { DropPathResolver } from '../util/useFileDrop';
 
 /**
  * A framework preset offered in Advanced view: an installed extension that
@@ -1021,6 +1023,8 @@ export const AgentLauncher = memo(function AgentLauncher({
   const [agentRoutingDirty, setAgentRoutingDirty] = useState(false);
   const [launchError, setLaunchError] = useState<string | null>(null);
   const [launching, setLaunching] = useState(false);
+  const [dropResolving, setDropResolving] = useState(false);
+  const [attachments, setAttachments] = useState<string[]>([]);
   const [fixingWithAi, setFixingWithAi] = useState(false);
   const teams = useTeams(useShallow((s) => s.teams));
   const pushToast = useUi((s) => s.pushToast);
@@ -1075,6 +1079,28 @@ export const AgentLauncher = memo(function AgentLauncher({
   const target = projectMode
     ? project!
     : (targetProjectId ? projects.find((p) => p.id === targetProjectId) : null) ?? anchor;
+  const remoteTarget = target?.remote ? { id: target.id, remote: target.remote } : undefined;
+  const addAttachments = (paths: string[]) => {
+    setAttachments((current) => [...new Set([...current, ...paths])]);
+  };
+  const remoteDropResolver: DropPathResolver = async (localPaths) => {
+    if (!remoteTarget) {
+      addAttachments(localPaths);
+      return '';
+    }
+    const uploaded: string[] = [];
+    for (const localPath of localPaths) {
+      const result = await window.cc.fs.uploadToRemote(remoteTarget.id, localPath, '.');
+      if (!result.ok || !result.path) {
+        pushToast(result.message ?? `Failed to upload ${localPath.split('/').pop()}`, 'error');
+        continue;
+      }
+      uploaded.push(result.path);
+      pushToast(`Uploaded ${localPath.split('/').pop()} to ${remoteTarget.remote.host}`);
+    }
+    addAttachments(uploaded);
+    return '';
+  };
   // Renderer eligibility is advisory. Main still verifies Git state and confines
   // the worktree before changing cwd.
   const scratchIsTarget = !projectMode && targetProjectId === null;
@@ -1368,6 +1394,9 @@ export const AgentLauncher = memo(function AgentLauncher({
     applyAdvanced: boolean
   ) => {
     if (!target) return;
+    const attachmentContext = attachments.length
+      ? `\n\nAttached files:\n${attachments.map((path) => `- ${path}`).join('\n')}`
+      : '';
     const chosenPersonaId = applyAdvanced && advanced ? personaId ?? undefined : undefined;
     const chosenFrameworkIds =
       applyAdvanced && advanced && !chosenPersonaId && frameworkIds.length > 0
@@ -1386,7 +1415,7 @@ export const AgentLauncher = memo(function AgentLauncher({
         : opts.extraArgs;
     const session = await createTerminal(target.id, profile, 80, 24, {
       extraArgs: chosenExtraArgs,
-      prompt: opts.prompt,
+      prompt: opts.prompt ? `${opts.prompt}${attachmentContext}` : attachmentContext || undefined,
       harnessRouting: family
         ? agentRoutingForSubmission(profileChosen, family.id, portableRouting, nativeRouting, agentRoutingDirty)
         : undefined,
@@ -1419,7 +1448,7 @@ export const AgentLauncher = memo(function AgentLauncher({
   };
 
   const launch = () => {
-    if (!descriptor) return; // no installed/enabled harness family to launch
+    if (!descriptor || dropResolving) return; // wait until remote uploads have inserted their paths
     const normalizedWorktreeName = normalizeWorktreeName(worktreeName);
     if (worktree && worktreeEligible && !normalizedWorktreeName) {
       setAdvanced(true);
@@ -1640,7 +1669,7 @@ export const AgentLauncher = memo(function AgentLauncher({
       >
         <div className="launch-panel">
           <div className="launch-header">
-            <h3>{projectMode ? project!.name : scratchIsTarget ? 'Quick agent' : target?.name ?? 'New agent'}</h3>
+            <h3 id="agent-launcher-title">{projectMode ? project!.name : scratchIsTarget ? 'Quick agent' : target?.name ?? 'New agent'}</h3>
             <p>
               {projectMode
                 ? 'Start a session'
@@ -1691,6 +1720,101 @@ export const AgentLauncher = memo(function AgentLauncher({
             value={prompt}
             onChange={setPrompt}
             mentionProjectPath={project?.path}
+            dropResolver={remoteDropResolver}
+            onDropResolvingChange={setDropResolving}
+            attachments={attachments}
+            onRemoveAttachment={(path) => setAttachments((current) => current.filter((item) => item !== path))}
+            onAddAttachments={addAttachments}
+            submitDisabled={!target || !descriptor || !configLoaded || !worktreeDefaultLoaded || personaProfileConflict || launching || dropResolving}
+            toolbarControls={
+              <>
+                {!projectMode && (
+                  <label className="home-agent-select launch-toolbar-project">
+                    <FolderGit2 size={15} aria-hidden="true" />
+                    <select
+                      value={targetProjectId ?? ''}
+                      onChange={(e) => setTargetProjectId(e.target.value || null)}
+                      aria-label="Target project"
+                    >
+                      <option value="">Quick workspace (scratch)</option>
+                      {projectGroups.favorites.length > 0 && (
+                        <optgroup label="Favorites">
+                          {projectGroups.favorites.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                        </optgroup>
+                      )}
+                      {projectGroups.remote.length > 0 && (
+                        <optgroup label="Remote">
+                          {projectGroups.remote.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                        </optgroup>
+                      )}
+                      {projectGroups.local.length > 0 && (
+                        <optgroup label="Local">
+                          {projectGroups.local.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                        </optgroup>
+                      )}
+                    </select>
+                    <ChevronDown size={14} aria-hidden="true" />
+                  </label>
+                )}
+                {mode === 'agent' && (
+                  <label className="home-agent-select">
+                    <select
+                      value={profileChosen ? family?.id ?? '' : ''}
+                      onChange={(e) => {
+                        const next = e.target.value as HarnessFamily;
+                        setFamilyId(next);
+                        setProfileChosen(Boolean(next));
+                      }}
+                      aria-label="Launch harness"
+                      disabled={!configLoaded}
+                    >
+                      <option value="">Use project/global default</option>
+                      {availableFamilies.map((f) => <option key={f.id} value={f.id}>{f.label}</option>)}
+                    </select>
+                    <ChevronDown size={14} aria-hidden="true" />
+                  </label>
+                )}
+                {mode === 'agent' && (
+                  <LauncherModelPicker
+                    id="launch-toolbar-model"
+                    models={selectedHarnessDescriptor?.targets?.models ?? []}
+                    value={(profileChosen ? selectedNativeRouting : portableRouting).modelTargetId ?? ''}
+                    disabled={!selectedHarnessDescriptor?.targets?.models.length}
+                    onChange={(modelTargetId) => {
+                      if (profileChosen && family) updateNativeRouting(family.id, { modelTargetId: modelTargetId || undefined });
+                      else {
+                        setAgentRoutingDirty(true);
+                        setPortableRouting((current) => ({ ...current, modelTargetId: modelTargetId || undefined }));
+                      }
+                    }}
+                  />
+                )}
+              </>
+            }
+            belowControls={mode === 'agent' ? (
+              <div className="launch-segmented" role="group" aria-label="Permission mode">
+                <button
+                  type="button"
+                  data-testid="launch-mode-normal"
+                  className={!yoloActive ? 'active' : ''}
+                  onClick={() => { setYolo(false); setProfileChosen(true); }}
+                  aria-pressed={!yoloActive}
+                >
+                  Normal
+                </button>
+                <button
+                  type="button"
+                  data-testid="launch-mode-yolo"
+                  className={yoloActive ? 'active' : ''}
+                  onClick={() => { setYolo(true); setProfileChosen(true); }}
+                  aria-pressed={yoloActive}
+                  disabled={!family?.yolo}
+                  title={family?.yolo ? 'Launch with permissions bypassed (auto-approve every action)' : `${family?.label ?? 'This harness'} has no permission-bypass mode`}
+                >
+                  <Zap size={13} /> Yolo
+                </button>
+              </div>
+            ) : undefined}
             onSubmit={mode === 'autonomous' ? launchAutonomous : launch}
             placeholder={
               mode === 'autonomous'
@@ -1767,8 +1891,8 @@ export const AgentLauncher = memo(function AgentLauncher({
             />
           )}
 
-          {!projectMode && (
-            <div className="launch-row">
+          {false && !projectMode && (
+            <div className="launch-row launch-toolbar-duplicate" aria-hidden="true">
               <span className="launch-row-label">Project</span>
               <div className="launch-folder">
                 <Folder size={13} aria-hidden="true" />
@@ -1840,8 +1964,8 @@ export const AgentLauncher = memo(function AgentLauncher({
             </div>
           )}
 
-          {mode === 'agent' && (
-            <div className="launch-row">
+          {false && mode === 'agent' && (
+            <div className="launch-row launch-toolbar-duplicate" aria-hidden="true">
               <span className="launch-row-label">Harness</span>
               {!configLoaded ? (
                 <span className="launch-squad-hint" role="status">Loading harness default…</span>
@@ -1929,8 +2053,8 @@ export const AgentLauncher = memo(function AgentLauncher({
             )
           )}
 
-          {mode === 'agent' && (
-            <div className="launch-row">
+          {false && mode === 'agent' && (
+            <div className="launch-row launch-toolbar-duplicate">
               <span className="launch-row-label">Mode</span>
               <div className="launch-segmented" role="group" aria-label="Permission mode">
                 <button
@@ -2312,26 +2436,14 @@ export const AgentLauncher = memo(function AgentLauncher({
               <button
                 className="btn primary"
                 onClick={launchAutonomous}
-                disabled={!teamId || !prompt.trim() || !target || launching}
+                  disabled={!teamId || !prompt.trim() || !target || launching || dropResolving}
                 aria-describedby={launchStatusA11y.describedBy}
                 title="Launch autonomous team (⌘↵)"
               >
                 <Zap size={14} />
                 Launch autonomous team
               </button>
-            ) : (
-              <button
-                data-testid="launch-send"
-                className="btn primary"
-                onClick={launch}
-                disabled={!target || !descriptor || !configLoaded || !worktreeDefaultLoaded || personaProfileConflict || launching}
-                aria-describedby={launchStatusA11y.describedBy}
-                title="Send (⌘↵)"
-              >
-                <TerminalIcon size={14} />
-                Send
-              </button>
-            )}
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/renderer/components/HomeAgentComposer.tsx
+++ b/src/renderer/components/HomeAgentComposer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ArrowUp, Check, ChevronDown, FileText, FolderGit2, Paperclip, Search, Server, X } from 'lucide-react';
+import { ArrowUp, Check, ChevronDown, FolderGit2, Paperclip, Search, Server } from 'lucide-react';
 import type { HarnessAdapterDescriptor, HarnessModelTarget } from '@shared/harness-adapter';
 import type { EffectiveHarnessDefaultResult, HarnessFamily, HarnessModelRoutingV1, LaunchProfileId, Project } from '@shared/types';
 import { buildLaunchArgs } from './AgentLauncher';
@@ -11,10 +11,12 @@ import {
   ComposerIconButton,
   ComposerToolbar
 } from './ui/CommandComposer';
+import { AttachmentPills } from './ui/AttachmentPills';
 import { VoiceInputButton } from './VoiceInputButton';
 import { useData, usePersonas, useUi } from '../store';
 import { useShallow } from 'zustand/react/shallow';
 import { useFileDrop } from '../util/useFileDrop';
+import { posixQuote } from '../util/quote';
 
 const PROFILE_BY_FAMILY: Record<HarnessFamily, LaunchProfileId> = {
   claude: 'claude',
@@ -84,6 +86,7 @@ export function HomeAgentComposer() {
   const setNav = useUi((s) => s.setNav);
   const selectProject = useUi((s) => s.selectProject);
   const selectTab = useUi((s) => s.selectTab);
+  const pushToast = useUi((s) => s.pushToast);
   const [preferences, setPreferences] = useState(readHomeLauncherPreferences);
   const [prompt, setPrompt] = useState('');
   const [projectId, setProjectId] = useState(preferences.projectId ?? '');
@@ -197,8 +200,24 @@ export function HomeAgentComposer() {
       ? automaticProfile
       : selectedHarness?.defaultProfileId ?? PROFILE_BY_FAMILY[familyId];
     if (!profile) return;
-    const attachmentContext = attachments.length
-      ? `\n\nAttached files:\n${attachments.map((path) => `- ${path}`).join('\n')}`
+    let attachmentPaths = attachments;
+    if (project.remote && attachments.length > 0) {
+      const uploaded: string[] = [];
+      setLaunching(true);
+      for (const localPath of attachments) {
+        const result = await window.cc.fs.uploadToRemote(project.id, localPath, '.');
+        if (!result.ok || !result.path) {
+          pushToast(result.message ?? `Failed to upload ${attachmentName(localPath)}`, 'error');
+          setLaunching(false);
+          return;
+        }
+        uploaded.push(result.path);
+        pushToast(`Uploaded ${attachmentName(localPath)} to ${project.remote.host}`);
+      }
+      attachmentPaths = uploaded.map(posixQuote);
+    }
+    const attachmentContext = attachmentPaths.length
+      ? `\n\nAttached files:\n${attachmentPaths.map((path) => `- ${path}`).join('\n')}`
       : '';
     const args = buildLaunchArgs(`${prompt}${attachmentContext}`, selectedHarness?.label ?? familyId);
     const validModelId = models.some((model) => model.id === modelId) ? modelId : '';
@@ -232,23 +251,10 @@ export function HomeAgentComposer() {
       </div>
 
       <CommandComposer className={`home-agent-command${dropOver ? ' is-drop-over' : ''}`} labelledBy="home-agent-composer-title" {...dropHandlers}>
-        {attachments.length > 0 && (
-          <div className="home-agent-attachments" aria-label="Attached files">
-            {attachments.map((path) => (
-              <span key={path} className="home-agent-attachment" title={path}>
-                <FileText size={14} aria-hidden="true" />
-                <span>{attachmentName(path)}</span>
-                <button
-                  type="button"
-                  onClick={() => setAttachments((current) => current.filter((item) => item !== path))}
-                  aria-label={`Remove ${attachmentName(path)}`}
-                >
-                  <X size={13} aria-hidden="true" />
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
+        <AttachmentPills
+          paths={attachments}
+          onRemove={(path) => setAttachments((current) => current.filter((item) => item !== path))}
+        />
         <AutoGrowTextarea
           value={prompt}
           onChange={(event) => setPrompt(event.target.value)}

--- a/src/renderer/components/PromptComposer.tsx
+++ b/src/renderer/components/PromptComposer.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState
 } from 'react';
-import { useFileDrop } from '../util/useFileDrop';
+import { useFileDrop, type DropPathResolver } from '../util/useFileDrop';
 import { useData } from '../store';
 import { fuzzyScore } from '../util/fuzzy';
 import { detectMention, applyMention, type MentionMatch } from '../util/mention';
@@ -14,6 +14,15 @@ import { highlightMatches } from './palette/highlight';
 import { ImprovePromptButton } from './ImprovePromptButton';
 import { VoiceInputButton } from './VoiceInputButton';
 import type { WalkedFile } from '@shared/types';
+import { AttachmentPills } from './ui/AttachmentPills';
+import {
+  AutoGrowTextarea,
+  type AutoGrowTextareaHandle,
+  CommandComposer,
+  ComposerIconButton,
+  ComposerToolbar
+} from './ui/CommandComposer';
+import { ArrowUp, Paperclip } from 'lucide-react';
 
 /**
  * The agent-instruction box, shared by every launcher that takes a typed prompt
@@ -44,6 +53,16 @@ interface Props {
   /** Absolute path of the project whose files back the `@`-mention picker. When
    *  absent (e.g. scratch mode with no resolved project) `@` does nothing. */
   mentionProjectPath?: string;
+  /** Transforms local dropped paths before inserting them into the prompt. */
+  dropResolver?: DropPathResolver;
+  /** Reports whether an asynchronous dropped-path transform is in flight. */
+  onDropResolvingChange?: (resolving: boolean) => void;
+  attachments?: readonly string[];
+  onRemoveAttachment?: (path: string) => void;
+  onAddAttachments?: (paths: string[]) => void;
+  submitDisabled?: boolean;
+  toolbarControls?: React.ReactNode;
+  belowControls?: React.ReactNode;
 }
 
 /** Most files to rank/show in the `@`-mention popover at once. */
@@ -64,7 +83,7 @@ interface Ranked {
 function useMention(
   value: string,
   onChange: (v: string) => void,
-  textareaRef: React.RefObject<HTMLTextAreaElement>,
+  textareaRef: React.RefObject<AutoGrowTextareaHandle>,
   projectPath: string | undefined
 ) {
   const [mention, setMention] = useState<MentionMatch | null>(null);
@@ -75,7 +94,7 @@ function useMention(
 
   // Recompute the mention token from the live caret position.
   const refresh = useCallback(() => {
-    const el = textareaRef.current;
+    const el = textareaRef.current?.element();
     if (!el || !projectPath) {
       setMention(null);
       return;
@@ -126,7 +145,7 @@ function useMention(
 
   const choose = useCallback(
     (file: WalkedFile) => {
-      const el = textareaRef.current;
+      const el = textareaRef.current?.element();
       if (!el || !mention) return;
       const caret = el.selectionStart ?? el.value.length;
       const out = applyMention(value, mention, caret, file.rel);
@@ -175,10 +194,14 @@ function useMention(
 }
 
 export const PromptComposer = forwardRef<PromptComposerHandle, Props>(function PromptComposer(
-  { value, onChange, onSubmit, placeholder, rows = 3, mentionProjectPath },
+  {
+    value, onChange, onSubmit, placeholder, rows = 3, mentionProjectPath, dropResolver,
+    onDropResolvingChange, attachments = [], onRemoveAttachment, onAddAttachments, submitDisabled = false,
+    toolbarControls, belowControls
+  },
   ref
 ) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const textareaRef = useRef<AutoGrowTextareaHandle>(null);
   const voiceInputEnabled = useData((s) => s.voiceInputEnabled);
   useImperativeHandle(ref, () => ({ focus: () => textareaRef.current?.focus() }), []);
 
@@ -194,8 +217,8 @@ export const PromptComposer = forwardRef<PromptComposerHandle, Props>(function P
 
   // Splice the dropped path(s) in at the caret, padding with a single space so
   // they don't fuse onto adjacent words; restore the caret just past the insert.
-  const { dropOver, dropHandlers } = useFileDrop((insert) => {
-    const el = textareaRef.current;
+  const { dropOver, resolving, dropHandlers } = useFileDrop((insert) => {
+    const el = textareaRef.current?.element();
     const start = el?.selectionStart ?? value.length;
     const end = el?.selectionEnd ?? value.length;
     const before = value.slice(0, start);
@@ -208,61 +231,80 @@ export const PromptComposer = forwardRef<PromptComposerHandle, Props>(function P
       el?.focus();
       el?.setSelectionRange(caret, caret);
     });
-  });
+  }, dropResolver);
+
+  useEffect(() => onDropResolvingChange?.(resolving), [onDropResolvingChange, resolving]);
 
   return (
-    <div className="prompt-composer">
-      <textarea
-        ref={textareaRef}
-        data-testid="launch-instruction"
-        className={`launch-instruction ${dropOver ? 'drop-over' : ''}`}
-        placeholder={placeholder}
-        value={value}
-        onChange={(e) => {
-          onChange(e.target.value);
-          mention.refresh();
-        }}
-        onKeyUp={mention.refresh}
-        onClick={mention.refresh}
-        onBlur={() => {
-          // Close on blur — but a row's mousedown (which preventDefaults, so the
-          // textarea keeps focus) fires its choose() first, so a genuine click
-          // still lands. A short delay guards against focus-shuffle races.
-          window.setTimeout(mention.close, 120);
-        }}
-        onKeyDown={onKeyDown}
+    <>
+      <CommandComposer
+        className={`launch-command${dropOver ? ' is-drop-over' : ''}`}
+        labelledBy="agent-launcher-title"
         {...dropHandlers}
-        rows={rows}
-      />
-      {mention.open && (
-        <div className="mention-popover" role="listbox" aria-label="Insert file">
-          {mention.ranked.map((r, i) => (
-            <button
-              type="button"
-              key={r.file.rel}
-              role="option"
-              aria-selected={i === mention.active}
-              className={`palette-item mention-item ${i === mention.active ? 'active' : ''}`}
-              // mousedown (not click) so it fires before the textarea's blur.
-              onMouseDown={(e) => {
-                e.preventDefault();
-                mention.choose(r.file);
-              }}
-              onMouseEnter={() => mention.setActive(i)}
-            >
-              {highlightMatches(r.file.rel, r.matchIdx)}
-            </button>
-          ))}
-        </div>
-      )}
-      <div className="prompt-composer-actions">
-        {voiceInputEnabled ? (
-          <VoiceInputButton value={value} onChange={onChange} textareaRef={textareaRef} />
-        ) : (
-          <span />
+      >
+        <AttachmentPills paths={attachments} onRemove={(path) => onRemoveAttachment?.(path)} />
+        <AutoGrowTextarea
+          ref={textareaRef}
+          data-testid="launch-instruction"
+          className="launch-instruction"
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value);
+            mention.refresh();
+          }}
+          onKeyUp={mention.refresh}
+          onClick={mention.refresh}
+          onBlur={() => window.setTimeout(mention.close, 120)}
+          onKeyDown={onKeyDown}
+          rows={rows}
+        />
+        {mention.open && (
+          <div className="mention-popover" role="listbox" aria-label="Insert file">
+            {mention.ranked.map((r, i) => (
+              <button
+                type="button"
+                key={r.file.rel}
+                role="option"
+                aria-selected={i === mention.active}
+                className={`palette-item mention-item ${i === mention.active ? 'active' : ''}`}
+                onMouseDown={(e) => { e.preventDefault(); mention.choose(r.file); }}
+                onMouseEnter={() => mention.setActive(i)}
+              >
+                {highlightMatches(r.file.rel, r.matchIdx)}
+              </button>
+            ))}
+          </div>
         )}
+        <ComposerToolbar>
+          {onAddAttachments && (
+            <ComposerIconButton
+              onClick={() => { void window.cc.fs.pickFiles().then(onAddAttachments); }}
+              title="Attach files"
+              aria-label="Attach files"
+            >
+              <Paperclip size={16} aria-hidden="true" />
+            </ComposerIconButton>
+          )}
+          {toolbarControls}
+          {voiceInputEnabled ? (
+            <VoiceInputButton value={value} onChange={onChange} textareaRef={textareaRef} iconOnly />
+          ) : <span />}
+          <ComposerIconButton
+            className="home-agent-launch"
+            onClick={onSubmit}
+            disabled={submitDisabled}
+            aria-label="Launch agent"
+            title="Launch agent (⌘↵)"
+          >
+            <ArrowUp size={17} aria-hidden="true" />
+          </ComposerIconButton>
+        </ComposerToolbar>
+      </CommandComposer>
+      <div className="prompt-composer-actions">
+        <span>{belowControls}</span>
         <ImprovePromptButton value={value} onChange={onChange} />
       </div>
-    </div>
+    </>
   );
 });

--- a/src/renderer/components/VoiceInputButton.tsx
+++ b/src/renderer/components/VoiceInputButton.tsx
@@ -1,12 +1,13 @@
 import { useState, useRef, useEffect } from 'react';
 import { Mic, Loader2 } from 'lucide-react';
 import { useUi } from '../store';
+import type { AutoGrowTextareaHandle } from './ui/CommandComposer';
 
 interface Props {
   value: string;
   onChange: (next: string) => void;
   className?: string;
-  textareaRef?: React.RefObject<HTMLTextAreaElement>;
+  textareaRef?: React.RefObject<AutoGrowTextareaHandle>;
   /** Render just the mic glyph (no text label) — for tight composer toolbars. */
   iconOnly?: boolean;
 }
@@ -185,7 +186,7 @@ export function VoiceInputButton({ value, onChange, className, textareaRef, icon
             return;
           }
 
-          const el = textareaRef?.current;
+      const el = textareaRef?.current?.element();
           const start = el?.selectionStart ?? value.length;
           const end = el?.selectionEnd ?? value.length;
           const before = value.slice(0, start);

--- a/src/renderer/components/__tests__/AgentLauncher.test.tsx
+++ b/src/renderer/components/__tests__/AgentLauncher.test.tsx
@@ -52,6 +52,15 @@ describe('buildLaunchArgs', () => {
   });
 });
 
+describe('remote launch drops', () => {
+  it('uploads dropped files before inserting their remote paths into the prompt', () => {
+    const source = readFileSync(new URL('../AgentLauncher.tsx', import.meta.url), 'utf8');
+    expect(source).toContain('window.cc.fs.uploadToRemote(remoteTarget.id, localPath, \'.\')');
+    expect(source).toContain('dropResolver={remoteDropResolver}');
+    expect(source).toContain('dropResolving');
+  });
+});
+
 describe('Fix with AI recovery launch', () => {
   it('uses the managed scratch workspace root instead of retrying a failed project cwd', () => {
     const source = readFileSync(new URL('../AgentLauncher.tsx', import.meta.url), 'utf8');

--- a/src/renderer/components/ui/AttachmentPills.tsx
+++ b/src/renderer/components/ui/AttachmentPills.tsx
@@ -1,0 +1,33 @@
+import { FileText, X } from 'lucide-react';
+
+function fileName(path: string): string {
+  return path.split(/[\\/]/).pop() || path;
+}
+
+/** Shared attachment display for composer-style inputs. Upload and launch policy
+ * remain with the caller; this component only renders removable file pills. */
+export function AttachmentPills({
+  paths,
+  onRemove
+}: {
+  paths: readonly string[];
+  onRemove: (path: string) => void;
+}) {
+  if (paths.length === 0) return null;
+  return (
+    <div className="ui-command-attachments" aria-label="Attached files">
+      {paths.map((path) => {
+        const name = fileName(path);
+        return (
+          <span key={path} className="ui-command-attachment-chip" title={path}>
+            <FileText size={14} aria-hidden="true" />
+            <span className="ui-command-attachment-name">{name}</span>
+            <button type="button" onClick={() => onRemove(path)} aria-label={`Remove ${name}`}>
+              <X size={13} aria-hidden="true" />
+            </button>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/renderer/components/ui/CommandComposer.tsx
+++ b/src/renderer/components/ui/CommandComposer.tsx
@@ -91,18 +91,3 @@ export function ComposerIconButton({
     </button>
   );
 }
-
-export function ComposerAttachmentChip({
-  name,
-  onRemove
-}: {
-  name: string;
-  onRemove: () => void;
-}) {
-  return (
-    <span className="ui-command-attachment-chip">
-      <span className="ui-command-attachment-name">{name}</span>
-      <button type="button" onClick={onRemove} aria-label={`Remove ${name}`}>x</button>
-    </span>
-  );
-}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -18818,6 +18818,28 @@ button.zana-assign-trigger.is-unassigned .zana-assign-caret {
   position: relative;
 }
 
+.launch-command {
+  margin-bottom: 14px;
+}
+
+/* Project, harness, and permission mode live in the shared composer toolbar.
+   Keep their existing controls mounted for advanced launch state continuity. */
+.launch-toolbar-duplicate {
+  display: none;
+}
+
+.launch-command .launch-model-picker-trigger {
+  min-height: 30px;
+  max-width: 220px;
+  padding: 5px 7px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+}
+
 .launch-instruction {
   width: 100%;
   box-sizing: border-box;
@@ -25720,14 +25742,14 @@ body.resizing-col .library-split-resizer::after {
   color: var(--text-dim);
 }
 
-.home-agent-attachments {
+.ui-command-attachments {
   display: flex;
   flex-wrap: wrap;
   gap: 7px;
   min-width: 0;
 }
 
-.home-agent-attachment {
+.ui-command-attachment-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -25740,13 +25762,13 @@ body.resizing-col .library-split-resizer::after {
   font-size: 12px;
 }
 
-.home-agent-attachment > span {
+.ui-command-attachment-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.home-agent-attachment button {
+.ui-command-attachment-chip button {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
@@ -25761,8 +25783,8 @@ body.resizing-col .library-split-resizer::after {
   cursor: pointer;
 }
 
-.home-agent-attachment button:hover,
-.home-agent-attachment button:focus-visible {
+.ui-command-attachment-chip button:hover,
+.ui-command-attachment-chip button:focus-visible {
   background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
 }
 
@@ -25803,32 +25825,6 @@ body.resizing-col .library-split-resizer::after {
   outline-offset: 2px;
 }
 
-.ui-command-attachment-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  max-width: 220px;
-  padding: 4px 6px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--bg-panel);
-  color: var(--text-primary);
-  font-size: 11px;
-}
-
-.ui-command-attachment-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ui-command-attachment-chip button {
-  border: 0;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-}
-
 .home-agent-select {
   display: inline-flex;
   align-items: center;
@@ -25854,6 +25850,15 @@ body.resizing-col .library-split-resizer::after {
   font-size: 12px;
   cursor: pointer;
   appearance: none;
+  color-scheme: dark;
+}
+
+/* Native macOS select menus otherwise render in the system light palette,
+   even though their trigger belongs to the dark command composer. */
+.home-agent-select option,
+.home-agent-select optgroup {
+  background: var(--bg-panel);
+  color: var(--text-primary);
 }
 
 .home-agent-project-picker {

--- a/src/renderer/util/useFileDrop.ts
+++ b/src/renderer/util/useFileDrop.ts
@@ -40,6 +40,14 @@ const defaultResolver: DropPathResolver = (localPaths) =>
  */
 export function useFileDrop(onPaths: (paths: string) => void, resolver: DropPathResolver = defaultResolver) {
   const [dropOver, setDropOver] = useState(false);
+  const [resolving, setResolving] = useState(false);
+
+  const resolvePaths = (localPaths: string[]) => {
+    setResolving(true);
+    void Promise.resolve(resolver(localPaths)).then((paths) => {
+      if (paths) onPaths(paths);
+    }).finally(() => setResolving(false));
+  };
 
   const onDragOver = (e: React.DragEvent) => {
     const types = Array.from(e.dataTransfer.types);
@@ -62,18 +70,14 @@ export function useFileDrop(onPaths: (paths: string) => void, resolver: DropPath
         .map((f) => window.cc.files.pathForFile(f))
         .filter(Boolean);
       if (localPaths.length === 0) return;
-      void Promise.resolve(resolver(localPaths)).then((paths) => {
-        if (paths) onPaths(paths);
-      });
+      resolvePaths(localPaths);
       return;
     }
     const text = e.dataTransfer.getData('text/plain');
     if (text && text.startsWith('/')) {
-      void Promise.resolve(resolver([text])).then((paths) => {
-        if (paths) onPaths(paths);
-      });
+      resolvePaths([text]);
     }
   };
 
-  return { dropOver, dropHandlers: { onDragOver, onDragLeave, onDrop } };
+  return { dropOver, resolving, dropHandlers: { onDragOver, onDragLeave, onDrop } };
 }


### PR DESCRIPTION
## Summary
- Upload attached files before launching remote agents and use the remote project directory for terminal drops.
- Reuse the Home composer layout and attachment pills in the New Agent launcher.
- Move project, harness, model, attachment, voice, and launch controls into the shared composer while retaining the Normal/Yolo control below it.

## Verification
- 
> zana-command-center@1.0.9 typecheck
> tsc --noEmit -p tsconfig.json
- 
 RUN  v4.1.8 /Users/grebmann/zcc-workspace/zana-command-center


 Test Files  3 passed (3)
      Tests  67 passed (67)
   Start at  12:52:21
   Duration  1.62s (transform 700ms, setup 26ms, import 815ms, tests 1.46s, environment 0ms)
- Full pre-push suite was attempted repeatedly but blocked by flaky  temp-directory cleanup/timeouts; focused test passes.