### PR TITLE
chore: add repository code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
+#ECCN:Open Source
+#GUSINFO:Agent Editors,GUS_Product_tag
+@geoffrey-baker-sf
+@grebmann1


### PR DESCRIPTION
## Summary
- add the standard Salesforce CODEOWNERS metadata file
- declare the Agent Editors GUS team and repository owners

## Validation
- git diff --check
- pre-push typecheck