### PR TITLE
fix(agents): remove duplicate list monitor

### DIFF
--- a/e2e/agent-launch-ui.spec.ts
+++ b/e2e/agent-launch-ui.spec.ts
@@ -143,6 +143,14 @@ test('launching an agent through the real UI opens its terminal and it goes work
         JSON.stringify(e.args).includes('working'),
       15_000
     );
+
+    // 11. The global List monitor owns the agent list. Its list must expand into
+    // column 2 instead of leaving the compact quick-agent list beside a duplicate.
+    await agentModal.getByLabel('Close').click();
+    await window.getByLabel('List view').click();
+    await expect(window.locator('.app-shell')).toHaveClass(/scoped-no-list/);
+    await expect(window.locator('.agents-list-pane')).toHaveCount(0);
+    await expect(window.locator('.agent-monitor-list')).toBeVisible();
   } finally {
     // Best-effort: close the agent (frees the held PTY), then remove the project.
     if (projectId) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -60,6 +60,7 @@ import { useFavoriteCount } from './util/useAgentCards';
 import { focusInboxEntry } from './util/inboxNavigation';
 import { projectDefaultLaunch } from './util/launchProfile';
 import { getScopedProjectId } from './util/windowScope';
+import { shouldHideListPane } from './util/agentsLayout';
 import { installShortcuts } from './shortcuts';
 
 // Lazy-load: LibraryPanel's doc preview pulls in monaco-editor, which registers
@@ -73,6 +74,7 @@ const LibraryPanel = lazy(() =>
 export function App() {
   const init = useData((s) => s.init);
   const nav = useUi((s) => s.nav);
+  const agentsBoardView = useUi((s) => s.agentsBoardView);
   const focusedProjectId = useUi((s) => s.focusedProjectId);
   const selectedProjectId = useUi((s) => s.selectedProjectId);
   const selectedTabId = useUi((s) => s.selectedTabId);
@@ -534,10 +536,15 @@ export function App() {
   // drop it and reclaim its column. This applies both to a per-project WINDOW
   // (scopedProject) and to the MAIN WINDOW drilled into a project (focusedProject)
   // — the project rail + tab bar already cover navigation, so the middle session
-  // list is just noise. The Inbox view still needs column 2 (its entry list lives
-  // there), so keep it when nav==='inbox'.
-  const hideListPane =
-    (!!scopedProject || !!focusedProject) && nav === 'projects';
+  // list is just noise. The global Agents List view also owns its agent list, so
+  // its monitor expands into column 2 instead of repeating the quick-agent list.
+  // The Inbox view still needs column 2 (its entry list lives there), so keep it
+  // when nav==='inbox'.
+  const hideListPane = shouldHideListPane(
+    nav,
+    agentsBoardView,
+    !!scopedProject || !!focusedProject
+  );
 
   return (
     <div

--- a/src/renderer/__tests__/agents-list-layout.test.ts
+++ b/src/renderer/__tests__/agents-list-layout.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentsBoardView } from '../store';
+import { shouldHideListPane } from '../util/agentsLayout';
+
+describe('Agents List layout', () => {
+  it('gives the global List monitor the full content area', () => {
+    expect(shouldHideListPane('agents', 'list', false)).toBe(true);
+  });
+
+  it.each<AgentsBoardView>(['board', 'flow'])('keeps the quick-agent list beside the %s view', (boardView) => {
+    expect(shouldHideListPane('agents', boardView, false)).toBe(false);
+  });
+
+  it('preserves the existing project-workspace behavior', () => {
+    expect(shouldHideListPane('projects', 'board', true)).toBe(true);
+    expect(shouldHideListPane('inbox', 'list', true)).toBe(false);
+  });
+});

--- a/src/renderer/util/agentsLayout.ts
+++ b/src/renderer/util/agentsLayout.ts
@@ -1,0 +1,16 @@
+import type { AgentsBoardView } from '../store';
+
+/**
+ * The compact quick-agent list and the full List monitor both enumerate the
+ * fleet. The monitor owns List mode, so it needs column 2 as well as column 3.
+ */
+export function shouldHideListPane(
+  nav: string,
+  boardView: AgentsBoardView,
+  hasScopedOrFocusedProject: boolean
+): boolean {
+  return (
+    (hasScopedOrFocusedProject && nav === 'projects') ||
+    (nav === 'agents' && boardView === 'list')
+  );
+}


### PR DESCRIPTION
Summary:\n- Let the global Agents List monitor use both content columns.\n- Hide the compact quick-agent list only while List view is active.\n- Add unit and Electron regression coverage.\n\nVerification: typecheck, focused Vitest tests, production build, and the agent-launch Electron spec passed.