### PR TITLE
fix(scheduler): stamp exit-0 runs "incomplete" when no schedule_report was filed

### DIFF
--- a/src/main/__tests__/scheduler.test.ts
+++ b/src/main/__tests__/scheduler.test.ts
@@ -548,6 +548,74 @@ describe('SchedulerManager.attachReport', () => {
   });
 });
 
+describe('SchedulerManager — incomplete (exit-0 with no schedule_report)', () => {
+  // Regression for the reported bug: a severed stream (Zscaler SSE idle-drop,
+  // etc.) can still leave the CLI exiting 0 after the agent never reached its
+  // work — indistinguishable from a real success by exit code alone. A
+  // report-capable, non-silent schedule that exits 0 without ever filing a
+  // `schedule_report` must be stamped `incomplete`, not `success`.
+  const runsOf = (manager: SchedulerManager, id: string) =>
+    manager.list().find((t) => t.id === id)!.status.runs;
+
+  it('stamps a claude run "incomplete" when exit-0 arrives with no report filed', () => {
+    const { manager, ptys, task } = makeManager({ prompt: 'work' }); // profile: claude, inboxLevel default 'quiet'
+    autoFire(manager, task.id);
+    const sid = ptys.sessions[0].id;
+
+    ptys.simulateExit(sid, 0); // no schedule_report ever called
+
+    const run = runsOf(manager, task.id).find((r) => r.sessionId === sid)!;
+    expect(run.result).toBe('incomplete');
+    expect(run.message).toMatch(/schedule_report/);
+    expect(manager.list().find((t) => t.id === task.id)!.status.lastRunResult).toBe('incomplete');
+  });
+
+  it('still reports "success" when the report was filed before exit', () => {
+    const { manager, ptys, task } = makeManager({ prompt: 'work' });
+    autoFire(manager, task.id);
+    const sid = ptys.sessions[0].id;
+
+    manager.attachReport(sid, 'all good', 'success');
+    ptys.simulateExit(sid, 0);
+
+    const run = runsOf(manager, task.id).find((r) => r.sessionId === sid)!;
+    expect(run.result).toBe('success');
+  });
+
+  it('does not flag "incomplete" on a `silent` schedule (nothing reads its report)', () => {
+    const { manager, ptys, task } = makeManager({ prompt: 'work', inboxLevel: 'silent' });
+    autoFire(manager, task.id);
+    const sid = ptys.sessions[0].id;
+
+    ptys.simulateExit(sid, 0);
+
+    const run = runsOf(manager, task.id).find((r) => r.sessionId === sid)!;
+    expect(run.result).toBe('success');
+  });
+
+  it('does not flag "incomplete" on a profile that can\'t file a report (e.g. cursor)', () => {
+    const { manager, ptys, task } = makeManager({ profile: 'cursor', prompt: 'work' });
+    autoFire(manager, task.id);
+    const sid = ptys.sessions[0].id;
+
+    ptys.simulateExit(sid, 0);
+
+    const run = runsOf(manager, task.id).find((r) => r.sessionId === sid)!;
+    expect(run.result).toBe('success');
+  });
+
+  it('a non-zero exit still records "error", never "incomplete"', () => {
+    const { manager, ptys, task } = makeManager({ prompt: 'work' });
+    autoFire(manager, task.id);
+    const sid = ptys.sessions[0].id;
+
+    ptys.simulateExit(sid, 1);
+
+    const run = runsOf(manager, task.id).find((r) => r.sessionId === sid)!;
+    expect(run.result).toBe('error');
+  });
+});
+
 describe('SchedulerManager.recordRun — eviction of a long-lived run', () => {
   const statusOf = (manager: SchedulerManager, id: string) =>
     manager.list().find((t) => t.id === id)!.status;
@@ -634,6 +702,7 @@ describe('SchedulerManager.onAgentFinished', () => {
     const sid = ptys.sessions[0].id;
 
     manager.onAgentFinished(sid); // turn ends, pty still alive
+    manager.attachReport(sid, 'done'); // filed its report, as expected
     ptys.simulateExit(sid, 0); // later the pty actually exits
 
     const run = runsOf(manager, task.id).find((r) => r.sessionId === sid)!;

--- a/src/main/scheduler-store.ts
+++ b/src/main/scheduler-store.ts
@@ -106,7 +106,8 @@ export function validateScheduleFile(raw: unknown): ScheduledTask | { error: str
               ? (r.status as { lastRunAt: string }).lastRunAt
               : undefined,
             lastRunResult:
-              (r.status as { lastRunResult?: 'success' | 'error' | 'skipped' }).lastRunResult,
+              (r.status as { lastRunResult?: 'success' | 'error' | 'skipped' | 'incomplete' })
+                .lastRunResult,
             lastRunSessionId:
               typeof (r.status as { lastRunSessionId?: unknown }).lastRunSessionId === 'string'
                 ? (r.status as { lastRunSessionId: string }).lastRunSessionId

--- a/src/main/scheduler.ts
+++ b/src/main/scheduler.ts
@@ -785,20 +785,47 @@ export class SchedulerManager extends EventEmitter {
         this.nonHookWatchdogs.delete(session.id);
       }
       const exitMs = Date.now();
+
+      // Exit code 0 alone doesn't mean the run actually completed: a severed
+      // stream (e.g. the known Zscaler SSE idle-drop) can still leave the CLI
+      // exiting 0 after the agent never reached its work. `schedule_report` is
+      // the run's own signal that it got to the end, so for a report-capable
+      // profile (only `claude` currently wires the `schedule_report` MCP tool —
+      // `injectsClaudeMcpConfig`) on a non-`silent` schedule, an exit-0 run that
+      // never filed one is stamped `incomplete` rather than `success` — silence
+      // must never look like success. `silent` schedules are exempt: nothing
+      // reads their report either way.
+      const expectsReport =
+        (live.task.inboxLevel ?? 'quiet') !== 'silent' &&
+        providerCapabilities(effectiveProfile).injectsClaudeMcpConfig;
+      const existingRun = live.task.status.runs.find(
+        (r) => r.id === runId || r.sessionId === session.id
+      );
+      const hasReport = !!existingRun?.report || !!existingRun?.reportStatus;
+      const result: ScheduleRun['result'] =
+        exitCode !== 0 ? 'error' : expectsReport && !hasReport ? 'incomplete' : 'success';
+
       const finalRun: ScheduleRun = {
         id: runId,
         at: runStartedAt,
-        result: exitCode === 0 ? 'success' : 'error',
+        result,
         sessionId: session.id,
         durationMs: exitMs - runStartMs,
-        message: exitCode === 0 ? undefined : `exit ${exitCode}`
+        message:
+          exitCode !== 0
+            ? `exit ${exitCode}`
+            : result === 'incomplete'
+            ? 'exited without filing a schedule_report — possible silent failure'
+            : undefined
       };
       this.recordRun(id, finalRun);
       // `silent` schedules never write a completion summary; `quiet`/`loud`
       // both write one, stamped with the level so the renderer can decide
-      // badge counting and inline-vs-grouped placement.
+      // badge counting and inline-vs-grouped placement. An `incomplete` run
+      // always escalates the notice to `loud` regardless of the schedule's
+      // configured level, so a quiet schedule's silent failure still surfaces.
       if ((live.task.inboxLevel ?? 'quiet') !== 'silent') {
-        void this.notifyInboxOnExit(live.task, finalRun, project);
+        void this.notifyInboxOnExit(live.task, finalRun, project, result === 'incomplete');
       }
     };
     this.deps?.ptys.on('exit', onExit);
@@ -824,13 +851,15 @@ export class SchedulerManager extends EventEmitter {
   private async notifyInboxOnExit(
     task: ScheduledTask,
     run: ScheduleRun,
-    project: Project
+    project: Project,
+    forceLoud = false
   ) {
     if (!this.deps?.inbox) return;
     try {
       const durationStr =
         run.durationMs !== undefined ? ` in ${formatDuration(run.durationMs)}` : '';
-      const body = `**${task.name}** — ${run.result}${durationStr}`;
+      const resultLabel = run.result === 'incomplete' ? '⚠️ incomplete' : run.result;
+      const body = `**${task.name}** — ${resultLabel}${durationStr}`;
       await this.deps.inbox.append({
         projectId: project.id,
         projectLabel: project.name,
@@ -848,8 +877,10 @@ export class SchedulerManager extends EventEmitter {
         scheduled: true,
         // `loud` schedules count toward the unread badge and render inline;
         // `quiet` (the default) stay collapsed and badge-free. `silent` never
-        // reaches here (gated by the caller).
-        notify: task.inboxLevel ?? 'quiet'
+        // reaches here (gated by the caller). `forceLoud` (an `incomplete`
+        // run) overrides the schedule's own level — a silent failure must
+        // surface even on a `quiet` schedule.
+        notify: forceLoud ? 'loud' : task.inboxLevel ?? 'quiet'
       });
     } catch (err) {
       this.log(`notifyInbox ${task.id}`, err);
@@ -927,7 +958,11 @@ export class SchedulerManager extends EventEmitter {
    * `recordRun` — so the report and the exit-time result are commutative:
    *   - report before exit: merges onto the optimistic run; later onExit spread
    *     (`{...existing, ...finalRun}`) carries no `report`, so it's preserved.
-   *   - report after exit: merges onto the finalized run.
+   *   - report after exit: merges onto the finalized run. If the exit handler
+   *     had already stamped it `incomplete` (no report seen yet), a report
+   *     arriving late is proof the run DID reach its end — just filed a beat
+   *     after the process closed — so it's promoted back to `success` here
+   *     rather than left permanently flagged as a silent failure.
    *
    * Best-effort: if the run was evicted from the ring buffer (extremely
    * unlikely within one run's lifetime), we log and return — the tool still
@@ -946,12 +981,17 @@ export class SchedulerManager extends EventEmitter {
           ? idxFromMap
           : runs.findIndex((r) => r.sessionId === sessionId);
       if (idx < 0) continue;
+      const wasIncomplete = runs[idx].result === 'incomplete';
       runs[idx] = {
         ...runs[idx],
         report: summary,
         reportedAt: new Date().toISOString(),
-        reportStatus: status
+        reportStatus: status,
+        ...(wasIncomplete ? { result: 'success' as const } : {})
       };
+      if (wasIncomplete && live.task.status.lastRunSessionId === sessionId) {
+        live.task.status.lastRunResult = 'success';
+      }
       this.persist(live.task);
       this.emit('changed');
       return;

--- a/src/renderer/components/scheduler/SchedulerOverview.tsx
+++ b/src/renderer/components/scheduler/SchedulerOverview.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   XCircle,
   CircleSlash,
+  AlertTriangle,
   ExternalLink,
   Folder,
   FileText,
@@ -54,7 +55,17 @@ export function SchedulerOverview({
 }: SchedulerOverviewProps) {
   const terminalsByProject = useData((s) => s.terminals);
 
-  const { enabled, disabled, working, finishedOpen, runs24, success24, errors24, skipped24 } = useMemo(() => {
+  const {
+    enabled,
+    disabled,
+    working,
+    finishedOpen,
+    runs24,
+    success24,
+    errors24,
+    skipped24,
+    incomplete24
+  } = useMemo(() => {
     const en = tasks.filter((t) => t.enabled);
     const live = new Set<string>();
     for (const [pid, list] of Object.entries(terminalsByProject)) {
@@ -80,7 +91,7 @@ export function SchedulerOverview({
       }
     }
     const dayAgo = Date.now() - 24 * 3600 * 1000;
-    let r24 = 0, ok = 0, err = 0, skip = 0;
+    let r24 = 0, ok = 0, err = 0, skip = 0, incomplete = 0;
     for (const t of tasks) {
       for (const r of t.status?.runs ?? []) {
         const ts = Date.parse(r.at);
@@ -89,6 +100,10 @@ export function SchedulerOverview({
         if (r.result === 'success') ok++;
         else if (r.result === 'error') err++;
         else if (r.result === 'skipped') skip++;
+        // 'incomplete' = exited 0 but never filed a schedule_report — a silent
+        // failure (dead stream mid-run, etc.). Counted separately from 'error'
+        // so the KPI distinguishes "crashed loudly" from "died quietly".
+        else if (r.result === 'incomplete') incomplete++;
       }
     }
     return {
@@ -99,7 +114,8 @@ export function SchedulerOverview({
       runs24: r24,
       success24: ok,
       errors24: err,
-      skipped24: skip
+      skipped24: skip,
+      incomplete24: incomplete
     };
     // dayAgo and live-session liveness depend on real time; tick keeps them fresh.
   }, [tasks, terminalsByProject, tick]);
@@ -217,8 +233,8 @@ export function SchedulerOverview({
         <KpiCard
           label="Last 24h"
           value={runs24}
-          sub={`${success24} ok · ${errors24} err · ${skipped24} skip`}
-          accent={errors24 > 0 ? 'error' : undefined}
+          sub={`${success24} ok · ${errors24} err · ${incomplete24} incomplete · ${skipped24} skip`}
+          accent={errors24 > 0 || incomplete24 > 0 ? 'error' : undefined}
         />
       </section>
 
@@ -360,6 +376,8 @@ export function SchedulerOverview({
                       <CheckCircle2 size={14} />
                     ) : run.result === 'error' ? (
                       <XCircle size={14} />
+                    ) : run.result === 'incomplete' ? (
+                      <AlertTriangle size={14} />
                     ) : (
                       <CircleSlash size={14} />
                     )}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -12368,6 +12368,7 @@ body.resizing-col .explorer-resizer::after {
 .scheduler-status-value--success { color: var(--success); }
 .scheduler-status-value--error { color: var(--danger); }
 .scheduler-status-value--skipped { color: var(--accent-gold); }
+.scheduler-status-value--incomplete { color: var(--accent-orange, #db6d28); }
 .scheduler-status-value--none { color: var(--text-dim); }
 
 .scheduler-card-actions {
@@ -12826,9 +12827,10 @@ body.resizing-col .explorer-resizer::after {
   justify-self: center;
 }
 
-.scheduler-run-dot--success { background: var(--success); }
-.scheduler-run-dot--error   { background: var(--danger); }
-.scheduler-run-dot--skipped { background: var(--accent-gold); }
+.scheduler-run-dot--success    { background: var(--success); }
+.scheduler-run-dot--error      { background: var(--danger); }
+.scheduler-run-dot--skipped    { background: var(--accent-gold); }
+.scheduler-run-dot--incomplete { background: var(--accent-orange, #db6d28); }
 
 .scheduler-run-when {
   color: var(--text-primary);
@@ -12843,9 +12845,10 @@ body.resizing-col .explorer-resizer::after {
   color: var(--text-dim);
 }
 
-.scheduler-run-row--success .scheduler-run-result { color: var(--success); }
-.scheduler-run-row--error   .scheduler-run-result { color: var(--danger); }
-.scheduler-run-row--skipped .scheduler-run-result { color: var(--accent-gold); }
+.scheduler-run-row--success    .scheduler-run-result { color: var(--success); }
+.scheduler-run-row--error      .scheduler-run-result { color: var(--danger); }
+.scheduler-run-row--skipped    .scheduler-run-result { color: var(--accent-gold); }
+.scheduler-run-row--incomplete .scheduler-run-result { color: var(--accent-orange, #db6d28); }
 
 .scheduler-run-duration {
   font-variant-numeric: tabular-nums;
@@ -14159,6 +14162,11 @@ body.resizing-col .explorer-resizer::after {
 .overview-result--skipped {
   color: var(--text-dim);
   background: rgba(139, 148, 158, 0.12);
+}
+
+.overview-result--incomplete {
+  color: rgb(219, 109, 40);
+  background: rgba(219, 109, 40, 0.12);
 }
 
 .overview-projects {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2938,7 +2938,15 @@ export interface ScheduleRun {
   id?: string;
   /** ISO-8601 timestamp of when the fire began. */
   at: string;
-  result: 'success' | 'error' | 'skipped';
+  /**
+   * `incomplete` = the process exited 0 (so it isn't `error`) but the run never
+   * filed a `schedule_report` before exiting, for a schedule that expects one
+   * (`inboxLevel !== 'silent'` on a report-capable profile). Exit code alone
+   * can't distinguish a clean finish from a stream that died mid-run (e.g. an
+   * idle-dropped SSE connection) — a dead run can still exit 0 — so `incomplete`
+   * is the loud, honest label for "we don't actually know this succeeded."
+   */
+  result: 'success' | 'error' | 'skipped' | 'incomplete';
   /** PtyManager session id, if a terminal was actually spawned. */
   sessionId?: string;
   /** Time from spawn to pty exit (only set once the session ends). */
@@ -2966,7 +2974,7 @@ export interface ScheduleRun {
 
 export interface ScheduleStatus {
   lastRunAt?: string;
-  lastRunResult?: 'success' | 'error' | 'skipped';
+  lastRunResult?: 'success' | 'error' | 'skipped' | 'incomplete';
   lastRunSessionId?: string;
   /** ISO-8601 timestamp of the next planned fire (informational; recomputed on load). */
   nextRunAt?: string;


### PR DESCRIPTION
## Summary
- Scheduled runs currently get marked "success" purely from process exit code 0, even when the underlying agent stream died mid-run (e.g. Zscaler SSE idle-drop) and never reached its work or called `schedule_report` — a silent failure indistinguishable from a real success.
- For report-capable (claude-family) profiles on non-`silent` schedules, an exit-0 run with no `report`/`reportStatus` is now stamped `result: 'incomplete'` and surfaced loudly in the inbox regardless of `inboxLevel`. A late-arriving report promotes the run back to `success`. Non-zero exits still record `error` as before; `silent` schedules and report-incapable profiles (codex/cursor/pi/opencode) are exempt so they don't false-positive.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — scheduler + scheduler-store suites green
- [x] Full pre-push suite green (4640 passed, 52 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)