### PR TITLE
fix(release): restore public update feed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,10 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          # Keep the published feed aligned with electron-builder.yml. This
+          # cross-repository release needs a token with contents:write there.
+          repository: grebmann1/zcc-releases
+          token: ${{ secrets.ZCC_RELEASES_TOKEN }}
           # dmg + zip + blockmap + latest-mac.yml must all be attached:
           # electron-updater reads latest-mac.yml to detect a new version and
           # downloads the zip (the dmg is for first-install only).

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -81,13 +81,13 @@ extraResources:
 # host/owner/repo are explicit (not derived from package.json) so a stale
 # `homepage` can't point the updater at the wrong repo.
 #
-# The release feed is the public github.com repo salesforce/zana.
+# The release feed is the public github.com repo grebmann1/zcc-releases.
 # electron-updater's `GitHubProvider` reads latest-mac.yml and artifacts
 # anonymously (no token, no VPN). Omitting `host:` defaults to public github.com.
 publish:
   provider: github
-  owner: salesforce
-  repo: zana
+  owner: grebmann1
+  repo: zcc-releases
 
 asar: true
 asarUnpack:


### PR DESCRIPTION
## Summary
- restore `grebmann1/zcc-releases` as the electron-updater GitHub feed
- publish release workflow artifacts to that cross-repository feed using `ZCC_RELEASES_TOKEN`

## Verification
- `npm test -- --run src/main/updater.test.ts`
- pre-push hook: typecheck and full test suite (4,577 passed; 51 skipped)