### PR TITLE
fix(launcher): restore layout and share home pickers

### DIFF
--- a/src/renderer/components/AgentLauncher.tsx
+++ b/src/renderer/components/AgentLauncher.tsx
@@ -22,7 +22,6 @@ import {
   Trash2,
   ShieldCheck,
   Boxes,
-  FolderGit2,
   type LucideIcon
 } from 'lucide-react';
 import type {
@@ -70,6 +69,7 @@ import { HarnessOptionSelect } from './HarnessOptionSelect';
 import { LauncherModelPicker } from './LauncherModelPicker';
 import { buildFixWithAiPrompt } from '../util/fixWithAiPrompt';
 import type { DropPathResolver } from '../util/useFileDrop';
+import { posixQuote } from '../util/quote';
 
 /**
  * A framework preset offered in Advanced view: an installed extension that
@@ -1024,7 +1024,6 @@ export const AgentLauncher = memo(function AgentLauncher({
   const [launchError, setLaunchError] = useState<string | null>(null);
   const [launching, setLaunching] = useState(false);
   const [dropResolving, setDropResolving] = useState(false);
-  const [attachments, setAttachments] = useState<string[]>([]);
   const [fixingWithAi, setFixingWithAi] = useState(false);
   const teams = useTeams(useShallow((s) => s.teams));
   const pushToast = useUi((s) => s.pushToast);
@@ -1080,14 +1079,8 @@ export const AgentLauncher = memo(function AgentLauncher({
     ? project!
     : (targetProjectId ? projects.find((p) => p.id === targetProjectId) : null) ?? anchor;
   const remoteTarget = target?.remote ? { id: target.id, remote: target.remote } : undefined;
-  const addAttachments = (paths: string[]) => {
-    setAttachments((current) => [...new Set([...current, ...paths])]);
-  };
   const remoteDropResolver: DropPathResolver = async (localPaths) => {
-    if (!remoteTarget) {
-      addAttachments(localPaths);
-      return '';
-    }
+    if (!remoteTarget) return localPaths.map(posixQuote).join(' ');
     const uploaded: string[] = [];
     for (const localPath of localPaths) {
       const result = await window.cc.fs.uploadToRemote(remoteTarget.id, localPath, '.');
@@ -1098,8 +1091,7 @@ export const AgentLauncher = memo(function AgentLauncher({
       uploaded.push(result.path);
       pushToast(`Uploaded ${localPath.split('/').pop()} to ${remoteTarget.remote.host}`);
     }
-    addAttachments(uploaded);
-    return '';
+    return uploaded.map(posixQuote).join(' ');
   };
   // Renderer eligibility is advisory. Main still verifies Git state and confines
   // the worktree before changing cwd.
@@ -1394,9 +1386,6 @@ export const AgentLauncher = memo(function AgentLauncher({
     applyAdvanced: boolean
   ) => {
     if (!target) return;
-    const attachmentContext = attachments.length
-      ? `\n\nAttached files:\n${attachments.map((path) => `- ${path}`).join('\n')}`
-      : '';
     const chosenPersonaId = applyAdvanced && advanced ? personaId ?? undefined : undefined;
     const chosenFrameworkIds =
       applyAdvanced && advanced && !chosenPersonaId && frameworkIds.length > 0
@@ -1415,7 +1404,7 @@ export const AgentLauncher = memo(function AgentLauncher({
         : opts.extraArgs;
     const session = await createTerminal(target.id, profile, 80, 24, {
       extraArgs: chosenExtraArgs,
-      prompt: opts.prompt ? `${opts.prompt}${attachmentContext}` : attachmentContext || undefined,
+      prompt: opts.prompt,
       harnessRouting: family
         ? agentRoutingForSubmission(profileChosen, family.id, portableRouting, nativeRouting, agentRoutingDirty)
         : undefined,
@@ -1669,7 +1658,7 @@ export const AgentLauncher = memo(function AgentLauncher({
       >
         <div className="launch-panel">
           <div className="launch-header">
-            <h3 id="agent-launcher-title">{projectMode ? project!.name : scratchIsTarget ? 'Quick agent' : target?.name ?? 'New agent'}</h3>
+            <h3>{projectMode ? project!.name : scratchIsTarget ? 'Quick agent' : target?.name ?? 'New agent'}</h3>
             <p>
               {projectMode
                 ? 'Start a session'
@@ -1722,99 +1711,6 @@ export const AgentLauncher = memo(function AgentLauncher({
             mentionProjectPath={project?.path}
             dropResolver={remoteDropResolver}
             onDropResolvingChange={setDropResolving}
-            attachments={attachments}
-            onRemoveAttachment={(path) => setAttachments((current) => current.filter((item) => item !== path))}
-            onAddAttachments={addAttachments}
-            submitDisabled={!target || !descriptor || !configLoaded || !worktreeDefaultLoaded || personaProfileConflict || launching || dropResolving}
-            toolbarControls={
-              <>
-                {!projectMode && (
-                  <label className="home-agent-select launch-toolbar-project">
-                    <FolderGit2 size={15} aria-hidden="true" />
-                    <select
-                      value={targetProjectId ?? ''}
-                      onChange={(e) => setTargetProjectId(e.target.value || null)}
-                      aria-label="Target project"
-                    >
-                      <option value="">Quick workspace (scratch)</option>
-                      {projectGroups.favorites.length > 0 && (
-                        <optgroup label="Favorites">
-                          {projectGroups.favorites.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
-                        </optgroup>
-                      )}
-                      {projectGroups.remote.length > 0 && (
-                        <optgroup label="Remote">
-                          {projectGroups.remote.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
-                        </optgroup>
-                      )}
-                      {projectGroups.local.length > 0 && (
-                        <optgroup label="Local">
-                          {projectGroups.local.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
-                        </optgroup>
-                      )}
-                    </select>
-                    <ChevronDown size={14} aria-hidden="true" />
-                  </label>
-                )}
-                {mode === 'agent' && (
-                  <label className="home-agent-select">
-                    <select
-                      value={profileChosen ? family?.id ?? '' : ''}
-                      onChange={(e) => {
-                        const next = e.target.value as HarnessFamily;
-                        setFamilyId(next);
-                        setProfileChosen(Boolean(next));
-                      }}
-                      aria-label="Launch harness"
-                      disabled={!configLoaded}
-                    >
-                      <option value="">Use project/global default</option>
-                      {availableFamilies.map((f) => <option key={f.id} value={f.id}>{f.label}</option>)}
-                    </select>
-                    <ChevronDown size={14} aria-hidden="true" />
-                  </label>
-                )}
-                {mode === 'agent' && (
-                  <LauncherModelPicker
-                    id="launch-toolbar-model"
-                    models={selectedHarnessDescriptor?.targets?.models ?? []}
-                    value={(profileChosen ? selectedNativeRouting : portableRouting).modelTargetId ?? ''}
-                    disabled={!selectedHarnessDescriptor?.targets?.models.length}
-                    onChange={(modelTargetId) => {
-                      if (profileChosen && family) updateNativeRouting(family.id, { modelTargetId: modelTargetId || undefined });
-                      else {
-                        setAgentRoutingDirty(true);
-                        setPortableRouting((current) => ({ ...current, modelTargetId: modelTargetId || undefined }));
-                      }
-                    }}
-                  />
-                )}
-              </>
-            }
-            belowControls={mode === 'agent' ? (
-              <div className="launch-segmented" role="group" aria-label="Permission mode">
-                <button
-                  type="button"
-                  data-testid="launch-mode-normal"
-                  className={!yoloActive ? 'active' : ''}
-                  onClick={() => { setYolo(false); setProfileChosen(true); }}
-                  aria-pressed={!yoloActive}
-                >
-                  Normal
-                </button>
-                <button
-                  type="button"
-                  data-testid="launch-mode-yolo"
-                  className={yoloActive ? 'active' : ''}
-                  onClick={() => { setYolo(true); setProfileChosen(true); }}
-                  aria-pressed={yoloActive}
-                  disabled={!family?.yolo}
-                  title={family?.yolo ? 'Launch with permissions bypassed (auto-approve every action)' : `${family?.label ?? 'This harness'} has no permission-bypass mode`}
-                >
-                  <Zap size={13} /> Yolo
-                </button>
-              </div>
-            ) : undefined}
             onSubmit={mode === 'autonomous' ? launchAutonomous : launch}
             placeholder={
               mode === 'autonomous'
@@ -1891,8 +1787,8 @@ export const AgentLauncher = memo(function AgentLauncher({
             />
           )}
 
-          {false && !projectMode && (
-            <div className="launch-row launch-toolbar-duplicate" aria-hidden="true">
+          {!projectMode && (
+            <div className="launch-row">
               <span className="launch-row-label">Project</span>
               <div className="launch-folder">
                 <Folder size={13} aria-hidden="true" />
@@ -1964,8 +1860,8 @@ export const AgentLauncher = memo(function AgentLauncher({
             </div>
           )}
 
-          {false && mode === 'agent' && (
-            <div className="launch-row launch-toolbar-duplicate" aria-hidden="true">
+          {mode === 'agent' && (
+            <div className="launch-row">
               <span className="launch-row-label">Harness</span>
               {!configLoaded ? (
                 <span className="launch-squad-hint" role="status">Loading harness default…</span>
@@ -2053,8 +1949,8 @@ export const AgentLauncher = memo(function AgentLauncher({
             )
           )}
 
-          {false && mode === 'agent' && (
-            <div className="launch-row launch-toolbar-duplicate">
+          {mode === 'agent' && (
+            <div className="launch-row">
               <span className="launch-row-label">Mode</span>
               <div className="launch-segmented" role="group" aria-label="Permission mode">
                 <button
@@ -2436,14 +2332,26 @@ export const AgentLauncher = memo(function AgentLauncher({
               <button
                 className="btn primary"
                 onClick={launchAutonomous}
-                  disabled={!teamId || !prompt.trim() || !target || launching || dropResolving}
+                disabled={!teamId || !prompt.trim() || !target || launching || dropResolving}
                 aria-describedby={launchStatusA11y.describedBy}
                 title="Launch autonomous team (⌘↵)"
               >
                 <Zap size={14} />
                 Launch autonomous team
               </button>
-            ) : null}
+            ) : (
+              <button
+                data-testid="launch-send"
+                className="btn primary"
+                onClick={launch}
+                disabled={!target || !descriptor || !configLoaded || !worktreeDefaultLoaded || personaProfileConflict || launching || dropResolving}
+                aria-describedby={launchStatusA11y.describedBy}
+                title="Send (⌘↵)"
+              >
+                <TerminalIcon size={14} />
+                Send
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/renderer/components/HomeAgentComposer.tsx
+++ b/src/renderer/components/HomeAgentComposer.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { ArrowUp, Check, ChevronDown, FolderGit2, Paperclip, Search, Server } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowUp, FolderGit2, Paperclip, Server } from 'lucide-react';
 import type { HarnessAdapterDescriptor, HarnessModelTarget } from '@shared/harness-adapter';
 import type { EffectiveHarnessDefaultResult, HarnessFamily, HarnessModelRoutingV1, LaunchProfileId, Project } from '@shared/types';
 import { buildLaunchArgs } from './AgentLauncher';
 import { LauncherModelPicker } from './LauncherModelPicker';
+import { PopoverPicklist } from './ui/PopoverPicklist';
 import {
   AutoGrowTextarea,
   CommandComposer,
@@ -278,9 +278,33 @@ export function HomeAgentComposer() {
           </ComposerIconButton>
           <div className="home-agent-select home-agent-project-picker">
             <FolderGit2 size={15} aria-hidden="true" />
-            <HomeProjectPicker
-              projects={launchProjects}
+            <PopoverPicklist
+              ariaLabel="Project"
               value={projectId}
+              placeholder="Choose project"
+              searchPlaceholder="Search projects"
+              emptyHint="No matching projects"
+              triggerClassName="home-agent-project-picker-trigger"
+              minWidth={360}
+              anchorToParent
+              options={launchProjects.map((candidate) => ({
+                value: candidate.id,
+                label: projectLabel(candidate),
+                className: 'home-agent-project-option',
+                content: (
+                  <span className="home-agent-project-option-details">
+                    {candidate.remote ? <Server size={15} aria-hidden="true" /> : <FolderGit2 size={15} aria-hidden="true" />}
+                    <span>
+                      <span className="home-agent-project-option-name">{projectLabel(candidate)}</span>
+                      {candidate.remote && (
+                        <span className="home-agent-project-option-meta">
+                          remote · {candidate.remote.user ? `${candidate.remote.user}@` : ''}{candidate.remote.host}
+                        </span>
+                      )}
+                    </span>
+                  </span>
+                )
+              }))}
               onChange={(nextProjectId) => {
                 selectionGeneration.current += 1;
                 setResolvedProjectId(null);
@@ -293,34 +317,30 @@ export function HomeAgentComposer() {
             />
           </div>
 
-          <label className="home-agent-select">
-            <select
-              aria-label="Agent harness"
-              value={familyId}
-              onChange={(event) => {
-                selectionGeneration.current += 1;
-                setFamilyId(event.target.value as HarnessFamily);
-                setAutomaticProfile(null);
-                setModelId('');
-                setSelectionProvenance('explicit');
-                setSelectionState('resolved');
-                setResolvedProjectId(projectId);
-                setSelectionMessage(null);
-              }}
-              disabled={harnesses.length === 0}
-            >
-              {!familyId && (
-                <option value="" disabled>
-                  {selectionState === 'unavailable' ? 'Choose an available harness' : 'Resolving default harness'}
-                </option>
-              )}
-              {harnesses.length === 0 && <option value="">No agent harness available</option>}
-              {harnesses.map((descriptor) => (
-                <option key={descriptor.id} value={descriptor.id}>{descriptor.label}</option>
-              ))}
-            </select>
-            <ChevronDown size={14} aria-hidden="true" />
-          </label>
+          <PopoverPicklist
+            ariaLabel="Agent harness"
+            value={familyId}
+            disabled={harnesses.length === 0}
+            searchable={false}
+            placeholder={
+              harnesses.length === 0
+                ? 'No agent harness available'
+                : selectionState === 'unavailable'
+                  ? 'Choose an available harness'
+                  : 'Resolving default harness'
+            }
+            options={harnesses.map((descriptor) => ({ value: descriptor.id, label: descriptor.label }))}
+            onChange={(nextFamilyId) => {
+              selectionGeneration.current += 1;
+              setFamilyId(nextFamilyId as HarnessFamily);
+              setAutomaticProfile(null);
+              setModelId('');
+              setSelectionProvenance('explicit');
+              setSelectionState('resolved');
+              setResolvedProjectId(projectId);
+              setSelectionMessage(null);
+            }}
+          />
 
           {selectionState === 'unavailable' && (
             <span className="home-agent-launch-status" role="status">{selectionMessage}</span>
@@ -357,114 +377,4 @@ const EMPTY_MODELS: readonly HarnessModelTarget[] = [];
 
 function projectLabel(project: Project): string {
   return project.quickAgent ? 'Quick workspace (scratch)' : project.name;
-}
-
-function HomeProjectPicker({
-  projects,
-  value,
-  onChange
-}: {
-  projects: readonly Project[];
-  value: string;
-  onChange: (value: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState('');
-  const [position, setPosition] = useState<{ left: number; top: number; width: number } | null>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const searchRef = useRef<HTMLInputElement>(null);
-  const selected = projects.find((project) => project.id === value);
-  const visibleProjects = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
-    return normalizedQuery
-      ? projects.filter((project) => projectLabel(project).toLowerCase().includes(normalizedQuery))
-      : projects;
-  }, [projects, query]);
-
-  useLayoutEffect(() => {
-    if (!open || !triggerRef.current) return;
-    // Anchor to the whole project control, including its folder icon, rather
-    // than the text-only button so the popover's left edge aligns with the field.
-    const rect = triggerRef.current.parentElement?.getBoundingClientRect() ?? triggerRef.current.getBoundingClientRect();
-    setPosition({ left: rect.left, top: rect.bottom + 4, width: Math.max(rect.width, 360) });
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const close = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    document.addEventListener('mousedown', close);
-    return () => document.removeEventListener('mousedown', close);
-  }, [open]);
-
-  useEffect(() => {
-    if (open) searchRef.current?.focus();
-    else setQuery('');
-  }, [open]);
-
-  return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className="home-agent-project-picker-trigger"
-        onClick={() => setOpen((current) => !current)}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-label="Project"
-      >
-        <span>{selected ? projectLabel(selected) : 'Choose project'}</span>
-        <ChevronDown size={14} aria-hidden="true" />
-      </button>
-      {open && createPortal(
-        <div
-          ref={menuRef}
-          className="launch-model-picker-menu"
-          role="listbox"
-          aria-label="Project"
-          style={position ? { left: position.left, top: position.top, width: position.width } : { visibility: 'hidden' }}
-        >
-          <div className="launch-model-picker-search">
-            <Search size={13} aria-hidden="true" />
-            <input
-              ref={searchRef}
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search projects"
-              aria-label="Search projects"
-            />
-          </div>
-          {visibleProjects.map((project) => (
-            <button
-              key={project.id}
-              type="button"
-              className={`launch-model-picker-option home-agent-project-option${value === project.id ? ' is-selected' : ''}`}
-              role="option"
-              aria-selected={value === project.id}
-              onClick={() => { onChange(project.id); setOpen(false); }}
-            >
-              <span className="home-agent-project-option-details">
-                {project.remote ? <Server size={15} aria-hidden="true" /> : <FolderGit2 size={15} aria-hidden="true" />}
-                <span>
-                  <span className="home-agent-project-option-name">{projectLabel(project)}</span>
-                  {project.remote && (
-                    <span className="home-agent-project-option-meta">
-                      remote · {project.remote.user ? `${project.remote.user}@` : ''}{project.remote.host}
-                    </span>
-                  )}
-                </span>
-              </span>
-              {value === project.id && <Check size={14} aria-hidden="true" />}
-            </button>
-          ))}
-          {visibleProjects.length === 0 && <div className="launch-model-picker-hint">No matching projects</div>}
-        </div>,
-        document.body
-      )}
-    </>
-  );
 }

--- a/src/renderer/components/LauncherModelPicker.tsx
+++ b/src/renderer/components/LauncherModelPicker.tsx
@@ -87,7 +87,7 @@ export function LauncherModelPicker({
         aria-haspopup="listbox"
         aria-expanded={open}
       >
-        <span>{selected?.label ?? 'Use project/global default'}</span>
+        <span>{selected?.label ?? 'Default Model'}</span>
         <ChevronDown size={15} aria-hidden="true" />
       </button>
       {open && createPortal(
@@ -115,7 +115,7 @@ export function LauncherModelPicker({
             aria-selected={!value}
             onClick={() => { onChange(''); setOpen(false); }}
           >
-            <span>Use project/global default</span>
+            <span>Default Model</span>
             {!value && <Check size={14} aria-hidden="true" />}
           </button>
           {visibleModels.map((model) => (

--- a/src/renderer/components/PromptComposer.tsx
+++ b/src/renderer/components/PromptComposer.tsx
@@ -14,15 +14,7 @@ import { highlightMatches } from './palette/highlight';
 import { ImprovePromptButton } from './ImprovePromptButton';
 import { VoiceInputButton } from './VoiceInputButton';
 import type { WalkedFile } from '@shared/types';
-import { AttachmentPills } from './ui/AttachmentPills';
-import {
-  AutoGrowTextarea,
-  type AutoGrowTextareaHandle,
-  CommandComposer,
-  ComposerIconButton,
-  ComposerToolbar
-} from './ui/CommandComposer';
-import { ArrowUp, Paperclip } from 'lucide-react';
+import type { AutoGrowTextareaHandle } from './ui/CommandComposer';
 
 /**
  * The agent-instruction box, shared by every launcher that takes a typed prompt
@@ -57,12 +49,6 @@ interface Props {
   dropResolver?: DropPathResolver;
   /** Reports whether an asynchronous dropped-path transform is in flight. */
   onDropResolvingChange?: (resolving: boolean) => void;
-  attachments?: readonly string[];
-  onRemoveAttachment?: (path: string) => void;
-  onAddAttachments?: (paths: string[]) => void;
-  submitDisabled?: boolean;
-  toolbarControls?: React.ReactNode;
-  belowControls?: React.ReactNode;
 }
 
 /** Most files to rank/show in the `@`-mention popover at once. */
@@ -83,7 +69,7 @@ interface Ranked {
 function useMention(
   value: string,
   onChange: (v: string) => void,
-  textareaRef: React.RefObject<AutoGrowTextareaHandle>,
+  textareaRef: React.RefObject<HTMLTextAreaElement>,
   projectPath: string | undefined
 ) {
   const [mention, setMention] = useState<MentionMatch | null>(null);
@@ -94,7 +80,7 @@ function useMention(
 
   // Recompute the mention token from the live caret position.
   const refresh = useCallback(() => {
-    const el = textareaRef.current?.element();
+    const el = textareaRef.current;
     if (!el || !projectPath) {
       setMention(null);
       return;
@@ -145,7 +131,7 @@ function useMention(
 
   const choose = useCallback(
     (file: WalkedFile) => {
-      const el = textareaRef.current?.element();
+      const el = textareaRef.current;
       if (!el || !mention) return;
       const caret = el.selectionStart ?? el.value.length;
       const out = applyMention(value, mention, caret, file.rel);
@@ -194,18 +180,16 @@ function useMention(
 }
 
 export const PromptComposer = forwardRef<PromptComposerHandle, Props>(function PromptComposer(
-  {
-    value, onChange, onSubmit, placeholder, rows = 3, mentionProjectPath, dropResolver,
-    onDropResolvingChange, attachments = [], onRemoveAttachment, onAddAttachments, submitDisabled = false,
-    toolbarControls, belowControls
-  },
+  { value, onChange, onSubmit, placeholder, rows = 3, mentionProjectPath, dropResolver, onDropResolvingChange },
   ref
 ) {
-  const textareaRef = useRef<AutoGrowTextareaHandle>(null);
+  const nativeTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const textareaRef = useRef<AutoGrowTextareaHandle | null>(null);
+  const textElement = () => nativeTextareaRef.current;
   const voiceInputEnabled = useData((s) => s.voiceInputEnabled);
-  useImperativeHandle(ref, () => ({ focus: () => textareaRef.current?.focus() }), []);
+  useImperativeHandle(ref, () => ({ focus: () => textElement()?.focus() }), []);
 
-  const mention = useMention(value, onChange, textareaRef, mentionProjectPath);
+  const mention = useMention(value, onChange, nativeTextareaRef, mentionProjectPath);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (mention.onKeyDown(e)) return; // popover consumed the key
@@ -218,7 +202,7 @@ export const PromptComposer = forwardRef<PromptComposerHandle, Props>(function P
   // Splice the dropped path(s) in at the caret, padding with a single space so
   // they don't fuse onto adjacent words; restore the caret just past the insert.
   const { dropOver, resolving, dropHandlers } = useFileDrop((insert) => {
-    const el = textareaRef.current?.element();
+    const el = textElement();
     const start = el?.selectionStart ?? value.length;
     const end = el?.selectionEnd ?? value.length;
     const before = value.slice(0, start);
@@ -236,75 +220,61 @@ export const PromptComposer = forwardRef<PromptComposerHandle, Props>(function P
   useEffect(() => onDropResolvingChange?.(resolving), [onDropResolvingChange, resolving]);
 
   return (
-    <>
-      <CommandComposer
-        className={`launch-command${dropOver ? ' is-drop-over' : ''}`}
-        labelledBy="agent-launcher-title"
+    <div className="prompt-composer">
+      <textarea
+        ref={(node) => {
+          nativeTextareaRef.current = node;
+          textareaRef.current = node ? { focus: () => node.focus(), element: () => node } : null;
+        }}
+        data-testid="launch-instruction"
+        className={`launch-instruction ${dropOver ? 'drop-over' : ''}`}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          mention.refresh();
+        }}
+        onKeyUp={mention.refresh}
+        onClick={mention.refresh}
+        onBlur={() => {
+          // Close on blur — but a row's mousedown (which preventDefaults, so the
+          // textarea keeps focus) fires its choose() first, so a genuine click
+          // still lands. A short delay guards against focus-shuffle races.
+          window.setTimeout(mention.close, 120);
+        }}
+        onKeyDown={onKeyDown}
         {...dropHandlers}
-      >
-        <AttachmentPills paths={attachments} onRemove={(path) => onRemoveAttachment?.(path)} />
-        <AutoGrowTextarea
-          ref={textareaRef}
-          data-testid="launch-instruction"
-          className="launch-instruction"
-          placeholder={placeholder}
-          value={value}
-          onChange={(e) => {
-            onChange(e.target.value);
-            mention.refresh();
-          }}
-          onKeyUp={mention.refresh}
-          onClick={mention.refresh}
-          onBlur={() => window.setTimeout(mention.close, 120)}
-          onKeyDown={onKeyDown}
-          rows={rows}
-        />
-        {mention.open && (
-          <div className="mention-popover" role="listbox" aria-label="Insert file">
-            {mention.ranked.map((r, i) => (
-              <button
-                type="button"
-                key={r.file.rel}
-                role="option"
-                aria-selected={i === mention.active}
-                className={`palette-item mention-item ${i === mention.active ? 'active' : ''}`}
-                onMouseDown={(e) => { e.preventDefault(); mention.choose(r.file); }}
-                onMouseEnter={() => mention.setActive(i)}
-              >
-                {highlightMatches(r.file.rel, r.matchIdx)}
-              </button>
-            ))}
-          </div>
-        )}
-        <ComposerToolbar>
-          {onAddAttachments && (
-            <ComposerIconButton
-              onClick={() => { void window.cc.fs.pickFiles().then(onAddAttachments); }}
-              title="Attach files"
-              aria-label="Attach files"
+        rows={rows}
+      />
+      {mention.open && (
+        <div className="mention-popover" role="listbox" aria-label="Insert file">
+          {mention.ranked.map((r, i) => (
+            <button
+              type="button"
+              key={r.file.rel}
+              role="option"
+              aria-selected={i === mention.active}
+              className={`palette-item mention-item ${i === mention.active ? 'active' : ''}`}
+              // mousedown (not click) so it fires before the textarea's blur.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                mention.choose(r.file);
+              }}
+              onMouseEnter={() => mention.setActive(i)}
             >
-              <Paperclip size={16} aria-hidden="true" />
-            </ComposerIconButton>
-          )}
-          {toolbarControls}
-          {voiceInputEnabled ? (
-            <VoiceInputButton value={value} onChange={onChange} textareaRef={textareaRef} iconOnly />
-          ) : <span />}
-          <ComposerIconButton
-            className="home-agent-launch"
-            onClick={onSubmit}
-            disabled={submitDisabled}
-            aria-label="Launch agent"
-            title="Launch agent (⌘↵)"
-          >
-            <ArrowUp size={17} aria-hidden="true" />
-          </ComposerIconButton>
-        </ComposerToolbar>
-      </CommandComposer>
+              {highlightMatches(r.file.rel, r.matchIdx)}
+            </button>
+          ))}
+        </div>
+      )}
       <div className="prompt-composer-actions">
-        <span>{belowControls}</span>
+        {voiceInputEnabled ? (
+          <VoiceInputButton value={value} onChange={onChange} textareaRef={textareaRef} />
+        ) : (
+          <span />
+        )}
         <ImprovePromptButton value={value} onChange={onChange} />
       </div>
-    </>
+    </div>
   );
 });

--- a/src/renderer/components/ui/PopoverPicklist.tsx
+++ b/src/renderer/components/ui/PopoverPicklist.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, ChevronDown, Search } from 'lucide-react';
+import { useExclusivePopover } from '../../util/useExclusivePopover';
+
+export interface PopoverPicklistOption<T extends string> {
+  value: T;
+  /** Plain text used for the trigger, search matching, and the default option row. */
+  label: string;
+  /** Optional richer option-row rendering (icon, meta line, ...); falls back to `label`. */
+  content?: ReactNode;
+  /** Extra class on this option's row, e.g. for a taller/richer layout. */
+  className?: string;
+  /** Renders a group header above the first option of a new group, in list order. */
+  group?: string;
+}
+
+export interface PopoverPicklistProps<T extends string> {
+  id?: string;
+  ariaLabel: string;
+  value: T | '';
+  options: readonly PopoverPicklistOption<T>[];
+  onChange: (value: T) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  emptyHint?: string;
+  className?: string;
+  /** Class on the trigger button; defaults to the bordered field look. */
+  triggerClassName?: string;
+  /** Minimum popover width in px; defaults to 200. */
+  minWidth?: number;
+  /**
+   * Anchor the popover to the trigger's parent element instead of the
+   * trigger itself — for a compound field (e.g. a leading icon beside the
+   * trigger) where the popover's left edge should align with the whole field.
+   */
+  anchorToParent?: boolean;
+}
+
+/**
+ * Generic single-select popover: a trigger button + a portal-rendered,
+ * optionally searchable options menu. Generalizes the popover pattern the
+ * project and model pickers each hand-rolled, so a new dropdown doesn't fall
+ * back to a plain native `<select>`. Reuses the `launch-model-picker-*` CSS
+ * classes those pickers already share.
+ */
+export function PopoverPicklist<T extends string>({
+  id,
+  ariaLabel,
+  value,
+  options,
+  onChange,
+  placeholder = 'Select…',
+  disabled,
+  searchable = true,
+  searchPlaceholder = 'Search…',
+  emptyHint = 'No matches',
+  className = '',
+  triggerClassName = 'launch-model-picker-trigger',
+  minWidth = 200,
+  anchorToParent = false
+}: PopoverPicklistProps<T>) {
+  const [open, setOpen] = useExclusivePopover();
+  const [query, setQuery] = useState('');
+  const [position, setPosition] = useState<{ left: number; top: number; width: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const wasOpenRef = useRef(false);
+  const selected = options.find((option) => option.value === value);
+  const visibleOptions = useMemo(() => {
+    if (!searchable) return options;
+    const normalizedQuery = query.trim().toLowerCase();
+    return normalizedQuery
+      ? options.filter((option) => option.label.toLowerCase().includes(normalizedQuery))
+      : options;
+  }, [options, query, searchable]);
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const rect = anchorToParent
+      ? triggerRef.current.parentElement?.getBoundingClientRect() ?? triggerRef.current.getBoundingClientRect()
+      : triggerRef.current.getBoundingClientRect();
+    setPosition({ left: rect.left, top: rect.bottom + 4, width: Math.max(rect.width, minWidth) });
+  }, [open, anchorToParent, minWidth]);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    // Capture phase: a modal dialog (e.g. the New Agent launcher) stops
+    // mousedown propagation on its own container to keep clicks inside it from
+    // bubbling to a backdrop's close-on-click-outside handler. That stopPropagation
+    // runs during the bubble phase, so a bubble-phase document listener here would
+    // never see clicks made inside that modal. Capture fires top-down BEFORE bubble,
+    // so it can't be blocked by a descendant's later stopPropagation call.
+    document.addEventListener('mousedown', close, true);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', close, true);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      if (searchable) searchRef.current?.focus();
+    } else {
+      setQuery('');
+      if (wasOpenRef.current) triggerRef.current?.focus();
+    }
+    wasOpenRef.current = open;
+  }, [open, searchable]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        id={id}
+        type="button"
+        className={`${triggerClassName} ${className}`}
+        disabled={disabled}
+        onClick={() => setOpen((current) => !current)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+      >
+        <span>{selected?.label ?? placeholder}</span>
+        <ChevronDown size={14} aria-hidden="true" />
+      </button>
+      {open && createPortal(
+        <div
+          ref={menuRef}
+          className="launch-model-picker-menu"
+          role="listbox"
+          aria-label={ariaLabel}
+          style={position ? { left: position.left, top: position.top, width: position.width } : { visibility: 'hidden' }}
+        >
+          {searchable && (
+            <div className="launch-model-picker-search">
+              <Search size={13} aria-hidden="true" />
+              <input
+                ref={searchRef}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={searchPlaceholder}
+                aria-label={searchPlaceholder}
+              />
+            </div>
+          )}
+          {visibleOptions.map((option, index) => (
+            <div key={option.value}>
+              {option.group && option.group !== visibleOptions[index - 1]?.group && (
+                <div className="launch-model-picker-group-label">{option.group}</div>
+              )}
+              <button
+                type="button"
+                className={`launch-model-picker-option${option.className ? ` ${option.className}` : ''}${value === option.value ? ' is-selected' : ''}`}
+                role="option"
+                aria-selected={value === option.value}
+                onClick={() => { onChange(option.value); setOpen(false); }}
+              >
+                {option.content ?? <span>{option.label}</span>}
+                {value === option.value && <Check size={14} aria-hidden="true" />}
+              </button>
+            </div>
+          ))}
+          {visibleOptions.length === 0 && <div className="launch-model-picker-hint">{emptyHint}</div>}
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -18782,6 +18782,14 @@ button.zana-assign-trigger.is-unassigned .zana-assign-caret {
   text-align: center;
 }
 
+.launch-model-picker-group-label {
+  padding: 7px 9px 3px;
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .launch-extra-args .settings-field {
   display: grid;
   grid-template-columns: 84px minmax(0, 1fr);

--- a/src/renderer/util/useExclusivePopover.ts
+++ b/src/renderer/util/useExclusivePopover.ts
@@ -1,0 +1,52 @@
+import { useRef, useSyncExternalStore } from 'react';
+
+type Listener = () => void;
+
+let activeId: symbol | null = null;
+const listeners = new Set<Listener>();
+
+function emit() {
+  listeners.forEach((listener) => listener());
+}
+
+function open(id: symbol) {
+  if (activeId === id) return;
+  activeId = id;
+  emit();
+}
+
+function close(id: symbol) {
+  if (activeId !== id) return;
+  activeId = null;
+  emit();
+}
+
+function isOpen(id: symbol) {
+  return activeId === id;
+}
+
+function subscribe(listener: Listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * Drop-in replacement for `useState(false)` on a popover's open flag, except
+ * only one such popover can be open across the whole app at a time — opening
+ * one closes any other (harness/model/project pickers all share this, so they
+ * no longer stack on screen simultaneously, see the composer toolbar).
+ */
+export function useExclusivePopover(): readonly [boolean, (next: boolean | ((current: boolean) => boolean)) => void] {
+  const idRef = useRef<symbol | null>(null);
+  if (!idRef.current) idRef.current = Symbol('popover');
+  const id = idRef.current;
+  const isCurrentlyOpen = useSyncExternalStore(subscribe, () => isOpen(id));
+
+  const setOpen = (next: boolean | ((current: boolean) => boolean)) => {
+    const resolved = typeof next === 'function' ? next(isOpen(id)) : next;
+    if (resolved) open(id);
+    else close(id);
+  };
+
+  return [isCurrentlyOpen, setOpen] as const;
+}


### PR DESCRIPTION
## Summary\n- restore the New Agent / Quick Agent modal layout while preserving remote drag-and-drop upload handling\n- replace Home page project and harness selects with the shared searchable popover picker\n- rename the model fallback to Default Model\n\n## Verification\n- npm run typecheck\n- npx vitest run src/renderer/components/__tests__/AgentLauncher.test.tsx src/renderer/components/__tests__/HomeAgentComposer.test.ts src/renderer/components/__tests__/LauncherModelPicker.test.ts\n- git diff --check