### PR TITLE
feat(ui): standardize picker controls

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -78,6 +78,10 @@ export default defineConfig({
     resolve: {
       alias: [
         ...sdkAlias,
+        // Built-in plugins share core renderer controls but live outside
+        // `src/renderer`, so use this explicit source alias instead of a brittle
+        // relative path back into the host UI.
+        { find: '@renderer', replacement: resolve(__dirname, 'src/renderer') },
         // Monaco 0.56 restricts its public exports, while its Vite worker
         // entrypoints remain under `esm/vs`. Resolve that subtree directly.
         {

--- a/plugins/slack/renderer/SlackPanel.tsx
+++ b/plugins/slack/renderer/SlackPanel.tsx
@@ -14,6 +14,7 @@ import {
   DEFAULT_SLACK_CONFIG,
   DEFAULT_SLACK_BOT_CONFIG
 } from '../shared/types.js';
+import { PopoverPicklist } from '@renderer/components/ui/PopoverPicklist';
 
 interface SlackPanelProps {
   host: ModuleHost;
@@ -419,17 +420,17 @@ export default function SlackPanel({ host }: SlackPanelProps) {
         <div className="settings-field">
           <label>
             <span className="settings-label">Launch sessions into</span>
-            <select
+            <PopoverPicklist
               value={config.bot.defaultProjectId ?? ''}
-              onChange={(e) => saveBot({ defaultProjectId: e.target.value || undefined })}
-            >
-              <option value="">Active project (whatever's selected)</option>
-              {projects.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
+              ariaLabel="Launch sessions into"
+              onChange={(projectId) => saveBot({ defaultProjectId: projectId || undefined })}
+              placeholder="Active project (whatever's selected)"
+              searchPlaceholder="Search projects"
+              options={[
+                { value: '', label: 'Active project (whatever\'s selected)' },
+                ...projects.map((project) => ({ value: project.id, label: project.name }))
+              ]}
+            />
           </label>
         </div>
 

--- a/resources/extension-creator-skill.md
+++ b/resources/extension-creator-skill.md
@@ -217,6 +217,80 @@ The defined ones (see `src/renderer/styles/global.css` `:root`):
 `var(--border)`, `var(--bg-panel)`, `var(--accent-blue)`. Always pass a literal
 fallback for anything else, e.g. `var(--surface-2, rgba(127,127,127,0.06))`.
 
+### Controls — use host picklists, not native selects
+
+The desktop app intentionally uses themed, searchable picklists instead of
+platform-native `select` menus. Native selects can open in the operating
+system's light palette, do not scale well to the user's project/persona lists,
+and make an extension feel detached from the rest of the app.
+
+- **For a choice from a changing or potentially long list** (projects, people,
+  teams, saved records, providers), render a semantic button that opens
+  `host.quickPick(...)`. The host renders the searchable picker, owns Escape and
+  focus return, and follows the app theme. Treat `null` as cancel; an empty
+  string may be a valid selected value.
+- **For two to four fixed, mutually exclusive modes**, use a visible button group
+  with `aria-pressed` on the selected button. Do not hide a small decision behind
+  a menu.
+- **For booleans**, prefer a real checkbox inside a label. Do not make a `div`
+  clickable. If a visual switch is essential, use a `button` with
+  `role="switch"` and `aria-checked`.
+- **For free-form values**, use a labelled `input` or `textarea`; do not force a
+  picklist where typing is clearer. Every visible field needs a programmatic
+  label, and disabled/unavailable choices need nearby explanatory text.
+- **Never import core renderer internals** such as `PopoverPicklist` or copy its
+  CSS into a disk extension. Those are host implementation details, not the
+  extension API. Use `host.quickPick` for selection and the documented theme
+  variables for your own layout.
+
+Example: a project choice that matches host interaction instead of rendering a
+native menu. This assumes the extension declared `projects:read`.
+
+```js
+function ProjectPicker({ projectId, onChange }) {
+  const projects = host.listProjects();
+  const selected = projects.find((project) => project.id === projectId);
+
+  const chooseProject = async () => {
+    const next = await host.quickPick(
+      [
+        {
+          label: 'Active project',
+          description: 'Use whichever project is currently selected',
+          value: ''
+        },
+        ...projects.map((project) => ({
+          label: project.name,
+          description: project.remote ? project.remote.host : project.path,
+          value: project.id
+        }))
+      ],
+      { title: 'Project', placeholder: 'Search projects' }
+    );
+    if (next !== null) onChange(next);
+  };
+
+  return h(
+    'button',
+    {
+      type: 'button',
+      onClick: () => { void chooseProject(); },
+      'aria-haspopup': 'dialog'
+    },
+    selected?.name ?? 'Active project'
+  );
+}
+```
+
+Use `host.confirm(...)` before a destructive choice, and use `host.prompt(...)`
+for one short text value. This keeps extension dialogs consistent with the rest
+of the app instead of recreating modal, focus-trap, and theme behavior.
+
+Because disk-extension renderers receive only injected React and `host`, do not
+assume you can import the host's React components. `host.quickPick` is the
+supported public selection primitive; its items accept `{ label, description,
+value }` and resolve to the selected `value` or `null` on cancel.
+
 ## Permissions (deny-by-default)
 
 The starter declares **no permissions**, so it installs consent-free. Add a token

--- a/src/main/__tests__/local-extension-kinds.test.ts
+++ b/src/main/__tests__/local-extension-kinds.test.ts
@@ -19,12 +19,20 @@ import { fileURLToPath } from 'node:url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 // The committed editable templates live at repo-root templates/extension-starter.
 const TEMPLATE_ROOT = join(__dirname, '../../../templates/extension-starter');
+const EXTENSION_CREATOR_SKILL = join(__dirname, '../../../resources/extension-creator-skill.md');
 
 async function importLocalExt() {
   return await import('../local-extension.js');
 }
 
 describe('local-extension template kinds', () => {
+  it('documents the host-owned picker contract in the bundled Creator skill', async () => {
+    const skill = await readFile(EXTENSION_CREATOR_SKILL, 'utf-8');
+    expect(skill).toContain('Controls — use host picklists, not native selects');
+    expect(skill).toContain('host.quickPick');
+    expect(skill).toContain('Never import core renderer internals');
+  });
+
   it('clampLocalKind allowlists the four kinds and defaults unknown → panel', async () => {
     const { clampLocalKind } = await importLocalExt();
     expect(clampLocalKind('panel')).toBe('panel');
@@ -102,6 +110,15 @@ describe('local-extension template kinds', () => {
           }
         }
       }
+    }
+  });
+
+  it('teaches every starter to use host picklists instead of native selects', async () => {
+    const { VALID_LOCAL_KINDS } = await importLocalExt();
+    for (const kind of VALID_LOCAL_KINDS) {
+      const brief = await readFile(join(TEMPLATE_ROOT, kind, 'CLAUDE.md'), 'utf-8');
+      expect(brief, `${kind}/CLAUDE.md`).toContain('host.quickPick');
+      expect(brief, `${kind}/CLAUDE.md`).toContain('native `select`');
     }
   });
 });

--- a/src/renderer/components/AgentLauncher.tsx
+++ b/src/renderer/components/AgentLauncher.tsx
@@ -69,6 +69,7 @@ import { useDialogFocusTrap } from '../util/useDialogFocusTrap';
 import { effectivePersonaRouting } from '../util/personaRouting';
 import { HarnessOptionSelect } from './HarnessOptionSelect';
 import { LauncherModelPicker } from './LauncherModelPicker';
+import { PopoverPicklist } from './ui/PopoverPicklist';
 import { buildFixWithAiPrompt } from '../util/fixWithAiPrompt';
 import { posixQuote } from '../util/quote';
 import { appendAttachmentContext, attachmentName, mergeAttachmentPaths } from '../util/attachments';
@@ -395,32 +396,38 @@ function NativeAgentRoutingFields({
       {targets?.executionStateMapping && descriptor.id !== 'codex' && descriptor.id !== 'opencode' && (
         <div className="launch-row launch-native-field--execution">
           <label className="launch-row-label" htmlFor="launch-native-execution">Execution State</label>
-          <select
+          <PopoverPicklist
             id="launch-native-execution"
             className="launch-folder-select"
             value={routing.executionState ?? ''}
             disabled={unavailable}
-            onChange={(event) => onChange({
-              executionState: (event.target.value || undefined) as LauncherRouting['executionState']
+            ariaLabel="Execution state"
+            searchable={false}
+            onChange={(executionState) => onChange({
+              executionState: (executionState || undefined) as LauncherRouting['executionState']
             })}
-          >
-            <option value="">Use project/global default</option>
-              {executionMappingOptions(targets.executionStateMapping).map(({ id, native, states }) => (
-                <option key={id} value={id}>{native} [{states.map(portableLabel).join(', ')}]</option>
-            ))}
-          </select>
+            options={[
+              { value: '', label: 'Use project/global default' },
+              ...executionMappingOptions(targets.executionStateMapping).map(({ id, native, states }) => ({
+                value: id,
+                label: `${native} [${states.map(portableLabel).join(', ')}]`
+              }))
+            ]}
+          />
         </div>
       )}
       {!!targets?.providers?.length && (
         <div className="launch-row launch-native-field--provider">
           <label className="launch-row-label" htmlFor="launch-provider-target">Provider</label>
-          <select
+          <PopoverPicklist
             id="launch-provider-target"
             className="launch-folder-select"
-            value={selectedProvider}
+            value={selectedProvider ?? ''}
             disabled={relationship === 'fixed-provider' || unavailable}
-            onChange={(event) => {
-              const providerTargetId = event.target.value || undefined;
+            ariaLabel="Provider"
+            searchable={false}
+            onChange={(providerId) => {
+              const providerTargetId = providerId || undefined;
               const currentModel = targets.models.find((target) => target.id === routing.modelTargetId);
               onChange({
                 providerTargetId,
@@ -429,10 +436,11 @@ function NativeAgentRoutingFields({
                   : {})
               });
             }}
-          >
-            {relationship !== 'fixed-provider' && <option value="">Use project/global default</option>}
-            {targets.providers.map((provider) => <option key={provider.id} value={provider.id}>{provider.label}</option>)}
-          </select>
+            options={[
+              ...(relationship !== 'fixed-provider' ? [{ value: '', label: 'Use project/global default' }] : []),
+              ...targets.providers.map((provider) => ({ value: provider.id, label: provider.label }))
+            ]}
+          />
         </div>
       )}
       {descriptor.id === 'codex' && (
@@ -581,17 +589,14 @@ function WorkflowArgForm({
           <div key={a.name} className="workflow-arg-field">
             <label htmlFor={id}>{a.name}</label>
             {a.type === 'enum' && a.enumValues && a.enumValues.length > 0 ? (
-              <select
+              <PopoverPicklist
                 id={id}
                 value={val}
-                onChange={(e) => onChange(a.name, e.target.value)}
-              >
-                {a.enumValues.map((v) => (
-                  <option key={v} value={v}>
-                    {v}
-                  </option>
-                ))}
-              </select>
+                ariaLabel={a.name}
+                searchable={false}
+                onChange={(nextValue) => onChange(a.name, nextValue)}
+                options={a.enumValues.map((enumValue) => ({ value: enumValue, label: enumValue }))}
+              />
             ) : (
               <input
                 id={id}
@@ -799,17 +804,14 @@ function QuickPromptEditor({
 
       <div className="workflow-arg-field">
         <label htmlFor="qpe-profile">Profile</label>
-        <select
+        <PopoverPicklist
           id="qpe-profile"
           value={profile}
-          onChange={(e) => setProfile(e.target.value as LaunchProfileId)}
-        >
-          {promptProfiles.map((p) => (
-            <option key={p} value={p}>
-              {profileLabel(p)}
-            </option>
-          ))}
-        </select>
+          ariaLabel="Profile"
+          searchable={false}
+          onChange={(nextProfile) => setProfile(nextProfile as LaunchProfileId)}
+          options={promptProfiles.map((item) => ({ value: item, label: profileLabel(item) }))}
+        />
       </div>
 
       {slotNames.length > 0 && (
@@ -823,14 +825,16 @@ function QuickPromptEditor({
             return (
               <div key={name} className="quick-prompt-editor-arg">
                 <span className="quick-prompt-editor-arg-name">{name}</span>
-                <select
-                  aria-label={`${name} type`}
+                <PopoverPicklist
                   value={meta.type ?? 'text'}
-                  onChange={(e) => setMeta(name, { type: e.target.value as 'text' | 'enum' })}
-                >
-                  <option value="text">text</option>
-                  <option value="enum">enum</option>
-                </select>
+                  ariaLabel={`${name} type`}
+                  searchable={false}
+                  onChange={(type) => setMeta(name, { type: type as 'text' | 'enum' })}
+                  options={[
+                    { value: 'text', label: 'text' },
+                    { value: 'enum', label: 'enum' }
+                  ]}
+                />
                 <input
                   type="text"
                   aria-label={`${name} description`}
@@ -1959,41 +1963,23 @@ export const AgentLauncher = memo(function AgentLauncher({
               <span className="launch-row-label">Project</span>
               <div className="launch-folder">
                 <Folder size={13} aria-hidden="true" />
-                <select
+                <PopoverPicklist
+                  id="agent-launcher-project"
                   className="launch-folder-select"
                   value={targetProjectId ?? ''}
-                  onChange={(e) => setTargetProjectId(e.target.value || null)}
-                  aria-label="Target project"
-                >
-                  <option value="">Quick workspace (scratch)</option>
-                  {projectGroups.favorites.length > 0 && (
-                    <optgroup label="Favorites">
-                      {projectGroups.favorites.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                  {projectGroups.remote.length > 0 && (
-                    <optgroup label="Remote">
-                      {projectGroups.remote.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                  {projectGroups.local.length > 0 && (
-                    <optgroup label="Local">
-                      {projectGroups.local.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                </select>
+                  ariaLabel="Target project"
+                  onChange={(nextProjectId) => setTargetProjectId(nextProjectId || null)}
+                  placeholder="Quick workspace (scratch)"
+                  searchPlaceholder="Search projects"
+                  emptyHint="No matching projects"
+                  minWidth={320}
+                  options={[
+                    { value: '', label: 'Quick workspace (scratch)' },
+                    ...projectGroups.favorites.map((project) => ({ value: project.id, label: project.name, group: 'Favorites' })),
+                    ...projectGroups.remote.map((project) => ({ value: project.id, label: project.name, group: 'Remote' })),
+                    ...projectGroups.local.map((project) => ({ value: project.id, label: project.name, group: 'Local' }))
+                  ]}
+                />
               </div>
             </div>
           )}
@@ -2186,39 +2172,45 @@ export const AgentLauncher = memo(function AgentLauncher({
                   <div className="launch-routing-defaults-fields">
                     <label className="launch-routing-defaults-field" htmlFor="launch-model-level">
                       <span>Model level</span>
-                      <select
+                      <PopoverPicklist
                         id="launch-model-level"
                         className="launch-folder-select"
                         value={portableRouting.modelLevel ?? ''}
-                        onChange={(event) => {
+                        ariaLabel="Model level"
+                        searchable={false}
+                        onChange={(modelLevel) => {
                           setAgentRoutingDirty(true);
                           setPortableRouting((current) => ({
                             ...current,
-                            modelLevel: (event.target.value || undefined) as LauncherRouting['modelLevel']
+                            modelLevel: (modelLevel || undefined) as LauncherRouting['modelLevel']
                           }));
                         }}
-                      >
-                        <option value="">Use configured default</option>
-                        {PORTABLE_MODEL_LEVELS.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
-                      </select>
+                        options={[
+                          { value: '', label: 'Use configured default' },
+                          ...PORTABLE_MODEL_LEVELS.map((option) => ({ value: option.id, label: option.label }))
+                        ]}
+                      />
                     </label>
                     <label className="launch-routing-defaults-field" htmlFor="launch-execution-state">
                       <span>Execution state</span>
-                      <select
+                      <PopoverPicklist
                         id="launch-execution-state"
                         className="launch-folder-select"
                         value={portableRouting.executionState ?? ''}
-                        onChange={(event) => {
+                        ariaLabel="Execution state"
+                        searchable={false}
+                        onChange={(executionState) => {
                           setAgentRoutingDirty(true);
                           setPortableRouting((current) => ({
                             ...current,
-                            executionState: (event.target.value || undefined) as LauncherRouting['executionState']
+                            executionState: (executionState || undefined) as LauncherRouting['executionState']
                           }));
                         }}
-                      >
-                        <option value="">Use configured default</option>
-                        {PORTABLE_EXECUTION_STATES.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
-                      </select>
+                        options={[
+                          { value: '', label: 'Use configured default' },
+                          ...PORTABLE_EXECUTION_STATES.map((option) => ({ value: option.id, label: option.label }))
+                        ]}
+                      />
                     </label>
                   </div>
                 </div>

--- a/src/renderer/components/FollowUpsPanel.tsx
+++ b/src/renderer/components/FollowUpsPanel.tsx
@@ -35,6 +35,7 @@ import { seedPromptArgs } from '@shared/launch-provider';
 import { answerFollowUp, useData, useFollowUps, useUi } from '../store';
 import { isClaudeProfile, knownProfile, projectDefaultProfile } from '../util/launchProfile';
 import { buildFollowUpPrompt, followUpAgentTitle } from '../util/followUpPrompt';
+import { PopoverPicklist } from './ui/PopoverPicklist';
 
 /** Status → pill label / class suffix. Reuses the scheduler pill palette. */
 const STATUS_META: Record<FollowUpStatus, { label: string; cls: string }> = {
@@ -987,30 +988,31 @@ function FollowUpModal({
           <div className="scheduler-form-row">
             <div className="scheduler-form-field">
               <label htmlFor="fu-kind">Kind</label>
-              <select
+              <PopoverPicklist
                 id="fu-kind"
+                ariaLabel="Kind"
                 value={kind}
-                onChange={(e) => setKind(e.target.value as FollowUpKind)}
-              >
-                <option value="question">Question</option>
-                <option value="decision">Decision</option>
-                <option value="note">Note</option>
-              </select>
+                searchable={false}
+                onChange={(nextKind) => setKind(nextKind as FollowUpKind)}
+                options={[
+                  { value: 'question', label: 'Question' },
+                  { value: 'decision', label: 'Decision' },
+                  { value: 'note', label: 'Note' }
+                ]}
+              />
             </div>
             <div className="scheduler-form-field">
               <label htmlFor="fu-project">Project</label>
-              <select
+              <PopoverPicklist
                 id="fu-project"
+                ariaLabel="Project"
                 value={projectId}
-                onChange={(e) => setProjectId(e.target.value)}
                 disabled={!isNew || Boolean(lockedProjectId)}
-              >
-                {projects.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
+                onChange={setProjectId}
+                placeholder="Choose project"
+                searchPlaceholder="Search projects"
+                options={projects.map((project) => ({ value: project.id, label: project.name }))}
+              />
             </div>
           </div>
           {isNew && !lockedProjectId && (

--- a/src/renderer/components/GoalsPanel.tsx
+++ b/src/renderer/components/GoalsPanel.tsx
@@ -29,6 +29,7 @@ import type {
 } from '@shared/types';
 import { useData, useGoals, useUi } from '../store';
 import { ImprovePromptButton } from './ImprovePromptButton';
+import { PopoverPicklist } from './ui/PopoverPicklist';
 import { VALID_PROFILES } from '@shared/launch-provider';
 
 const PROFILES = VALID_PROFILES;
@@ -653,32 +654,27 @@ function GoalModal({
           <div className="scheduler-form-row">
             <div className="scheduler-form-field">
               <label htmlFor="goal-project">Project</label>
-              <select
+              <PopoverPicklist
                 id="goal-project"
+                ariaLabel="Project"
                 value={projectId}
-                onChange={(e) => setProjectId(e.target.value)}
                 disabled={!isNew || Boolean(lockedProjectId)}
-              >
-                {projects.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
+                onChange={setProjectId}
+                placeholder="Choose project"
+                searchPlaceholder="Search projects"
+                options={projects.map((project) => ({ value: project.id, label: project.name }))}
+              />
             </div>
             <div className="scheduler-form-field">
               <label htmlFor="goal-profile">Launch profile</label>
-              <select
+              <PopoverPicklist
                 id="goal-profile"
+                ariaLabel="Launch profile"
                 value={profile}
-                onChange={(e) => setProfile(e.target.value as LaunchProfileId)}
-              >
-                {PROFILES.map((p) => (
-                  <option key={p} value={p}>
-                    {PROFILE_LABEL[p]}
-                  </option>
-                ))}
-              </select>
+                searchable={false}
+                onChange={(nextProfile) => setProfile(nextProfile as LaunchProfileId)}
+                options={PROFILES.map((profile) => ({ value: profile, label: PROFILE_LABEL[profile] }))}
+              />
             </div>
           </div>
           <div className="scheduler-form-row">

--- a/src/renderer/components/HarnessOptionSelect.tsx
+++ b/src/renderer/components/HarnessOptionSelect.tsx
@@ -1,9 +1,10 @@
 import type { ProviderUiOption } from '@shared/launch-provider';
+import { PopoverPicklist } from './ui/PopoverPicklist';
 
 /**
  * The generic picker for a data-driven harness option axis.
  *
- * It renders a single `<select>` from a `ProviderUiOption[]` — the flat,
+ * It renders a single popover picker from a `ProviderUiOption[]` — the flat,
  * role-tagged catalog produced by `harnessOptions(profile)` in
  * `@shared/launch-provider`. Every model / permission-mode / sandbox / approval
  * selector in the app funnels through THIS, so the option list + sentinel +
@@ -38,7 +39,7 @@ export interface HarnessOptionSelectProps {
    */
   dropDefaultId?: boolean;
   disabled?: boolean;
-  /** Native `title` (hover copy explaining a disabled axis). */
+  /** Hover copy explaining a disabled axis. */
   title?: string;
   /** Optional class for the caller's surrounding form layout. */
   className?: string;
@@ -49,7 +50,7 @@ export interface HarnessOptionSelectProps {
 const DEFAULT_EMPTY: ProviderUiOption = { id: 'default', label: 'Default' };
 
 /**
- * Pure assembly of the rendered `<option>` list — extracted so the sentinel /
+ * Pure assembly of the rendered option list — extracted so the sentinel /
  * dropDefault / empty-fallback behaviour is unit-testable without a DOM. Order:
  * [sentinel?] + catalog (minus the built-in `default` when dropped, minus any
  * catalog entry duplicating the sentinel), falling back to `emptyOption` when
@@ -84,19 +85,15 @@ export function HarnessOptionSelect({
   const list = buildOptionList({ options, sentinel, dropDefaultId, emptyOption });
 
   return (
-    <select
+    <PopoverPicklist
       id={id}
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      ariaLabel={title ?? id}
+      onChange={onChange}
       disabled={disabled}
-      title={title}
+      searchable={false}
       className={className}
-    >
-      {list.map((o) => (
-        <option key={o.id} value={o.id}>
-          {o.label}
-        </option>
-      ))}
-    </select>
+      options={list.map((option) => ({ value: option.id, label: option.label }))}
+    />
   );
 }

--- a/src/renderer/components/PersonaEditor.tsx
+++ b/src/renderer/components/PersonaEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { X, Trash2, Copy, Pencil, FolderOpen, ChevronRight } from 'lucide-react';
-import { executionMappingOptions, type HarnessAdapterDescriptor } from '@shared/harness-adapter';
+import type { HarnessAdapterDescriptor } from '@shared/harness-adapter';
 import type { HarnessFamily, LaunchProfileId, Persona, PersonaInput } from '@shared/types';
 import {
   harnessFamilyOf,
@@ -12,6 +12,7 @@ import {
 import { useUi, useData } from '../store';
 import { ImprovePromptButton } from './ImprovePromptButton';
 import { HarnessOptionSelect } from './HarnessOptionSelect';
+import { PopoverPicklist } from './ui/PopoverPicklist';
 import { effectivePersonaRouting } from '../util/personaRouting';
 import {
   PERSONA_ICON_NAMES,
@@ -208,12 +209,14 @@ function PersonaHarnessRoutingFields({
       {!!targets?.providers?.length && (
         <div className="scheduler-form-field">
           <label htmlFor="persona-provider-target">Provider</label>
-          <select
+          <PopoverPicklist
             id="persona-provider-target"
-            value={selectedProvider}
-             disabled={relationship === 'fixed-provider'}
-            onChange={(event) => {
-              const providerTargetId = event.target.value || undefined;
+            value={selectedProvider ?? ''}
+            ariaLabel="Provider"
+            searchable={false}
+            disabled={relationship === 'fixed-provider'}
+            onChange={(providerId) => {
+              const providerTargetId = providerId || undefined;
               const currentModel = targets.models.find((target) => target.id === routing.modelTargetId);
               onChange({
                 providerTargetId,
@@ -222,46 +225,50 @@ function PersonaHarnessRoutingFields({
                   : {})
               });
             }}
-          >
-            {relationship !== 'fixed-provider' && <option value="">Use project/global default</option>}
-            {targets.providers.map((provider) => (
-              <option key={provider.id} value={provider.id}>{provider.label}</option>
-            ))}
-          </select>
+            options={[
+              ...(relationship !== 'fixed-provider' ? [{ value: '', label: 'Use project/global default' }] : []),
+              ...targets.providers.map((provider) => ({ value: provider.id, label: provider.label }))
+            ]}
+          />
         </div>
       )}
       {!!targets?.models.length && (
         <div className="scheduler-form-field">
           <label htmlFor="persona-model-target">Model</label>
-          <select
+          <PopoverPicklist
             id="persona-model-target"
             value={routing.modelTargetId ?? ''}
-             onChange={(event) => onChange({ modelTargetId: event.target.value || undefined })}
-          >
-            <option value="">Use project/global default</option>
-            {visibleModels.map((target) => (
-              <option key={target.id} value={target.id}>
-                {target.label}{target.level ? ` [${portableLabel(target.level)}]` : ''}
-              </option>
-            ))}
-          </select>
+            ariaLabel="Model"
+            onChange={(modelTargetId) => onChange({ modelTargetId: modelTargetId || undefined })}
+            options={[
+              { value: '', label: 'Use project/global default' },
+              ...visibleModels.map((target) => ({
+                value: target.id,
+                label: `${target.label}${target.level ? ` [${portableLabel(target.level)}]` : ''}`
+              }))
+            ]}
+          />
         </div>
       )}
       {targets?.executionStateMapping && descriptor.id !== 'codex' && (
         <div className="scheduler-form-field">
           <label htmlFor="persona-execution-target">Execution state</label>
-          <select
+          <PopoverPicklist
             id="persona-execution-target"
             value={routing.executionState ?? ''}
-             onChange={(event) => onChange({
-              executionState: (event.target.value || undefined) as NonNullable<typeof routing.executionState> | undefined
+            ariaLabel="Execution state"
+            searchable={false}
+            onChange={(executionState) => onChange({
+              executionState: (executionState || undefined) as NonNullable<typeof routing.executionState> | undefined
             })}
-          >
-            <option value="">Use project/global default</option>
-            {executionMappingOptions(targets.executionStateMapping).map(({ id, native, states }) => (
-              <option key={id} value={id}>{native} [{states.map(portableLabel).join(', ')}]</option>
-            ))}
-          </select>
+            options={[
+              { value: '', label: 'Use project/global default' },
+              ...Object.entries(targets.executionStateMapping).map(([state, native]) => ({
+                value: state,
+                label: `${native} [${portableLabel(state)}]`
+              }))
+            ]}
+          />
         </div>
       )}
       {descriptor.id === 'codex' && (
@@ -663,49 +670,54 @@ function PersonaForm({ persona, onClose }: { persona: Persona | null; onClose: (
         <div className={`persona-routing-grid persona-routing-grid--${baseProfile ? 'pinned' : 'neutral'}`}>
           <div className="scheduler-form-field">
             <label htmlFor="persona-profile">Harness profile</label>
-            <select
+            <PopoverPicklist
               id="persona-profile"
               value={baseProfile}
-              onChange={(e) => setBaseProfile(e.target.value as LaunchProfileId | '')}
-            >
-              <option value="">Use launch harness (neutral)</option>
-              {PROFILES.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.label}
-                </option>
-              ))}
-            </select>
+              ariaLabel="Harness profile"
+              searchable={false}
+              onChange={(profile) => setBaseProfile(profile as LaunchProfileId | '')}
+              options={[
+                { value: '', label: 'Use launch harness (neutral)' },
+                ...PROFILES.map((item) => ({ value: item.id, label: item.label }))
+              ]}
+            />
           </div>
 
         {!baseProfile ? (
           <div className="persona-portable-routing" data-testid="persona-portable-routing">
               <div className="scheduler-form-field">
                 <label htmlFor="persona-model-level">Model level</label>
-                <select
+                <PopoverPicklist
                   id="persona-model-level"
                   value={modelLevel}
-                  onChange={(e) => setModelLevel(e.target.value)}
-                >
-                  <option value="default">Use harness default (unset)</option>
-                  <option value="low">Low (speed/cost sensitive)</option>
-                  <option value="medium">Medium (balanced normal)</option>
-                  <option value="high">High (frontier reasoning)</option>
-                  <option value="extra-high">Extra-high (deep reasoning)</option>
-                </select>
+                  ariaLabel="Model level"
+                  searchable={false}
+                  onChange={setModelLevel}
+                  options={[
+                    { value: 'default', label: 'Use harness default (unset)' },
+                    { value: 'low', label: 'Low (speed/cost sensitive)' },
+                    { value: 'medium', label: 'Medium (balanced normal)' },
+                    { value: 'high', label: 'High (frontier reasoning)' },
+                    { value: 'extra-high', label: 'Extra-high (deep reasoning)' }
+                  ]}
+                />
               </div>
               <div className="scheduler-form-field">
                 <label htmlFor="persona-execution-state">Execution state</label>
-                <select
+                <PopoverPicklist
                   id="persona-execution-state"
                   value={executionState}
-                  onChange={(e) => setExecutionState(e.target.value)}
-                >
-                  <option value="default">Use harness default (unset)</option>
-                  <option value="plan">Plan (planning only)</option>
-                  <option value="interactive">Interactive (human-in-loop)</option>
-                  <option value="accept-edits">Accept Edits (auto-approve edits)</option>
-                  <option value="autonomous">Autonomous (fully auto)</option>
-                </select>
+                  ariaLabel="Execution state"
+                  searchable={false}
+                  onChange={setExecutionState}
+                  options={[
+                    { value: 'default', label: 'Use harness default (unset)' },
+                    { value: 'plan', label: 'Plan (planning only)' },
+                    { value: 'interactive', label: 'Interactive (human-in-loop)' },
+                    { value: 'accept-edits', label: 'Accept Edits (auto-approve edits)' },
+                    { value: 'autonomous', label: 'Autonomous (fully auto)' }
+                  ]}
+                />
               </div>
           </div>
         ) : selectedDescriptor ? (

--- a/src/renderer/components/SquadEditor.tsx
+++ b/src/renderer/components/SquadEditor.tsx
@@ -7,6 +7,7 @@ import { resolveIcon } from '../util/resolveIcon';
 import { personaIcon } from '../util/profileIcon';
 import { PERSONA_ICON_NAMES, personaIconByName } from '../util/profileIcon';
 import { getScopedProjectId } from '../util/windowScope';
+import { PopoverPicklist } from './ui/PopoverPicklist';
 
 /**
  * Team detail + editor modal — the Teams counterpart of {@link PersonaEditor}.
@@ -442,23 +443,20 @@ function TeamForm({ team, onClose }: { team: Team | null; onClose: () => void })
                         ▼
                       </button>
                     </div>
-                    <select
+                    <PopoverPicklist
                       className="team-slot-persona"
                       value={slot.personaId}
-                      onChange={(e) => updateSlot(idx, { personaId: e.target.value })}
-                      aria-label="Slot persona"
-                    >
-                      {/* Keep an unknown id selectable so editing a team that
-                       *  references a not-yet-loaded persona doesn't silently drop it. */}
-                      {!known && slot.personaId && (
-                        <option value={slot.personaId}>{slot.personaId} (unknown)</option>
-                      )}
-                      {personas.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
-                    </select>
+                      ariaLabel="Slot persona"
+                      onChange={(personaId) => updateSlot(idx, { personaId })}
+                      placeholder="Choose persona"
+                      searchPlaceholder="Search personas"
+                      options={[
+                        // Keep an unknown id selectable so editing a team that references a
+                        // not-yet-loaded persona does not silently drop it.
+                        ...(!known && slot.personaId ? [{ value: slot.personaId, label: `${slot.personaId} (unknown)` }] : []),
+                        ...personas.map((persona) => ({ value: persona.id, label: persona.name }))
+                      ]}
+                    />
                     <input
                       className="team-slot-label-input"
                       type="text"
@@ -528,18 +526,18 @@ function TeamForm({ team, onClose }: { team: Team | null; onClose: () => void })
 
         <div className="scheduler-form-field">
           <label htmlFor="team-project">Default project</label>
-          <select
+          <PopoverPicklist
             id="team-project"
+            ariaLabel="Default project"
             value={defaultProjectId}
-            onChange={(e) => setDefaultProjectId(e.target.value)}
-          >
-            <option value="">None — choose at launch</option>
-            {projects.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </select>
+            onChange={setDefaultProjectId}
+            placeholder="None — choose at launch"
+            searchPlaceholder="Search projects"
+            options={[
+              { value: '', label: 'None — choose at launch' },
+              ...projects.map((project) => ({ value: project.id, label: project.name }))
+            ]}
+          />
         </div>
 
         <p className="settings-help persona-form-hint">

--- a/src/renderer/components/scheduler/ScheduleModal.tsx
+++ b/src/renderer/components/scheduler/ScheduleModal.tsx
@@ -13,6 +13,7 @@ import { isValidCron, nextCronRuns } from '@shared/parse-cron';
 import { useData, useUi, useScheduleGroups } from '../../store';
 import { Modal } from '../Modal';
 import { ImprovePromptButton } from '../ImprovePromptButton';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 import { PROFILE_LABEL, INBOX_LEVELS, scopeLabel, sourceLabel } from './schedulerUtils';
 
 /** Seed values handed to ScheduleModal. May come from a template ("Use this")
@@ -270,27 +271,26 @@ export function ScheduleModal({ task, seed, lockedProjectId, onClose }: Schedule
       <div className="scheduler-form-row">
         <div className="scheduler-form-field">
           <label htmlFor="sched-project">Project</label>
-          <select
+          <PopoverPicklist
             id="sched-project"
+            ariaLabel="Project"
             value={projectId}
-            onChange={(e) => setProjectId(e.target.value)}
-          >
-            {projects.map((p) => (
-              <option key={p.id} value={p.id}>{p.name}</option>
-            ))}
-          </select>
+            onChange={setProjectId}
+            placeholder="Choose project"
+            searchPlaceholder="Search projects"
+            options={projects.map((project) => ({ value: project.id, label: project.name }))}
+          />
         </div>
         <div className="scheduler-form-field">
           <label htmlFor="sched-profile">Launch profile</label>
-          <select
+          <PopoverPicklist
             id="sched-profile"
+            ariaLabel="Launch profile"
             value={profile}
-            onChange={(e) => setProfile(e.target.value as LaunchProfileId)}
-          >
-            {PROFILES.map((p) => (
-              <option key={p} value={p}>{PROFILE_LABEL[p]}</option>
-            ))}
-          </select>
+            searchable={false}
+            onChange={(nextProfile) => setProfile(nextProfile as LaunchProfileId)}
+            options={PROFILES.map((profile) => ({ value: profile, label: PROFILE_LABEL[profile] }))}
+          />
         </div>
       </div>
       {isNew ? (
@@ -343,21 +343,19 @@ export function ScheduleModal({ task, seed, lockedProjectId, onClose }: Schedule
           <label htmlFor="sched-group">
             Group <span className="scheduler-form-optional">(optional)</span>
           </label>
-          <select
+          <PopoverPicklist
             id="sched-group"
+            ariaLabel="Group"
             value={group}
-            onChange={(e) => setGroup(e.target.value)}
-          >
-            <option value="">Ungrouped</option>
-            {groups.map((g) => (
-              <option key={g.id} value={g.id}>{g.name}</option>
-            ))}
-            {/* A stale group id (its group was deleted) still shows so the
-                user sees what's set; picking another value reassigns it. */}
-            {group && !groups.some((g) => g.id === group) && (
-              <option value={group}>{group} (deleted)</option>
-            )}
-          </select>
+            onChange={setGroup}
+            options={[
+              { value: '', label: 'Ungrouped' },
+              ...groups.map((item) => ({ value: item.id, label: item.name })),
+              ...(group && !groups.some((item) => item.id === group)
+                ? [{ value: group, label: `${group} (deleted)` }]
+                : [])
+            ]}
+          />
           <p className="modal-hint">
             Sort this schedule into a Personal / Work bucket. Manage groups
             from the scheduler sidebar.

--- a/src/renderer/components/settings/AgentsTab.tsx
+++ b/src/renderer/components/settings/AgentsTab.tsx
@@ -2,6 +2,7 @@ import type { AppConfig } from '@shared/types';
 import { AUTO_CLOSE_IDLE_DEFAULTS, HEARTBEAT_DEFAULTS } from '@shared/types';
 import { Section, Field, CheckboxField } from './FormFields';
 import { OverseerRecentPane } from './OverseerRecentPane';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 
 export function AgentsTab({
   config,
@@ -199,19 +200,21 @@ export function AgentsTab({
               label="Need Attention sensitivity"
               help="How aggressively a triaged idle agent jumps to the “Needs you” lane. High surfaces almost any non-done idle agent; Medium only genuine questions; Low only high-confidence questions."
             >
-              <select
+              <PopoverPicklist
                 value={config.idleAttentionSensitivity ?? 'medium'}
-                onChange={(e) =>
+                ariaLabel="Need Attention sensitivity"
+                searchable={false}
+                onChange={(idleAttentionSensitivity) =>
                   onUpdate({
-                    idleAttentionSensitivity: e.target
-                      .value as AppConfig['idleAttentionSensitivity']
+                    idleAttentionSensitivity: idleAttentionSensitivity as AppConfig['idleAttentionSensitivity']
                   })
                 }
-              >
-                <option value="high">High</option>
-                <option value="medium">Medium</option>
-                <option value="low">Low</option>
-              </select>
+                options={[
+                  { value: 'high', label: 'High' },
+                  { value: 'medium', label: 'Medium' },
+                  { value: 'low', label: 'Low' }
+                ]}
+              />
             </Field>
             <CheckboxField
               label="Promote triaged agents to “Needs you” in the side list"
@@ -477,16 +480,19 @@ export function AgentsTab({
           label="Mode"
           help="Off: no hook installed, fully inert. Dry-run: logs what it WOULD auto-approve (in the terminal) but still prompts you — try this first. On: auto-approvals take effect."
         >
-          <select
+          <PopoverPicklist
             value={config.overseerMode ?? 'off'}
-            onChange={(e) =>
-              onUpdate({ overseerMode: e.target.value as AppConfig['overseerMode'] })
+            ariaLabel="Overseer mode"
+            searchable={false}
+            onChange={(overseerMode) =>
+              onUpdate({ overseerMode: overseerMode as AppConfig['overseerMode'] })
             }
-          >
-            <option value="off">Off</option>
-            <option value="dryRun">Dry-run (observe only)</option>
-            <option value="on">On</option>
-          </select>
+            options={[
+              { value: 'off', label: 'Off' },
+              { value: 'dryRun', label: 'Dry-run (observe only)' },
+              { value: 'on', label: 'On' }
+            ]}
+          />
         </Field>
         {config.overseerMode && config.overseerMode !== 'off' && (
           <>

--- a/src/renderer/components/settings/AuthorizationsSection.tsx
+++ b/src/renderer/components/settings/AuthorizationsSection.tsx
@@ -8,6 +8,7 @@ import {
   type AuthorizationApplyResult
 } from '@shared/authorizations';
 import { Section, Field } from './FormFields';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 
 /**
  * "Auto-configure authorizations" — one click writes a curated permission preset
@@ -61,13 +62,13 @@ export function AuthorizationsSection() {
       help="One-click apply a curated permission preset to your agent CLIs (user-global). Instead of approving tools one prompt at a time, pick a trust tier and let the app write the allow-rules into the CLI's own settings."
     >
       <Field label="Preset" help={activePreset?.description}>
-        <select value={tier} onChange={(e) => setTier(e.target.value as AuthorizationTier)}>
-          {AUTHORIZATION_PRESETS.map((p) => (
-            <option key={p.tier} value={p.tier}>
-              {p.label}
-            </option>
-          ))}
-        </select>
+        <PopoverPicklist
+          ariaLabel="Authorization preset"
+          value={tier}
+          searchable={false}
+          onChange={(nextTier) => setTier(nextTier as AuthorizationTier)}
+          options={AUTHORIZATION_PRESETS.map((preset) => ({ value: preset.tier, label: preset.label }))}
+        />
       </Field>
 
       <div className="settings-field">

--- a/src/renderer/components/settings/ExperimentalTab.tsx
+++ b/src/renderer/components/settings/ExperimentalTab.tsx
@@ -1,5 +1,6 @@
 import type { AppConfig } from '@shared/types';
 import { Section, Field, CheckboxField } from './FormFields';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 
 /**
  * Experimental settings — opt-in features still under evaluation. Each is OFF by
@@ -87,14 +88,17 @@ export function ExperimentalTab({
               dictation. No separate voice key is needed.
             </p>
             <Field label="Transcription model">
-              <select
+              <PopoverPicklist
                 value={config.voiceModel ?? 'whisper-1'}
-                onChange={(e) => onUpdate({ voiceModel: e.target.value })}
-              >
-                <option value="whisper-1">whisper-1</option>
-                <option value="gpt-4o-transcribe">gpt-4o-transcribe</option>
-                <option value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe</option>
-              </select>
+                ariaLabel="Transcription model"
+                searchable={false}
+                onChange={(voiceModel) => onUpdate({ voiceModel })}
+                options={[
+                  { value: 'whisper-1', label: 'whisper-1' },
+                  { value: 'gpt-4o-transcribe', label: 'gpt-4o-transcribe' },
+                  { value: 'gpt-4o-mini-transcribe', label: 'gpt-4o-mini-transcribe' }
+                ]}
+              />
             </Field>
             <Field label="Language" help="ISO-639-1 code (e.g. 'en', 'fr'). Leave empty for auto-detect.">
               <input

--- a/src/renderer/components/settings/GlobalTab.tsx
+++ b/src/renderer/components/settings/GlobalTab.tsx
@@ -4,6 +4,7 @@ import { useUi } from '../../store';
 import { Section, Field, CheckboxField } from './FormFields';
 import { DoctorSection } from './DoctorSection';
 import { AuthorizationsSection } from './AuthorizationsSection';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 
 interface GlobalTabProps {
   config: AppConfig;
@@ -24,14 +25,17 @@ export function GlobalTab({
     <>
       <Section anchorId="appearance" title="Appearance">
         <Field label="Theme">
-          <select
+          <PopoverPicklist
             value={config.theme}
-            onChange={(e) => onUpdate({ theme: e.target.value as AppConfig['theme'] })}
-          >
-            <option value="system">System</option>
-            <option value="dark">Dark</option>
-            <option value="light">Light</option>
-          </select>
+            ariaLabel="Theme"
+            searchable={false}
+            onChange={(theme) => onUpdate({ theme: theme as AppConfig['theme'] })}
+            options={[
+              { value: 'system', label: 'System' },
+              { value: 'dark', label: 'Dark' },
+              { value: 'light', label: 'Light' }
+            ]}
+          />
         </Field>
       </Section>
 

--- a/src/renderer/components/settings/HarnessTab.tsx
+++ b/src/renderer/components/settings/HarnessTab.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { CheckCircle2, XCircle, RefreshCw, ChevronRight } from 'lucide-react';
 import type { AppConfig, HarnessFamily, HarnessVerifyResult, LaunchProfileId } from '@shared/types';
-import { executionMappingOptions, type HarnessAdapterDescriptor } from '@shared/harness-adapter';
+import type { HarnessAdapterDescriptor } from '@shared/harness-adapter';
 import { useData } from '../../store';
 import { profileIcon } from '../../util/profileIcon';
 import { Section, Field, ToggleSwitch, ChipField, TextArgsField } from './FormFields';
 import { HarnessOptionSelect } from '../HarnessOptionSelect';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 import { providerUiSchema } from '@shared/launch-provider';
 
 const USE_HARNESS_DEFAULT = { id: '', label: 'Use harness default' } as const;
@@ -165,15 +166,17 @@ function HarnessRow({
     <Field label="Default Provider" help={providerRelationship === 'fixed-provider'
       ? `${h.label} uses this fixed provider.`
       : 'Selects which provider’s models appear below. Combined provider/model harnesses encode this choice in the model id.'}>
-      <select
+      <PopoverPicklist
         value={selectedProvider}
+        ariaLabel="Default provider"
+        searchable={false}
         disabled={providerRelationship === 'fixed-provider'}
-        onChange={(event) => {
+        onChange={(nextProvider) => {
           const byAdapter = { ...(config.harnessRouting?.byAdapter ?? {}) };
           const current = byAdapter[h.family] ?? {};
           const modelStillMatches = modelTargets.some((target) =>
-            target.id === current.modelTargetId && (!target.provider || target.provider === event.target.value));
-          const providerTargetId = event.target.value || undefined;
+            target.id === current.modelTargetId && (!target.provider || target.provider === nextProvider));
+          const providerTargetId = nextProvider || undefined;
           const next = {
             ...current,
             providerTargetId,
@@ -186,23 +189,25 @@ function HarnessRow({
           }
           void onUpdate({ harnessRouting: Object.keys(byAdapter).length ? { schemaVersion: 1, byAdapter } : undefined });
         }}
-      >
-        {providerRelationship !== 'fixed-provider' && <option value="">Use harness default</option>}
-        {providerTargets.map((provider) => <option key={provider.id} value={provider.id}>{provider.label}</option>)}
-      </select>
+        options={[
+          ...(providerRelationship !== 'fixed-provider' ? [{ value: '', label: 'Use harness default' }] : []),
+          ...providerTargets.map((provider) => ({ value: provider.id, label: provider.label }))
+        ]}
+      />
     </Field>
   ) : null;
   const modelLevelField = modelTargets.length ? (
     <Field label="Default Model Level" help={`Native ${h.label} models with their portable model-level mapping.`}>
-      <select
+      <PopoverPicklist
         value={selectedModelTarget}
-        onChange={(event) => {
+        ariaLabel="Default model level"
+        onChange={(modelTargetId) => {
           const byAdapter = { ...(config.harnessRouting?.byAdapter ?? {}) };
           const current = byAdapter[h.family] ?? {};
-          if (event.target.value) {
+          if (modelTargetId) {
             byAdapter[h.family] = {
               ...current,
-              modelTargetId: event.target.value,
+              modelTargetId,
               modelLevel: undefined
             };
           } else {
@@ -214,26 +219,28 @@ function HarnessRow({
         }}
         disabled={!descriptor?.availability.enabled || !descriptor?.availability.installed}
         title={!descriptor?.availability.enabled || !descriptor?.availability.installed ? descriptor?.availability.reason ?? 'Harness unavailable' : undefined}
-      >
-        <option value="">Use harness default</option>
-        {visibleModels.map((target) => (
-          <option key={target.id} value={target.id}>
-            {target.label}{target.level ? ` [${portableLabel(target.level)}]` : ''}
-          </option>
-        ))}
-      </select>
+        options={[
+          { value: '', label: 'Use harness default' },
+          ...visibleModels.map((target) => ({
+            value: target.id,
+            label: `${target.label}${target.level ? ` [${portableLabel(target.level)}]` : ''}`
+          }))
+        ]}
+      />
     </Field>
   ) : null;
   const executionMapping = descriptor?.targets?.executionStateMapping;
   const executionStateField = executionMapping && h.family !== 'codex' ? (
     <Field label="Default Execution State" help={`Native ${h.label} execution policies with their portable execution-state mapping.`}>
-      <select
+      <PopoverPicklist
         value={config.harnessRouting?.byAdapter?.[h.family]?.executionState ?? ''}
-        onChange={(event) => {
+        ariaLabel="Default execution state"
+        searchable={false}
+        onChange={(executionState) => {
           const byAdapter = { ...(config.harnessRouting?.byAdapter ?? {}) };
           const current = byAdapter[h.family] ?? {};
-          if (event.target.value) {
-            byAdapter[h.family] = { ...current, executionState: event.target.value as 'plan' | 'interactive' | 'accept-edits' | 'autonomous' };
+          if (executionState) {
+            byAdapter[h.family] = { ...current, executionState: executionState as 'plan' | 'interactive' | 'accept-edits' | 'autonomous' };
           } else {
             const { executionState: _state, ...rest } = current;
             if (Object.keys(rest).length) byAdapter[h.family] = rest;
@@ -242,12 +249,14 @@ function HarnessRow({
           void onUpdate({ harnessRouting: Object.keys(byAdapter).length ? { schemaVersion: 1, byAdapter } : undefined });
         }}
         disabled={!descriptor?.availability.enabled || !descriptor?.availability.installed}
-      >
-        <option value="">Use harness default</option>
-        {executionMappingOptions(executionMapping).map(({ id, native, states }) => (
-          <option key={id} value={id}>{native} [{states.map(portableLabel).join(', ')}]</option>
-        ))}
-      </select>
+        options={[
+          { value: '', label: 'Use harness default' },
+          ...Object.entries(executionMapping).map(([state, native]) => ({
+            value: state,
+            label: `${native} [${portableLabel(state)}]`
+          }))
+        ]}
+      />
     </Field>
   ) : null;
 
@@ -435,19 +444,22 @@ export function HarnessTab({
         label="Default thinking level"
         help="Passed as ‘pi --thinking <level>’ — PI’s extended-reasoning budget. ‘Default’ ⇒ emit no flag (PI decides)."
       >
-        <select
+        <PopoverPicklist
           value={config.piThinking ?? 'default'}
-          onChange={(e) => onUpdate({ piThinking: e.target.value as AppConfig['piThinking'] })}
-        >
-          <option value="default">Default</option>
-          <option value="off">Off</option>
-          <option value="minimal">Minimal</option>
-          <option value="low">Low</option>
-          <option value="medium">Medium</option>
-          <option value="high">High</option>
-          <option value="xhigh">XHigh</option>
-          <option value="max">Max</option>
-        </select>
+          ariaLabel="Default thinking level"
+          searchable={false}
+          onChange={(piThinking) => onUpdate({ piThinking: piThinking as AppConfig['piThinking'] })}
+          options={[
+            { value: 'default', label: 'Default' },
+            { value: 'off', label: 'Off' },
+            { value: 'minimal', label: 'Minimal' },
+            { value: 'low', label: 'Low' },
+            { value: 'medium', label: 'Medium' },
+            { value: 'high', label: 'High' },
+            { value: 'xhigh', label: 'XHigh' },
+            { value: 'max', label: 'Max' }
+          ]}
+        />
       </Field>
     </>
   );
@@ -518,27 +530,21 @@ export function HarnessTab({
         {descriptors === null ? (
           <span className="settings-help" role="status">Loading harness default…</span>
         ) : (
-          <select
+          <PopoverPicklist
             value={config.defaultHarness ?? 'claude'}
-            onChange={(event) => {
-              const defaultHarness = event.target.value as AppConfig['defaultHarness'];
+            ariaLabel="Default harness"
+            onChange={(nextHarness) => {
+              const defaultHarness = nextHarness as AppConfig['defaultHarness'];
               onConfigDraft({ ...config, defaultHarness });
               void onUpdate({ defaultHarness });
             }}
-          >
-            {defaultHarnessOptions.map((descriptor) => (
-              <option
-                key={descriptor.id}
-                value={descriptor.id}
-                disabled={
-                  (descriptor.id !== 'shell' && optionAvailability.get(descriptor.id)?.installed === false) ||
-                   (descriptor.id !== 'shell' && !!ENABLE_KEY[descriptor.id] && config[ENABLE_KEY[descriptor.id]!] !== true)
-                }
-              >
-                {descriptor.label}{descriptor.availability.installed ? '' : ' (not installed)'}
-              </option>
-            ))}
-          </select>
+            options={defaultHarnessOptions.map((descriptor) => ({
+              value: descriptor.id,
+              label: `${descriptor.label}${descriptor.availability.installed ? '' : ' (not installed)'}`,
+              disabled: (descriptor.id !== 'shell' && optionAvailability.get(descriptor.id)?.installed === false) ||
+                (descriptor.id !== 'shell' && !!ENABLE_KEY[descriptor.id] && config[ENABLE_KEY[descriptor.id]!] !== true)
+            }))}
+          />
         )}
       </Field>
       {defaultUnavailable && (

--- a/src/renderer/components/settings/ProjectTab.tsx
+++ b/src/renderer/components/settings/ProjectTab.tsx
@@ -10,11 +10,12 @@ import type {
   LaunchProfileId,
   ProjectExecutionConsentGrant
 } from '@shared/types';
-import { executionMappingOptions, type HarnessAdapterDescriptor } from '@shared/harness-adapter';
+import type { HarnessAdapterDescriptor } from '@shared/harness-adapter';
 import { providerUiSchema } from '@shared/launch-provider';
 import { useData, useUi } from '../../store';
 import { Section, Field, ChipField, TextArgsField } from './FormFields';
 import { HarnessOptionSelect } from '../HarnessOptionSelect';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 import { profileIcon } from '../../util/profileIcon';
 
 const USE_DEFAULT = { id: '', label: 'Use default' } as const;
@@ -409,18 +410,19 @@ export function ProjectHarnessSettings({ project, onSaved }: { project: Project;
         {descriptors === null || !settingsReady ? (
           <span className="settings-help" role="status">Loading project harness settings...</span>
         ) : (
-          <select value={current} onChange={(event) => save(event.target.value)}>
-            <option value="">Use global default</option>
-            {options.map((entry) => (
-              <option
-                key={entry.id}
-                value={entry.id}
-                disabled={!entry.availability.enabled || !entry.availability.installed}
-              >
-                {entry.label}
-              </option>
-            ))}
-          </select>
+          <PopoverPicklist
+            ariaLabel="Default harness"
+            value={current}
+            onChange={save}
+            options={[
+              { value: '', label: 'Use global default' },
+              ...options.map((entry) => ({
+                value: entry.id,
+                label: entry.label,
+                disabled: !entry.availability.enabled || !entry.availability.installed
+              }))
+            ]}
+          />
         )}
       </Field>
       {settingsError && <ProjectSettingsError message={settingsError} />}
@@ -459,13 +461,15 @@ export function ProjectHarnessSettings({ project, onSaved }: { project: Project;
                     <Field label="Default Provider" help={descriptor.targets.providerModelRelationship === 'fixed-provider'
                       ? `${descriptor.label} uses this fixed provider.`
                       : 'Selects which provider’s models appear below. Combined provider/model harnesses encode this choice in the model id.'}>
-                      <select
+                      <PopoverPicklist
                         value={routing?.providerTargetId
                           ?? descriptor.targets.models.find((target) => target.id === routing?.modelTargetId)?.provider
                           ?? (descriptor.targets.providerModelRelationship === 'fixed-provider' ? descriptor.targets.providers[0]?.id : '')}
+                        ariaLabel="Default provider"
+                        searchable={false}
                         disabled={descriptor.targets.providerModelRelationship === 'fixed-provider'}
-                        onChange={(event) => {
-                          const providerTargetId = event.target.value || undefined;
+                        onChange={(providerId) => {
+                          const providerTargetId = providerId || undefined;
                           const currentModel = descriptor.targets?.models.find((target) => target.id === routing?.modelTargetId);
                           saveRouting(id, {
                             providerTargetId,
@@ -474,37 +478,41 @@ export function ProjectHarnessSettings({ project, onSaved }: { project: Project;
                               : {})
                           });
                         }}
-                      >
-                        {descriptor.targets.providerModelRelationship !== 'fixed-provider' && <option value="">Use global default</option>}
-                        {descriptor.targets.providers.map((provider) => <option key={provider.id} value={provider.id}>{provider.label}</option>)}
-                      </select>
+                        options={[
+                          ...(descriptor.targets.providerModelRelationship !== 'fixed-provider' ? [{ value: '', label: 'Use global default' }] : []),
+                          ...descriptor.targets.providers.map((provider) => ({ value: provider.id, label: provider.label }))
+                        ]}
+                      />
                     </Field>
                   )}
                   {!!descriptor.targets?.models.length && (
                     <Field label="Default Model Level" help={`Native ${descriptor.label} models with portable mappings.`}>
-                      <select
+                      <PopoverPicklist
                         value={routing?.modelTargetId ?? ''}
-                        onChange={(event) => saveRouting(id, { modelTargetId: event.target.value || undefined })}
+                        ariaLabel="Default model level"
+                        onChange={(modelTargetId) => saveRouting(id, { modelTargetId: modelTargetId || undefined })}
                         disabled={unavailable}
                         title={unavailable ? descriptor.availability.reason ?? 'Harness unavailable' : undefined}
-                      >
-                        <option value="">Use global default</option>
-                        {descriptor.targets.models
+                        options={[
+                          { value: '', label: 'Use global default' },
+                          ...descriptor.targets.models
                           .filter((target) => !routing?.providerTargetId || !target.provider || target.provider === routing.providerTargetId)
-                          .map((target) => (
-                          <option key={target.id} value={target.id}>
-                            {target.label}{target.level ? ` [${portableLabel(target.level)}]` : ''}
-                          </option>
-                        ))}
-                      </select>
+                          .map((target) => ({
+                            value: target.id,
+                            label: `${target.label}${target.level ? ` [${portableLabel(target.level)}]` : ''}`
+                          }))
+                        ]}
+                      />
                     </Field>
                   )}
                   {executionMapping && id !== 'codex' && (
                     <Field label="Default Execution State" help={`Native ${descriptor.label} policies with portable mappings.`}>
-                      <select
+                      <PopoverPicklist
                         value={routing?.executionState ?? ''}
-                        onChange={(event) => saveRouting(id, {
-                          executionState: (event.target.value || undefined) as
+                        ariaLabel="Default execution state"
+                        searchable={false}
+                        onChange={(executionState) => saveRouting(id, {
+                          executionState: (executionState || undefined) as
                             | 'plan'
                             | 'interactive'
                             | 'accept-edits'
@@ -513,12 +521,14 @@ export function ProjectHarnessSettings({ project, onSaved }: { project: Project;
                         })}
                         disabled={unavailable}
                         title={unavailable ? descriptor.availability.reason ?? 'Harness unavailable' : undefined}
-                      >
-                        <option value="">Use global default</option>
-                        {executionMappingOptions(executionMapping).map(({ id, native, states }) => (
-                          <option key={id} value={id}>{native} [{states.map(portableLabel).join(', ')}]</option>
-                        ))}
-                      </select>
+                        options={[
+                          { value: '', label: 'Use global default' },
+                          ...Object.entries(executionMapping).map(([state, native]) => ({
+                            value: state,
+                            label: `${native} [${portableLabel(state)}]`
+                          }))
+                        ]}
+                      />
                     </Field>
                   )}
                   {id === 'claude' && (
@@ -559,18 +569,20 @@ export function ProjectWorktreeIsolationField({
       label="Worktree isolation"
       help="Controls the initial Worktree choice for new agents in this project. Main still verifies the folder is a Git repository before creating a worktree."
     >
-      <select
+      <PopoverPicklist
         value={selected}
         disabled={disabled}
-        onChange={(event) => {
-          const next = event.target.value;
+        ariaLabel="Worktree isolation"
+        searchable={false}
+        onChange={(next) => {
           onChange(next === 'on' ? true : next === 'off' ? false : undefined);
         }}
-      >
-        <option value="inherit">Use global default</option>
-        <option value="on">Always use worktrees</option>
-        <option value="off">Never use worktrees</option>
-      </select>
+        options={[
+          { value: 'inherit', label: 'Use global default' },
+          { value: 'on', label: 'Always use worktrees' },
+          { value: 'off', label: 'Never use worktrees' }
+        ]}
+      />
     </Field>
   );
 }
@@ -657,19 +669,22 @@ function PiProjectLaunchFields({
         />
       </Field>
       <Field label="Default Thinking Level" help="Passed to PI as --thinking. Leave Default selected to inherit PI's native behavior.">
-        <select
+        <PopoverPicklist
           value={settings.piThinking ?? 'default'}
-          onChange={(event) => save({ piThinking: event.target.value as ProjectSettings['piThinking'] })}
-        >
-          <option value="default">Default</option>
-          <option value="off">Off</option>
-          <option value="minimal">Minimal</option>
-          <option value="low">Low</option>
-          <option value="medium">Medium</option>
-          <option value="high">High</option>
-          <option value="xhigh">XHigh</option>
-          <option value="max">Max</option>
-        </select>
+          ariaLabel="Default thinking level"
+          searchable={false}
+          onChange={(piThinking) => save({ piThinking: piThinking as ProjectSettings['piThinking'] })}
+          options={[
+            { value: 'default', label: 'Default' },
+            { value: 'off', label: 'Off' },
+            { value: 'minimal', label: 'Minimal' },
+            { value: 'low', label: 'Low' },
+            { value: 'medium', label: 'Medium' },
+            { value: 'high', label: 'High' },
+            { value: 'xhigh', label: 'XHigh' },
+            { value: 'max', label: 'Max' }
+          ]}
+        />
       </Field>
     </>
   );
@@ -994,13 +1009,15 @@ function ClaudeScopeCardInner({
       </header>
 
       <Field label="Default permission mode">
-        <select
+        <PopoverPicklist
           value={perm.defaultMode ?? ''}
-          onChange={(e) =>
+          ariaLabel="Default permission mode"
+          searchable={false}
+          onChange={(defaultMode) =>
             onSave({
               permissions: {
                 ...perm,
-                defaultMode: (e.target.value || undefined) as
+                defaultMode: (defaultMode || undefined) as
                   | 'default'
                   | 'acceptEdits'
                   | 'plan'
@@ -1009,13 +1026,14 @@ function ClaudeScopeCardInner({
               }
             })
           }
-        >
-          <option value="">Unset</option>
-          <option value="default">Default</option>
-          <option value="acceptEdits">Accept Edits</option>
-          <option value="plan">Plan</option>
-          <option value="bypassPermissions">Bypass Permissions</option>
-        </select>
+          options={[
+            { value: '', label: 'Unset' },
+            { value: 'default', label: 'Default' },
+            { value: 'acceptEdits', label: 'Accept Edits' },
+            { value: 'plan', label: 'Plan' },
+            { value: 'bypassPermissions', label: 'Bypass Permissions' }
+          ]}
+        />
       </Field>
 
       <Field label="Model" help="Top-level `model` override (e.g. opus, sonnet, haiku).">

--- a/src/renderer/components/settings/PromptsTab.tsx
+++ b/src/renderer/components/settings/PromptsTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { FolderOpen, Play, RotateCcw, Loader2 } from 'lucide-react';
 import type { LlmPromptEntry, LlmProviderId, LlmRunResult } from '@shared/types';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 
 /**
  * Providers offered in the editor, in display order. `base` is the human label;
@@ -224,18 +225,18 @@ export function PromptsTab() {
 
                 <div className="prompts-row">
                   <PField label="Provider">
-                    <select
+                    <PopoverPicklist
                       value={draft.provider ?? 'claude-cli'}
-                      onChange={(e) =>
-                        setDraft({ ...draft, provider: e.target.value as LlmProviderId })
+                      ariaLabel="Provider"
+                      onChange={(provider) =>
+                        setDraft({ ...draft, provider: provider as LlmProviderId })
                       }
-                    >
-                      {providerOptions.map((p) => (
-                        <option key={p.id} value={p.id} disabled={!p.enabled}>
-                          {p.label}
-                        </option>
-                      ))}
-                    </select>
+                      options={providerOptions.map((provider) => ({
+                        value: provider.id,
+                        label: provider.label,
+                        disabled: !provider.enabled
+                      }))}
+                    />
                   </PField>
                   <PField label="Model" help="Alias (haiku/sonnet/opus) or full id. Blank = default.">
                     <input

--- a/src/renderer/components/settings/ScopeControl.tsx
+++ b/src/renderer/components/settings/ScopeControl.tsx
@@ -1,5 +1,6 @@
 import type { Project } from '@shared/types';
 import { sortProjectsForDisplay, useUi } from '../../store';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 
 /**
  * Scope control in the Settings content header: a `Global | Project-Specific`
@@ -57,19 +58,18 @@ export function ScopeControl({
         </div>
       )}
       {(isProjectScope || !allowGlobal) && (
-        <select
+        <PopoverPicklist
           className="settings-scope-select"
           value={selectedProjectId ?? ''}
-          onChange={(e) => selectProject(e.target.value || null)}
-          aria-label="Project"
-        >
-          {!allowGlobal && <option value="">Select a project…</option>}
-          {sorted.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name}
-            </option>
-          ))}
-        </select>
+          ariaLabel="Project"
+          onChange={(projectId) => selectProject(projectId || null)}
+          placeholder="Select a project…"
+          searchPlaceholder="Search projects"
+          options={[
+            ...(!allowGlobal ? [{ value: '', label: 'Select a project…' }] : []),
+            ...sorted.map((project) => ({ value: project.id, label: project.name }))
+          ]}
+        />
       )}
     </div>
   );

--- a/src/renderer/components/settings/TerminalTab.tsx
+++ b/src/renderer/components/settings/TerminalTab.tsx
@@ -7,6 +7,7 @@ import {
   type TerminalThemeId
 } from '@shared/terminalThemes';
 import { Section, Field, CheckboxField } from './FormFields';
+import { PopoverPicklist } from '../ui/PopoverPicklist';
 
 /**
  * Terminal settings — everything scoped to the embedded terminal itself
@@ -58,16 +59,13 @@ export function TerminalTab({
           label="Terminal theme"
           help="Color palette for the terminal, independent of the app theme. ‘Auto’ follows the app’s light/dark mode. Applies live to open terminals."
         >
-          <select
+          <PopoverPicklist
             value={config.terminalTheme ?? DEFAULT_TERMINAL_THEME}
-            onChange={(e) => onUpdate({ terminalTheme: e.target.value as TerminalThemeId })}
-          >
-            {TERMINAL_THEME_OPTIONS.map((opt) => (
-              <option key={opt.id} value={opt.id}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+            ariaLabel="Terminal theme"
+            searchable={false}
+            onChange={(terminalTheme) => onUpdate({ terminalTheme: terminalTheme as TerminalThemeId })}
+            options={TERMINAL_THEME_OPTIONS.map((option) => ({ value: option.id, label: option.label }))}
+          />
         </Field>
         <Field label="Terminal font size" help="Range 10–20. Affects new tabs.">
           <input
@@ -115,14 +113,17 @@ export function TerminalTab({
           label="tmux session persistence"
           help="Back sessions with tmux so they survive an app restart or a dropped SSH connection. A durability feature, not a speed-up — it does not make terminals faster. Needs tmux installed; ignored on Windows or when tmux is absent. Off: never wrap. Remote only: wrap SSH sessions only — the strongest use case (surviving a dropped link) — and skip the extra tmux server for local runs that don't need it. All sessions: wrap local and remote (the default)."
         >
-          <select
+          <PopoverPicklist
             value={config.tmuxScope ?? 'all'}
-            onChange={(e) => onUpdate({ tmuxScope: e.target.value as AppConfig['tmuxScope'] })}
-          >
-            <option value="off">Off</option>
-            <option value="remote">Remote only</option>
-            <option value="all">All sessions</option>
-          </select>
+            ariaLabel="tmux session persistence"
+            searchable={false}
+            onChange={(tmuxScope) => onUpdate({ tmuxScope: tmuxScope as AppConfig['tmuxScope'] })}
+            options={[
+              { value: 'off', label: 'Off' },
+              { value: 'remote', label: 'Remote only' },
+              { value: 'all', label: 'All sessions' }
+            ]}
+          />
         </Field>
         <div className="settings-field">
           <span className="settings-label">Runtime status</span>

--- a/src/renderer/components/settings/__tests__/ProjectHarnessSettings.test.tsx
+++ b/src/renderer/components/settings/__tests__/ProjectHarnessSettings.test.tsx
@@ -42,10 +42,8 @@ describe('ProjectHarnessSettings', () => {
       <ProjectWorktreeIsolationField value={false} onChange={vi.fn()} />
     );
     expect(html).toContain('Worktree isolation');
-    expect(html).toContain('Use global default');
-    expect(html).toContain('Always use worktrees');
     expect(html).toContain('Never use worktrees');
-    expect(html).toContain('<option value="off" selected="">Never use worktrees</option>');
+    expect(html).toContain('aria-label="Worktree isolation"');
   });
 
   it('renders one default harness control and per-harness accordion rows', () => {

--- a/src/renderer/components/ui/PopoverPicklist.tsx
+++ b/src/renderer/components/ui/PopoverPicklist.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { Check, ChevronDown, Search } from 'lucide-react';
 import { useExclusivePopover } from '../../util/useExclusivePopover';
+
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 export interface PopoverPicklistOption<T extends string> {
   value: T;
@@ -13,6 +15,8 @@ export interface PopoverPicklistOption<T extends string> {
   className?: string;
   /** Renders a group header above the first option of a new group, in list order. */
   group?: string;
+  /** Keeps an unavailable choice visible without allowing it to be selected. */
+  disabled?: boolean;
 }
 
 export interface PopoverPicklistProps<T extends string> {
@@ -23,6 +27,7 @@ export interface PopoverPicklistProps<T extends string> {
   onChange: (value: T) => void;
   placeholder?: string;
   disabled?: boolean;
+  title?: string;
   searchable?: boolean;
   searchPlaceholder?: string;
   emptyHint?: string;
@@ -42,8 +47,8 @@ export interface PopoverPicklistProps<T extends string> {
 /**
  * Generic single-select popover: a trigger button + a portal-rendered,
  * optionally searchable options menu. Generalizes the popover pattern the
- * project and model pickers each hand-rolled, so a new dropdown doesn't fall
- * back to a plain native `<select>`. Reuses the `launch-model-picker-*` CSS
+ * project and model pickers each hand-rolled, so a new dropdown does not fall
+ * back to a plain native menu. Reuses the `launch-model-picker-*` CSS
  * classes those pickers already share.
  */
 export function PopoverPicklist<T extends string>({
@@ -54,6 +59,7 @@ export function PopoverPicklist<T extends string>({
   onChange,
   placeholder = 'Select…',
   disabled,
+  title,
   searchable = true,
   searchPlaceholder = 'Search…',
   emptyHint = 'No matches',
@@ -69,6 +75,8 @@ export function PopoverPicklist<T extends string>({
   const menuRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const wasOpenRef = useRef(false);
+  const menuId = useId();
+  const [activeIndex, setActiveIndex] = useState(0);
   const selected = options.find((option) => option.value === value);
   const visibleOptions = useMemo(() => {
     if (!searchable) return options;
@@ -77,8 +85,49 @@ export function PopoverPicklist<T extends string>({
       ? options.filter((option) => option.label.toLowerCase().includes(normalizedQuery))
       : options;
   }, [options, query, searchable]);
+  const activeOption = visibleOptions[activeIndex];
 
-  useLayoutEffect(() => {
+  const optionId = (option: PopoverPicklistOption<T>) => `${menuId}-${option.value}`;
+  const selectOption = (option: PopoverPicklistOption<T> | undefined) => {
+    if (!option || option.disabled) return;
+    onChange(option.value);
+    setOpen(false);
+  };
+  const moveActive = (direction: 1 | -1) => {
+    if (visibleOptions.length === 0) return;
+    setActiveIndex((current) => {
+      for (let offset = 1; offset <= visibleOptions.length; offset += 1) {
+        const index = (current + direction * offset + visibleOptions.length) % visibleOptions.length;
+        if (!visibleOptions[index].disabled) return index;
+      }
+      return current;
+    });
+  };
+  const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement | HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      moveActive(1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      moveActive(-1);
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      const index = visibleOptions.findIndex((option) => !option.disabled);
+      if (index >= 0) setActiveIndex(index);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      const index = visibleOptions.length - 1 - [...visibleOptions].reverse().findIndex((option) => !option.disabled);
+      if (index >= 0) setActiveIndex(index);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      selectOption(activeOption);
+    }
+  };
+
+  useIsomorphicLayoutEffect(() => {
     if (!open || !triggerRef.current) return;
     const rect = anchorToParent
       ? triggerRef.current.parentElement?.getBoundingClientRect() ?? triggerRef.current.getBoundingClientRect()
@@ -112,13 +161,21 @@ export function PopoverPicklist<T extends string>({
 
   useEffect(() => {
     if (open) {
+      const selectedIndex = visibleOptions.findIndex((option) => option.value === value && !option.disabled);
+      const firstEnabledIndex = visibleOptions.findIndex((option) => !option.disabled);
+      setActiveIndex(selectedIndex >= 0 ? selectedIndex : Math.max(0, firstEnabledIndex));
       if (searchable) searchRef.current?.focus();
+      else menuRef.current?.focus();
     } else {
       setQuery('');
       if (wasOpenRef.current) triggerRef.current?.focus();
     }
     wasOpenRef.current = open;
-  }, [open, searchable]);
+  }, [open, searchable, value]);
+
+  useEffect(() => {
+    if (activeIndex >= visibleOptions.length) setActiveIndex(0);
+  }, [activeIndex, visibleOptions.length]);
 
   return (
     <>
@@ -128,9 +185,17 @@ export function PopoverPicklist<T extends string>({
         type="button"
         className={`${triggerClassName} ${className}`}
         disabled={disabled}
+        title={title}
         onClick={() => setOpen((current) => !current)}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            setOpen(true);
+          }
+        }}
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
         aria-label={ariaLabel}
       >
         <span>{selected?.label ?? placeholder}</span>
@@ -141,7 +206,11 @@ export function PopoverPicklist<T extends string>({
           ref={menuRef}
           className="launch-model-picker-menu"
           role="listbox"
+          id={menuId}
+          tabIndex={-1}
           aria-label={ariaLabel}
+          aria-activedescendant={activeOption ? optionId(activeOption) : undefined}
+          onKeyDown={handleMenuKeyDown}
           style={position ? { left: position.left, top: position.top, width: position.width } : { visibility: 'hidden' }}
         >
           {searchable && (
@@ -153,6 +222,8 @@ export function PopoverPicklist<T extends string>({
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder={searchPlaceholder}
                 aria-label={searchPlaceholder}
+                aria-activedescendant={activeOption ? optionId(activeOption) : undefined}
+                onKeyDown={handleMenuKeyDown}
               />
             </div>
           )}
@@ -163,10 +234,16 @@ export function PopoverPicklist<T extends string>({
               )}
               <button
                 type="button"
-                className={`launch-model-picker-option${option.className ? ` ${option.className}` : ''}${value === option.value ? ' is-selected' : ''}`}
+                id={optionId(option)}
+                className={`launch-model-picker-option${option.className ? ` ${option.className}` : ''}${value === option.value ? ' is-selected' : ''}${activeIndex === index ? ' is-active' : ''}`}
                 role="option"
                 aria-selected={value === option.value}
-                onClick={() => { onChange(option.value); setOpen(false); }}
+                aria-disabled={option.disabled || undefined}
+                disabled={option.disabled}
+                tabIndex={-1}
+                onMouseEnter={() => setActiveIndex(index)}
+                onFocus={() => setActiveIndex(index)}
+                onClick={() => selectOption(option)}
               >
                 {option.content ?? <span>{option.label}</span>}
                 {value === option.value && <Check size={14} aria-hidden="true" />}

--- a/src/renderer/components/ui/__tests__/PopoverPicklist.test.ts
+++ b/src/renderer/components/ui/__tests__/PopoverPicklist.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('PopoverPicklist', () => {
+  it('supports disabled choices and keyboard navigation without restoring native selects', () => {
+    const source = readFileSync(new URL('../PopoverPicklist.tsx', import.meta.url), 'utf8');
+
+    expect(source).toContain('disabled?: boolean');
+    expect(source).toContain('aria-haspopup="listbox"');
+    expect(source).toContain('aria-activedescendant');
+    expect(source).toContain("event.key === 'ArrowDown'");
+    expect(source).toContain("event.key === 'ArrowUp'");
+    expect(source).toContain("event.key === 'Enter'");
+    expect(source).not.toContain('<select');
+  });
+});

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -18787,6 +18787,24 @@ button.zana-assign-trigger.is-unassigned .zana-assign-caret {
   opacity: 0.55;
 }
 
+.settings-field .launch-model-picker-trigger,
+.scheduler-form-field .launch-model-picker-trigger {
+  background: var(--bg-base);
+  padding: 7px 10px;
+}
+
+.settings-field .launch-model-picker-trigger {
+  font-size: 13px;
+}
+
+.scheduler-form-field .launch-model-picker-trigger {
+  font-size: 12px;
+}
+
+.scheduler-form-field .launch-model-picker-trigger:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-blue) 20%, transparent);
+}
+
 .launch-model-picker-menu {
   position: fixed;
   z-index: 400;
@@ -18839,6 +18857,7 @@ button.zana-assign-trigger.is-unassigned .zana-assign-caret {
 }
 
 .launch-model-picker-option:hover,
+.launch-model-picker-option.is-active,
 .launch-model-picker-option.is-selected {
   background: var(--bg-hover);
 }
@@ -19982,6 +20001,10 @@ button.launch-persona {
 .launch-folder-select:focus-visible {
   outline: none;
   border-color: var(--accent-blue);
+}
+
+.launch-folder .launch-model-picker-trigger {
+  width: auto;
 }
 
 /* "+" in the Agents list header. agents-count owns margin-left:auto, so when

--- a/src/renderer/util/useExclusivePopover.ts
+++ b/src/renderer/util/useExclusivePopover.ts
@@ -40,7 +40,7 @@ export function useExclusivePopover(): readonly [boolean, (next: boolean | ((cur
   const idRef = useRef<symbol | null>(null);
   if (!idRef.current) idRef.current = Symbol('popover');
   const id = idRef.current;
-  const isCurrentlyOpen = useSyncExternalStore(subscribe, () => isOpen(id));
+  const isCurrentlyOpen = useSyncExternalStore(subscribe, () => isOpen(id), () => false);
 
   const setOpen = (next: boolean | ((current: boolean) => boolean)) => {
     const resolved = typeof next === 'function' ? next(isOpen(id)) : next;

--- a/templates/extension-starter/agent-preset/CLAUDE.md
+++ b/templates/extension-starter/agent-preset/CLAUDE.md
@@ -24,6 +24,14 @@ user what this agent is FOR — its role, voice, and boundaries — and write a 
 `systemPrompt`. Tune `label`, `description`, `icon`, `model`, and
 `initialPrompt` (the opening message injected once the session is live) to match.
 
+## Optional panel controls
+
+If you keep the optional companion panel, do **not** render native `select`
+menus. Use a semantic button plus `host.quickPick(items, { title, placeholder })`
+for changing or long lists, button groups with `aria-pressed` for two to four
+fixed modes, and labelled native checkboxes for booleans. Use documented theme
+variables rather than importing core renderer components or copying their CSS.
+
 ## The trust boundary
 
 Your edits are **INERT** until packed + installed — either you call the

--- a/templates/extension-starter/main-panel/CLAUDE.md
+++ b/templates/extension-starter/main-panel/CLAUDE.md
@@ -52,6 +52,17 @@ Your panel's root element must fill it — `height: '100%'` (or `flex: 1`) + its
 own `overflow: 'auto'`. The starter already does this; keep it. Put an inner
 `max-width` only where reading width matters, never on the root.
 
+## Controls — match the host UI
+
+Do **not** render native `select` menus. For projects, people, teams, or any
+changing/long list, use a semantic button that awaits `host.quickPick(items,
+{ title, placeholder })`; it is searchable, theme-aware, and returns `null` on
+cancel. For two to four fixed modes, use a button group with `aria-pressed`; for
+a boolean, use a labelled native checkbox. Keep every input and textarea
+programmatically labelled. Do not import core renderer components or copy their
+CSS — use documented theme variables plus `host.quickPick`, `host.confirm`, and
+`host.prompt` for host-owned interactions.
+
 ## Build / iterate loop
 
 1. Edit `dist/main.mjs` (capabilities) and/or `dist/renderer.js` (UI) and

--- a/templates/extension-starter/mcp-consumer/CLAUDE.md
+++ b/templates/extension-starter/mcp-consumer/CLAUDE.md
@@ -50,6 +50,16 @@ user to approve it the first time, like any tool with a real side effect.
   workspace-scoped server child; omit it (or pass `useGlobal: true`) for the
   global (`~`) workspace child.
 
+## Controls — match the host UI
+
+Do **not** render native `select` menus. Use a semantic button plus
+`host.quickPick(items, { title, placeholder })` for projects, MCP-provided
+records, and other changing/long lists; it is searchable, theme-aware, and
+returns `null` on cancel. Use button groups with `aria-pressed` for two to four
+fixed modes and a labelled native checkbox for booleans. Do not import core
+renderer components or copy their CSS — use documented theme variables and the
+host dialog APIs instead.
+
 ## Build / iterate loop
 
 1. Wire the real server id + tool (see FIRST TASK above), then edit `dist/main.mjs`

--- a/templates/extension-starter/panel/CLAUDE.md
+++ b/templates/extension-starter/panel/CLAUDE.md
@@ -49,6 +49,19 @@ This starter is renderer-only and needs **no build step** — edit
 `dist/renderer.js` directly. If you introduce a bundler later, make sure the
 manifest's `entry.renderer` still points at the built file under `dist/`.
 
+## Controls — match the host UI
+
+- Do **not** render native `select` menus. For projects, people, teams, or any
+  changing/long list, use a semantic button that awaits `host.quickPick(items,
+  { title, placeholder })`. It is searchable, theme-aware, and returns `null`
+  on cancel; an empty string can still be a valid choice.
+- For two to four fixed modes, render an explicit button group with
+  `aria-pressed`; for a boolean, prefer a labelled native checkbox. Keep inputs
+  and textareas visibly and programmatically labelled.
+- Do not import core renderer components or copy their CSS. They are host
+  internals; build your own layout with documented theme variables and use
+  `host.quickPick` / `host.confirm` / `host.prompt` for host-owned interactions.
+
 ## Cleanup & reaching host outside React
 
 - **Subscriptions auto-dispose.** `host.on(event, cb)` and `host.subscribe(...)`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noEmit": true,
     "paths": {
       "@shared/*": ["./src/shared/*"],
+      "@renderer/*": ["./src/renderer/*"],
       "@zana-ai/zcc-extension-sdk": ["./packages/extension-sdk/src/index.ts"],
       "@zana-ai/zcc-extension-sdk/*": ["./packages/extension-sdk/src/*"],
       "@zcc/harness-sdk": ["./packages/harness-sdk/src/index.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,7 +36,8 @@ export default defineConfig({
         find: /^@zcc\/harness-sdk\/(.*)$/,
         replacement: resolve(__dirname, 'packages/harness-sdk/src/$1.ts')
       },
-      { find: '@shared', replacement: resolve(__dirname, 'src/shared') }
+      { find: '@shared', replacement: resolve(__dirname, 'src/shared') },
+      { find: '@renderer', replacement: resolve(__dirname, 'src/renderer') }
     ]
   }
 });


### PR DESCRIPTION
## Summary
- replace core renderer native selects with the shared searchable popover picker
- extend picker keyboard navigation, disabled options, and SSR support
- document the public host quick-pick API in extension skill and starter templates
- convert the built-in Slack project selector and expose the renderer alias for built-in plugins

## Verification
- `git diff --check`
- focused suite passed before rebasing: `npm test -- src/main/__tests__/local-extension-kinds.test.ts src/main/__tests__/local-extension.test.ts plugins/slack src/renderer/components/ui/__tests__/PopoverPicklist.test.ts` (125 tests)
- current isolated worktree lacks dependencies, so the same suite cannot run here (`vitest: command not found`).

## Notes
- no unrelated working-tree changes are included.