### PR TITLE
feat(website): refresh product experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm run dev
 
 ## What You Can Do
 
-- **Run coding agents in parallel.** Launch real PTY sessions for Claude Code, Cursor, Codex, Pi, OpenCode, or a plain shell. Choose the CLI, model, and execution mode per persona or launch.
+- **Run coding agents in parallel.** Launch real PTY sessions for Claude Code, Codex, Pi, OpenCode, or a plain shell. Choose the CLI, model, and execution mode per persona or launch.
 - **Work across local and remote projects.** Keep local folders and SSH projects in one workspace, each with its own terminals, agents, explorer, settings, and project-scoped views.
 - **Monitor the agent fleet.** Use Home, the Agents board, activity feeds, and notifications to find working, idle, blocked, and completed sessions without hunting through terminal tabs.
 - **Coordinate human decisions.** Agents can publish reports, questions, and other results to the Inbox. Reply from an Inbox question to route an answer back to the waiting session. Follow-ups preserve decisions that need human input.

--- a/docs/extensions-authoring.md
+++ b/docs/extensions-authoring.md
@@ -44,7 +44,7 @@ The host discovers extensions under `~/.zcc/extensions/<id>/`:
 | `permissions` | Capabilities the extension intends to use. **Enforced deny-by-default for disk extensions** (P3-B) — see below. |
 | `permissionScopes` | Scopes for `exec`/`fs:*`/`net`/`mcp`/`stream` (`execAllowlist`, `fsRoots`, `egressAllowlist`, `mcpAllowlist`, `streamAllowlist`) — see below. |
 | `projectTab` | Optional. Opt the renderer panel into a **per-project tab** (alongside Terminals / Explorer / Tickets). `{ label?, icon?, order? }`. See [Per-project tabs](#per-project-tabs-projecttab). |
-| `agentPreset` | Optional. Contribute a **framework preset** to the Advanced Quick-Agent launcher — a primer that boots a Claude session already understanding your framework. `{ systemPrompt, label?, description?, icon?, initialPrompt?, model?, baseProfile? }`. See [Framework presets](#framework-presets-agentpreset). |
+| `agentPreset` | Optional. Contribute a **framework preset** to the Advanced Quick-Agent launcher — a primer that boots a supported harness session already understanding your framework. `{ systemPrompt, label?, description?, icon?, initialPrompt?, model?, baseProfile? }`. See [Framework presets](#framework-presets-agentpreset). |
 | `skills` | Optional `SKILL.md` contributions, deployed only with `agent:contribute`. See [Contributing Skills & MCP servers](#contributing-skills--mcp-servers-agentcontribute). |
 | `mcpServers` | Optional MCP server definitions owned by this extension, deployed only with `agent:contribute`. See [Contributing Skills & MCP servers](#contributing-skills--mcp-servers-agentcontribute). |
 
@@ -529,7 +529,7 @@ view).
 Some extensions wrap a whole *way of working* — an orchestration surface, a CLI,
 a decision ritual. Declaring `agentPreset` lets your extension contribute a
 **framework preset** to the Advanced view of the Quick-Agent launcher (Agents →
-"+" → **Advanced** → **Framework**). Picking it spawns a Claude session with your
+"+" → **Advanced** → **Framework**). Picking it spawns a harness session with your
 `systemPrompt` injected via `--append-system-prompt`, so the agent boots already
 fluent in your framework's concepts, tools, and conventions — no per-launch
 copy-paste of a primer.
@@ -632,7 +632,7 @@ Key facts:
 ## Contributing Skills & MCP servers (`agent:contribute`)
 
 Unlike Personas/Teams (pure in-memory data ZCC owns end-to-end), a **skill** is
-a `SKILL.md` file every Claude Code session on the machine can load, and an
+a `SKILL.md` file compatible agent sessions on the machine can load, and an
 **MCP server** contribution is a server *definition* your extension owns (an
 arbitrary `command`/`args`/`url`) — both are artifacts that outlive your
 process and are consumed by `claude` CLI processes ZCC doesn't control. So
@@ -823,7 +823,7 @@ rejected (`PermissionDenied`) and audited.
 | `projects:read` | reading the open-project list / active project |
 | `projects:select` | changing the shell's selected project |
 | `session:reply` | `host.replyToSession(...)` / `host.writeToSession(...)` — writing to an existing terminal |
-| `session:launch` | `host.launchSession(...)` — launching a Claude tab |
+| `session:launch` | `host.launchSession(...)` — launching an agent tab |
 | `external:open` | `host.openExternal(url)` — opening an http(s) URL |
 | `inbox:push` | `host.pushInbox(...)` / `ctx.inbox.push(...)` — pushing a durable inbox entry |
 | `ssh:hosts` | `ctx.sshHosts` — contributing structured SSH hosts to the remote-project picker |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,14 +1,13 @@
 # Getting started
 
-Zana Command Center (ZCC) turns Claude Code from a single terminal into a
-**multi-project cockpit**: run many `claude` sessions at once, see which ones
+Zana Command Center (ZCC) turns supported coding harnesses into a
+**multi-project cockpit**: run many agent sessions at once, see which ones
 need you versus which are still working, reply to them, and drive multi-agent
 workflows — all from one window.
 
 This guide takes you from a fresh install to your first orchestrated agent in
-about five minutes. It assumes you already use [Claude
-Code](https://claude.com/claude-code); ZCC runs real `claude` sessions, not a
-wrapper around them.
+about five minutes. ZCC launches the native CLI for Claude Code, OpenCode,
+Codex, or Pi rather than wrapping the harness in a generic chat UI.
 
 ```mermaid
 flowchart LR
@@ -26,10 +25,9 @@ flowchart LR
 Download the app from the [**Download**](/download/) page and open it. macOS is
 available today; Windows and Linux are on the way.
 
-**Prerequisites:** [Node](https://nodejs.org) 20 or newer, `git`, and the
-[`claude`](https://claude.com/claude-code) CLI on your `PATH`. ZCC launches
-`claude` for every session, so if `claude` works in your terminal, it works in
-ZCC.
+**Prerequisites:** [Node](https://nodejs.org) 20 or newer, `git`, and at least
+one supported harness CLI on your `PATH`: Claude Code, OpenCode, Codex, or Pi.
+If the harness works in your terminal, ZCC can launch its native session.
 
 On first launch the app opens to an empty cockpit — no projects yet. That's the
 next step.
@@ -52,14 +50,13 @@ navigable.
 
 ## 3. Spawn your first agent
 
-Open a project and start a session. Every tab is a **real PTY running
-`claude`** — a genuine Claude Code session, with the same behavior, tools, and
-permissions you already know.
+Open a project and start a session. Every tab is a **real PTY running the
+selected harness** with its native behavior, tools, and permissions.
 
 - Hit **New agent** (or the `+` in the workspace) to open a session in the
   current project.
-- The session starts in the project's directory, so `claude` sees the right
-  files immediately.
+- The session starts in the project's directory, so the selected harness sees
+  the right files immediately.
 - Type your task and let it work — exactly as you would in a standalone
   terminal.
 

--- a/docs/releases/1.0.4.md
+++ b/docs/releases/1.0.4.md
@@ -4,7 +4,7 @@ This is our biggest update yet — more ways to run agents, safer automation, an
 
 ## ✨ New
 
-- **Run agents with Cursor and Codex, not just Claude.** Pick the coding assistant you prefer when you launch an agent.
+- **Run agents with Codex, not just Claude.** Pick the coding assistant you prefer when you launch an agent.
 - **Give each agent its own workspace.** Agents can now work in their own isolated copy of your project, so parallel agents never step on each other's changes. Each agent card shows the branch it's working on.
 - **Next Steps.** Agents can now suggest concrete follow-up actions you can run with one click — each with a short reason why. Reports link to their related next steps.
 - **Ask-me-anything prompts, in the app.** When an agent needs a decision, it can ask you a question right in the app instead of only in the terminal.
@@ -28,4 +28,4 @@ This is our biggest update yet — more ways to run agents, safer automation, an
 
 ---
 
-_Some new capabilities (Cursor/Codex agents, approve-for-me, isolated workspaces) start turned off — enable them in Settings when you're ready._
+_Some new capabilities (Codex agents, approve-for-me, isolated workspaces) start turned off — enable them in Settings when you're ready._

--- a/docs/releases/1.0.9.md
+++ b/docs/releases/1.0.9.md
@@ -27,7 +27,7 @@ A big one: a new Home dashboard for the whole workspace, per-agent model and CLI
 - **Long-running terminals stay healthy.** The app now independently cleans up dead terminal sessions on a regular schedule (not only when a recurring job happens to run), preventing a slow leak that could eventually stop new agents from launching after long uptime or sleep/wake cycles.
 - **Smoother startup.** The app recovers gracefully if its own startup bookkeeping fails partway through, and several under-the-hood hardening fixes reduce the chance of state getting corrupted or out of sync.
 - **Copying a file path from the Inbox works reliably.** It no longer silently fails when the app window isn't focused.
-- **"Yolo" (unrestricted) launch profiles work again** for Claude, Codex, and Cursor when no specific execution target is set.
+- **"Yolo" (unrestricted) launch profiles work again** for Claude and Codex when no specific execution target is set.
 - **OpenCode agents behave more consistently.** Sessions get proper auto-generated tab names, restarts resume the exact conversation you were in, remote OpenCode sessions are more stable, and the live status panel now shows real file/model/token details instead of staying empty.
 - **Goal automation no longer gets stuck retrying forever** when an agent fails to launch — it now counts against the same retry budget as any other stalled attempt and gives up gracefully instead of hammering retries indefinitely.
 - **Various extension polish.** Text inside extension panels can be selected again, and an extension is now validated up front at install time to catch problems earlier.

--- a/docs/using-zana.md
+++ b/docs/using-zana.md
@@ -25,8 +25,8 @@ From the board you can:
   auto-close-idle.
 - **Close** a session when its work is done.
 
-Each tab is a real `claude` PTY, so anything you'd do in a standalone Claude
-Code session works here too.
+Each tab is a real harness PTY, so the native Claude Code, OpenCode, Codex, or
+Pi workflow remains available inside Zana.
 
 ### Keeping the fleet tidy
 

--- a/website/app/components/BrowserFrame.tsx
+++ b/website/app/components/BrowserFrame.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface BrowserFrameProps {
+  title: string;
+  badge?: string;
+  caption?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+/** A shared, semantic frame for all app screenshots and their placeholders. */
+export function BrowserFrame({ title, badge, caption, className = '', children }: BrowserFrameProps) {
+  return (
+    <figure className={`browser-frame ${className}`}>
+      <div className="browser-frame-chrome">
+        <span className="browser-frame-controls" aria-hidden="true">
+          <i /><i /><i />
+        </span>
+        <span className="browser-frame-title">{title}</span>
+        {badge && <span className="browser-frame-badge">{badge}</span>}
+      </div>
+      <div className="browser-frame-content">{children}</div>
+      {caption && <figcaption>{caption}</figcaption>}
+    </figure>
+  );
+}

--- a/website/app/components/Fairy.tsx
+++ b/website/app/components/Fairy.tsx
@@ -1,8 +1,7 @@
 /**
  * The fairy — an Art-Nouveau figure in gold linework, floating with a wish-orb
  * that releases dandelion seeds. Ported from the Zana framework website's
- * `Fairy.astro`; adapted to JSX and to the ZCC theme (its gold/forest palette
- * reads on both the cream light theme and the warm dark theme).
+ * `Fairy.astro`; adapted to JSX and the app's blue/gold visual system.
  *
  * Animations (flutter / glow / drift + the hover on the wrapper) live in
  * globals.css and are fully disabled under `prefers-reduced-motion: reduce`.

--- a/website/app/components/HarnessStrip.tsx
+++ b/website/app/components/HarnessStrip.tsx
@@ -1,0 +1,14 @@
+const HARNESSES = ['Claude Code', 'OpenCode', 'Codex', 'Pi'] as const;
+
+export function HarnessStrip() {
+  return (
+    <div className="harness-strip" aria-label="Supported coding harnesses">
+      <span>Works with</span>
+      <ul>
+        {HARNESSES.map((harness) => (
+          <li key={harness}>{harness}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/website/app/components/Nav.tsx
+++ b/website/app/components/Nav.tsx
@@ -1,15 +1,18 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { site } from '@/lib/site';
 
 const LINKS = [
+  { href: '/how-it-works/', label: 'How it works' },
   { href: '/features/', label: 'Features' },
+  { href: '/extensions/', label: 'Extensions' },
   { href: '/marketplace/', label: 'Marketplace' },
   { href: '/docs/', label: 'Docs' },
-  { href: '/dashboard/', label: 'Publish an extension' }
+  { href: '/dashboard/', label: 'Publish' }
 ];
 
 function ThemeToggle() {
@@ -73,7 +76,8 @@ export function Nav() {
     <nav className="nav">
       <div className="wrap">
         <Link href="/" className="brand">
-          <span className="mark">Z</span> Zana Command Center
+          <Image className="brand-mark" src="/favicon.svg" alt="" width={28} height={28} priority />
+          Zana Command Center
         </Link>
 
         <div className="nav-links desktop">
@@ -82,7 +86,7 @@ export function Nav() {
               {l.label}
             </Link>
           ))}
-          <a href={site.repo} target="_blank" rel="noopener noreferrer">GitHub ↗</a>
+          <a href={site.repo} target="_blank" rel="noopener noreferrer">GitHub <span aria-hidden="true">↗</span></a>
           <div className="nav-cta">
             <ThemeToggle />
             <Link href="/download/" className="btn btn-primary btn-sm">
@@ -116,7 +120,7 @@ export function Nav() {
               {l.label}
             </Link>
           ))}
-          <a href={site.repo} target="_blank" rel="noopener noreferrer">GitHub ↗</a>
+          <a href={site.repo} target="_blank" rel="noopener noreferrer">GitHub <span aria-hidden="true">↗</span></a>
           <Link href="/download/" className="btn btn-primary">
             ⬇ Download
           </Link>
@@ -137,16 +141,18 @@ export function Footer() {
         <div className="foot-top">
           <div>
             <span className="foot-brand">
-              <span className="mark">Z</span> Zana Command Center
+              <Image className="brand-mark" src="/favicon.svg" alt="" width={28} height={28} />
+              Zana Command Center
             </span>
             <p className="foot-blurb">
-              An Electron cockpit for Claude Code — orchestrate many sessions across every project, from one
-              window.
+              A desktop control plane for Claude Code, OpenCode, Codex, and Pi sessions across every project.
             </p>
           </div>
           <div className="foot-col">
             <h4>Product</h4>
+            <Link href="/how-it-works/">How it works</Link>
             <Link href="/features/">Features</Link>
+            <Link href="/extensions/">Extensions</Link>
             <Link href="/marketplace/">Marketplace</Link>
             <Link href="/download/">Download</Link>
             <Link href="/dashboard/">Publish an extension</Link>

--- a/website/app/components/ProductShot.tsx
+++ b/website/app/components/ProductShot.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Image from 'next/image';
+import { BrowserFrame } from './BrowserFrame';
+import { productShot, type ProductShotId } from '@/lib/product-shots';
+
+interface ProductShotProps {
+  id: ProductShotId;
+  priority?: boolean;
+  className?: string;
+}
+
+/**
+ * Renders a reviewed product image when its registry entry has `src`; otherwise
+ * it preserves the final layout with an explicit, easy-to-replace placeholder.
+ */
+export function ProductShot({ id, priority = false, className = '' }: ProductShotProps) {
+  const shot = productShot(id);
+  return (
+    <BrowserFrame
+      title={shot.title}
+      badge={shot.src ? 'Product screenshot' : 'Screenshot placeholder'}
+      className={`product-shot product-shot-${shot.aspectRatio} ${className}`}
+      caption={
+        <>
+          <strong>{shot.caption}</strong>
+          {!shot.src && <span className="product-shot-capture">Replace with: {shot.capture}</span>}
+        </>
+      }
+    >
+      {shot.src ? (
+        <div className="product-shot-image">
+          <Image src={shot.src} alt={shot.alt} fill priority={priority} sizes="(max-width: 760px) 100vw, 960px" />
+        </div>
+      ) : (
+        <div className="product-shot-placeholder" aria-hidden="true">
+          <div className="product-shot-placeholder-grid" />
+          <div className="product-shot-placeholder-panel product-shot-placeholder-panel-main">
+            <span className="product-shot-placeholder-kicker">ZANA PRODUCT SHOT</span>
+            <strong>{shot.title}</strong>
+            <span>Real application screenshot goes here</span>
+          </div>
+          <div className="product-shot-placeholder-panel product-shot-placeholder-panel-meta">
+            <span>Capture target</span>
+            <p>{shot.capture}</p>
+          </div>
+        </div>
+      )}
+    </BrowserFrame>
+  );
+}

--- a/website/app/docs/DocLayout.tsx
+++ b/website/app/docs/DocLayout.tsx
@@ -46,6 +46,49 @@ function DocsPager({ slug }: { slug: string }) {
   );
 }
 
+function DocsNextStep({ slug }: { slug: string }) {
+  const nextSteps: Partial<Record<string, { title: string; body: string; href: string; action: string }>> = {
+    'getting-started': {
+      title: 'See the operating model',
+      body: 'Follow the visual walkthrough for the project, session, Agents board, and Inbox loop.',
+      href: '/how-it-works/',
+      action: 'Take the product tour'
+    },
+    'using-zana': {
+      title: 'Explore every product surface',
+      body: 'Use the visual feature catalog to find the right workflow for your next task.',
+      href: '/features/',
+      action: 'Explore features'
+    },
+    'extensions-quickstart': {
+      title: 'Use the visual extension workflow',
+      body: 'See the scaffold-to-reload loop, then return here for the exact code and commands.',
+      href: '/extensions/getting-started/',
+      action: 'Open extension quickstart'
+    },
+    'extensions-authoring': {
+      title: 'Choose an extension task',
+      body: 'The extension hub separates installation, first-panel authoring, and the SDK boundary.',
+      href: '/extensions/',
+      action: 'Open extension hub'
+    },
+    'extensions-sdk-reference': {
+      title: 'Review the SDK as a workflow',
+      body: 'See how the manifest, renderer, optional main module, and permissions fit together.',
+      href: '/extensions/sdk/',
+      action: 'Open SDK overview'
+    }
+  };
+  const step = nextSteps[slug];
+  if (!step) return null;
+  return (
+    <aside className="docs-next-step" aria-label="Suggested next step">
+      <div><span>Suggested next step</span><h2>{step.title}</h2><p>{step.body}</p></div>
+      <Link className="btn btn-ghost" href={step.href}>{step.action} <span aria-hidden="true">→</span></Link>
+    </aside>
+  );
+}
+
 export async function DocLayout({ meta, html, toc }: { meta: DocMeta; html: string; toc: TocItem[] }) {
   const searchIndex = await buildSearchIndex();
   return (
@@ -69,8 +112,9 @@ export async function DocLayout({ meta, html, toc }: { meta: DocMeta; html: stri
           {/* mobile: sidebar collapses to a select */}
           <DocsSidebar active={meta.slug} mobile />
 
-          <article className="prose" dangerouslySetInnerHTML={{ __html: html }} />
-          <DocsPager slug={meta.slug} />
+           <article className="prose" dangerouslySetInnerHTML={{ __html: html }} />
+           <DocsNextStep slug={meta.slug} />
+           <DocsPager slug={meta.slug} />
           <DocsEnhancer slug={meta.slug} />
         </div>
 

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { DocLayout } from './DocLayout';
 import { DOCS, renderDoc } from '@/lib/docs';
 
@@ -19,5 +20,23 @@ export const metadata: Metadata = {
 export default async function DocsIndex() {
   const meta = DOCS[0];
   const { html, toc } = await renderDoc(meta);
-  return <DocLayout meta={meta} html={html} toc={toc} />;
+  return (
+    <>
+      <section className="docs-hub-hero">
+        <div className="wrap">
+          <div className="docs-hub-hero-copy" data-reveal>
+            <span className="eyebrow">Documentation</span>
+            <h1>Start with the task.<br /><span className="grad">Keep the reference close.</span></h1>
+            <p>Guides for operating Zana, building extensions, and running a marketplace. Each path leads to the same maintained public reference used by the product.</p>
+          </div>
+          <div className="docs-hub-paths" data-reveal-stagger>
+            <Link href="/docs/getting-started/"><span>New to Zana</span><strong>Set up your first project <b aria-hidden="true">→</b></strong></Link>
+            <Link href="/how-it-works/"><span>Understand the product</span><strong>Take the visual tour <b aria-hidden="true">→</b></strong></Link>
+            <Link href="/extensions/"><span>Build or install</span><strong>Open the extensions hub <b aria-hidden="true">→</b></strong></Link>
+          </div>
+        </div>
+      </section>
+      <DocLayout meta={meta} html={html} toc={toc} />
+    </>
+  );
 }

--- a/website/app/download/DownloadClient.tsx
+++ b/website/app/download/DownloadClient.tsx
@@ -80,7 +80,7 @@ export function DownloadClient() {
           ))}
         </div>
 
-        <div className="card" style={{ marginTop: 28 }}>
+        <div className="card build-source-card" style={{ marginTop: 28 }}>
           <h3>Build from source</h3>
           <p>Clone the repository, install dependencies, and run the development app:</p>
           <pre style={{ background: 'var(--bg-soft)', padding: 16, borderRadius: 10, overflowX: 'auto' }}>

--- a/website/app/download/page.tsx
+++ b/website/app/download/page.tsx
@@ -4,11 +4,11 @@ import { DownloadClient } from './DownloadClient';
 export const metadata: Metadata = {
   title: 'Download',
   description:
-    'Download Zana Command Center for macOS, Windows, and Linux — free, open, signed, and auto-updating.',
+    'Download Zana Command Center for macOS. Windows and Linux are coming soon.',
   alternates: { canonical: '/download/' },
   openGraph: {
     title: 'Download — Zana Command Center',
-    description: 'Free, open, and signed. Install in minutes on macOS, Windows, or Linux.',
+    description: 'Free, open, and signed. Install in minutes on macOS; Windows and Linux are coming soon.',
     url: '/download/',
     type: 'website',
     images: ['/opengraph-image']

--- a/website/app/extensions/getting-started/page.tsx
+++ b/website/app/extensions/getting-started/page.tsx
@@ -1,0 +1,117 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { ProductShot } from '../../components/ProductShot';
+
+export const metadata: Metadata = {
+  title: 'Build your first extension',
+  description: 'Create a renderer-only Zana extension, build it, install it, and see the panel reload inside the app.',
+  alternates: { canonical: '/extensions/getting-started/' }
+};
+
+const STEPS = [
+  ['1', 'Scaffold a small extension', 'Run the scaffolder to create the manifest, renderer entry, and build configuration. Start renderer-only so no permissions are required.'],
+  ['2', 'Describe the extension', 'Set a stable id, title, renderer entry, and compatible Zana API range in extension.json. This manifest is the host contract.'],
+  ['3', 'Return a panel', 'Default-export a RendererEntry. Its activate function receives the host React instance and permission-gated ModuleHost surface.'],
+  ['4', 'Build and install', 'Build the renderer bundle, then install the artifact from Extensions settings or copy it into the extension directory for the lowest-level loop.'],
+  ['5', 'Reload and refine', 'An editable local source connection lets a creator or shell session rebuild the source and reload the installed extension without an app restart.']
+] as const;
+
+const MANIFEST = `{
+  "id": "hello",
+  "title": "Hello",
+  "icon": "Sparkles",
+  "entry": { "renderer": "renderer.js" },
+  "engines": { "zccApi": "^1.0.0" },
+  "permissions": []
+}`;
+
+export default function ExtensionGettingStartedPage() {
+  return (
+    <>
+      <section className="guide-hero">
+        <div className="wrap">
+          <div className="guide-hero-copy" data-reveal>
+            <span className="eyebrow">Extension quickstart</span>
+            <h1>A working panel in<br /><span className="grad">five focused steps.</span></h1>
+            <p>Build a React panel that runs inside Zana using the host SDK. Begin with no permissions, then grow into capabilities only when the workflow calls for them.</p>
+            <div className="cta">
+              <a className="btn btn-primary btn-lg" href="#steps">Start building <span aria-hidden="true">↓</span></a>
+              <Link className="btn btn-ghost btn-lg" href="/extensions/sdk/">Understand the SDK</Link>
+            </div>
+          </div>
+          <ProductShot id="extension-panel-result" priority />
+        </div>
+      </section>
+
+      <section className="guide-prerequisites">
+        <div className="wrap" data-reveal>
+          <strong>Before you begin</strong>
+          <span>Node 20+, a local Zana installation, and a working TypeScript environment.</span>
+          <Link href="/download/">Get Zana <span aria-hidden="true">→</span></Link>
+        </div>
+      </section>
+
+      <section id="steps" className="guide-steps-section">
+        <div className="wrap">
+          <div className="guide-steps-head" data-reveal>
+            <span className="eyebrow">The build loop</span>
+            <h2>Small surface area, fast feedback.</h2>
+            <p>Everything begins with a renderer bundle. The host owns React, routes, permissions, and the extension lifecycle.</p>
+          </div>
+          <ol className="guide-steps" data-reveal-stagger>
+            {STEPS.map(([number, title, body]) => (
+              <li key={number}>
+                <span>{number}</span>
+                <div><h3>{title}</h3><p>{body}</p></div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="product-proof reverse" data-reveal>
+            <div className="product-proof-copy">
+              <span className="eyebrow">The starting manifest</span>
+              <h2>Declare the smallest useful extension.</h2>
+              <p>A renderer-only panel with an empty permissions list installs without a consent prompt. Add capabilities later only when you have a concrete need.</p>
+              <p style={{ marginTop: 20 }}><Link className="text-link" href="/docs/extensions-authoring/#manifest-extensionjson">Read the manifest contract <span aria-hidden="true">→</span></Link></p>
+            </div>
+            <pre className="guide-code"><code>{MANIFEST}</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="product-proof" data-reveal>
+            <div className="product-proof-copy">
+              <span className="eyebrow">A live local loop</span>
+              <h2>Keep the source editable and the result visible.</h2>
+              <p>Once the folder is connected as a local source, build changes can refresh the installed artifact without an application restart. This is the fastest way to refine the panel in real product context.</p>
+              <ul>
+                <li>Source remains in your working directory</li>
+                <li>Only the manifest and dist build are packaged for installation</li>
+                <li>Permission changes continue through the normal consent path</li>
+              </ul>
+            </div>
+            <ProductShot id="local-extension-workspace" />
+          </div>
+        </div>
+      </section>
+
+      <section className="guide-next-section">
+        <div className="wrap">
+          <div className="guide-next-card" data-reveal>
+            <div><span className="eyebrow">Continue when ready</span><h2>From a panel to a complete integration.</h2><p>Add project tabs, commands, persistent storage, contributions, or brokered main-side capabilities as the extension earns the extra complexity.</p></div>
+            <div className="guide-next-actions">
+              <Link className="btn btn-primary" href="/extensions/sdk/">Explore the SDK</Link>
+              <Link className="btn btn-ghost" href="/docs/extensions-quickstart/">Read the canonical quickstart</Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/website/app/extensions/install/page.tsx
+++ b/website/app/extensions/install/page.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { ProductShot } from '../../components/ProductShot';
+
+export const metadata: Metadata = {
+  title: 'Install extensions',
+  description: 'Understand marketplace, local folder, archive, and editable-source extension installation in Zana Command Center.',
+  alternates: { canonical: '/extensions/install/' }
+};
+
+const METHODS = [
+  ['Marketplace', 'Use when the extension is published to a registry.', 'Discover the capability, inspect its description and permissions, then install from Zana’s Extensions settings.'],
+  ['Local built folder', 'Use during private development or team testing.', 'Choose a folder containing extension.json and the current dist build. The host validates the artifact before it activates.'],
+  ['Published archive', 'Use when a registry is not part of the distribution path.', 'Install a packaged extension bundle through the same manifest and API-compatibility validation path.'],
+  ['Editable source', 'Use when you are actively authoring an extension.', 'Keep source connected locally so builds can reload the installed extension while preserving the normal permission model.']
+] as const;
+
+export default function ExtensionInstallPage() {
+  return (
+    <>
+      <section className="guide-hero">
+        <div className="wrap">
+          <div className="guide-hero-copy" data-reveal>
+            <span className="eyebrow">Install extensions</span>
+            <h1>Choose the source.<br /><span className="grad">Zana validates the rest.</span></h1>
+            <p>Extensions use one installation boundary whether they arrive from a marketplace, a local build folder, or a shareable archive. The host checks compatibility before an extension is allowed to run.</p>
+            <div className="cta"><Link className="btn btn-primary btn-lg" href="/marketplace/">Browse marketplace</Link><Link className="btn btn-ghost btn-lg" href="/extensions/getting-started/">Build one instead</Link></div>
+          </div>
+          <ProductShot id="extension-install" priority />
+        </div>
+      </section>
+
+      <section className="install-methods-section">
+        <div className="wrap">
+          <div className="section-head" data-reveal><span className="eyebrow">Four routes, one trust boundary</span><h2>Pick the distribution model that fits the work.</h2></div>
+          <div className="install-methods" data-reveal-stagger>
+            {METHODS.map(([title, use, description]) => <article key={title}><h3>{title}</h3><strong>{use}</strong><p>{description}</p></article>)}
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="product-proof reverse" data-reveal>
+            <div className="product-proof-copy">
+              <span className="eyebrow">Permissions are explicit</span>
+              <h2>Read the declared access before the extension receives it.</h2>
+              <p>Disk extensions declare what they need. Zana asks for consent and enforces the resulting grant, rather than treating an installed package as automatically trusted.</p>
+              <ul><li>Renderer-only panels can require no permissions</li><li>Scope is reviewed before capabilities are granted</li><li>Permission-widening updates require a new consent decision</li></ul>
+              <p style={{ marginTop: 20 }}><Link className="text-link" href="/extensions/sdk/#permissions">See the permission model <span aria-hidden="true">→</span></Link></p>
+            </div>
+            <ProductShot id="extension-consent" />
+          </div>
+        </div>
+      </section>
+
+      <section className="guide-next-section">
+        <div className="wrap"><div className="guide-next-card" data-reveal><div><span className="eyebrow">Need deeper detail?</span><h2>Use the reference for exact install and publishing commands.</h2><p>The public docs retain the detailed artifact, registry, API, and permission contract.</p></div><div className="guide-next-actions"><Link className="btn btn-primary" href="/docs/extensions-authoring/#install--dev-loop">Open authoring install guide</Link><Link className="btn btn-ghost" href="/docs/release-hosting/">Marketplace hosting</Link></div></div></div>
+      </section>
+    </>
+  );
+}

--- a/website/app/extensions/page.tsx
+++ b/website/app/extensions/page.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { ProductShot } from '../components/ProductShot';
+
+export const metadata: Metadata = {
+  title: 'Extensions',
+  description:
+    'Install, build, and publish Zana Command Center extensions with a task-oriented guide to the marketplace, SDK, permissions, and live reload workflow.',
+  alternates: { canonical: '/extensions/' },
+  openGraph: {
+    title: 'Extensions for Zana Command Center',
+    description: 'Install new capabilities or build your own with the Zana extension SDK.',
+    url: '/extensions/',
+    type: 'website',
+    images: ['/opengraph-image']
+  }
+};
+
+const PATHS = [
+  {
+    number: '01',
+    title: 'Install an extension',
+    body: 'Use the marketplace for published capabilities, or install a built folder or archive when you already have the extension.',
+    href: '/extensions/install/',
+    action: 'See installation paths'
+  },
+  {
+    number: '02',
+    title: 'Build your first panel',
+    body: 'Start with a renderer-only TypeScript extension. It has no permissions, so you can validate the host integration before adding complexity.',
+    href: '/extensions/getting-started/',
+    action: 'Start the quickstart'
+  },
+  {
+    number: '03',
+    title: 'Learn the SDK boundary',
+    body: 'Use the host API for panels, then add an optional main module only when your extension needs brokered capabilities or contributions.',
+    href: '/extensions/sdk/',
+    action: 'Explore the SDK'
+  }
+];
+
+export default function ExtensionsPage() {
+  return (
+    <>
+      <section className="extensions-hero">
+        <div className="wrap">
+          <div className="extensions-hero-copy" data-reveal>
+            <span className="eyebrow">The Zana extension system</span>
+            <h1>Shape the cockpit<br /><span className="grad">around your work.</span></h1>
+            <p>
+              Add panels, project tabs, commands, personas, teams, and optional main-side capabilities without
+              modifying Zana core. Start with the marketplace, then build only as much as your workflow needs.
+            </p>
+            <div className="cta">
+              <Link className="btn btn-primary btn-lg" href="/extensions/getting-started/">Build your first extension</Link>
+              <Link className="btn btn-ghost btn-lg" href="/marketplace/">Browse marketplace</Link>
+            </div>
+          </div>
+          <ProductShot id="extension-panel-result" priority />
+        </div>
+      </section>
+
+      <section className="extension-paths-section">
+        <div className="wrap">
+          <div className="section-head center" data-reveal>
+            <span className="eyebrow">Choose a starting point</span>
+            <h2>One system, three practical paths.</h2>
+            <p className="section-lede">The task pages explain the outcome first and lead into the canonical SDK documentation when you need detail.</p>
+          </div>
+          <div className="extension-paths" data-reveal-stagger>
+            {PATHS.map((path) => (
+              <Link key={path.number} className="extension-path-card" href={path.href}>
+                <span className="extension-path-number">{path.number}</span>
+                <h3>{path.title}</h3>
+                <p>{path.body}</p>
+                <span className="text-link">{path.action} <span aria-hidden="true">→</span></span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="wrap">
+          <div className="product-proof" data-reveal>
+            <div className="product-proof-copy">
+              <span className="eyebrow">Install with confidence</span>
+              <h2>Discover a capability, then review what it needs.</h2>
+              <p>
+                Marketplace entries describe what an extension contributes. If an extension requests capabilities,
+                Zana presents its declared scope before it can run.
+              </p>
+              <ul>
+                <li>Install published extensions from the same catalog the app reads</li>
+                <li>Use a local built folder or archive for private development workflows</li>
+                <li>Review declared permissions before an extension receives access</li>
+              </ul>
+              <p style={{ marginTop: 20 }}><Link className="text-link" href="/extensions/install/">Read the install guide <span aria-hidden="true">→</span></Link></p>
+            </div>
+            <ProductShot id="extension-install" />
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="product-proof reverse" data-reveal>
+            <div className="product-proof-copy">
+              <span className="eyebrow">A safe authoring loop</span>
+              <h2>Build locally. Reload live. Keep core untouched.</h2>
+              <p>
+                A local extension is an ordinary disk extension with an editable source folder. Build its manifest and
+                renderer bundle, then reload the installed build while you refine the experience.
+              </p>
+              <ul>
+                <li>Use the stable TypeScript SDK instead of internal app modules</li>
+                <li>Start with a renderer-only panel and no permission prompt</li>
+                <li>Add a main module only when you need brokered, scoped capabilities</li>
+              </ul>
+              <p style={{ marginTop: 20 }}><Link className="text-link" href="/extensions/getting-started/">Follow the five-minute quickstart <span aria-hidden="true">→</span></Link></p>
+            </div>
+            <ProductShot id="local-extension-workspace" />
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="extension-reference" data-reveal>
+            <div>
+              <span className="eyebrow">Reference when you need it</span>
+              <h2>Short path to action. Deep documentation behind it.</h2>
+              <p>Use the task guides for a visual workflow, then move into the maintained reference for contracts, permissions, lifecycle details, and publishing.</p>
+            </div>
+            <div className="extension-reference-links">
+              <Link href="/docs/extensions-quickstart/">Build your first extension <span aria-hidden="true">→</span></Link>
+              <Link href="/docs/extensions-authoring/">Extension authoring guide <span aria-hidden="true">→</span></Link>
+              <Link href="/docs/extensions-sdk-reference/">SDK reference <span aria-hidden="true">→</span></Link>
+              <Link href="/docs/extensions/">Extension architecture overview <span aria-hidden="true">→</span></Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/website/app/extensions/sdk/page.tsx
+++ b/website/app/extensions/sdk/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { ProductShot } from '../../components/ProductShot';
+
+export const metadata: Metadata = {
+  title: 'Extension SDK',
+  description: 'An approachable overview of the Zana Command Center extension SDK, host boundary, optional main module, and permission model.',
+  alternates: { canonical: '/extensions/sdk/' }
+};
+
+const SDK_LAYERS = [
+  ['Manifest', 'Declares identity, entry points, compatible API range, contributions, and requested permissions.'],
+  ['Renderer entry', 'Returns a panel through activate({ React, host }); the host provides React and the supported ModuleHost surface.'],
+  ['Optional main module', 'Handles capabilities that must execute outside the renderer through a brokered, permission-gated context.'],
+  ['Contributions', 'Adds commands, project tabs, personas, teams, agent capabilities, or other declared extension surfaces.']
+] as const;
+
+export default function ExtensionSdkPage() {
+  return (
+    <>
+      <section className="guide-hero">
+        <div className="wrap">
+          <div className="guide-hero-copy" data-reveal>
+            <span className="eyebrow">SDK overview</span>
+            <h1>Build against a stable host.<br /><span className="grad">Not app internals.</span></h1>
+            <p>The extension SDK is the public contract between your TypeScript code and Zana. Renderer panels use a provided host surface; main-side work is brokered and scope-checked.</p>
+            <div className="cta"><Link className="btn btn-primary btn-lg" href="/extensions/getting-started/">Start with a panel</Link><Link className="btn btn-ghost btn-lg" href="/docs/extensions-sdk-reference/">Open full SDK reference</Link></div>
+          </div>
+          <ProductShot id="sdk-main-module" priority />
+        </div>
+      </section>
+
+      <section className="sdk-layers-section">
+        <div className="wrap">
+          <div className="section-head center" data-reveal><span className="eyebrow">The contract</span><h2>Four layers, each with a clear responsibility.</h2></div>
+          <div className="sdk-layers" data-reveal-stagger>{SDK_LAYERS.map(([title, body], index) => <article key={title}><span>0{index + 1}</span><h3>{title}</h3><p>{body}</p></article>)}</div>
+        </div>
+      </section>
+
+      <section id="permissions" style={{ paddingTop: 0 }}>
+        <div className="wrap"><div className="product-proof" data-reveal><div className="product-proof-copy"><span className="eyebrow">The permission model</span><h2>Declare intent. Get consent. Run within scope.</h2><p>An extension does not receive broad system access just because it ships a main module. The effective grant is derived from declared permissions and user consent, then enforced at each brokered call.</p><ul><li>Use the smallest permission set that makes the feature possible</li><li>Keep filesystem roots and network or executable scopes explicit</li><li>Treat a wider permission request as a product decision users can evaluate</li></ul><p style={{ marginTop: 20 }}><Link className="text-link" href="/docs/extensions-authoring/#permissions-are-enforced-for-disk-extensions-p3-b">Read scoped permission details <span aria-hidden="true">→</span></Link></p></div><ProductShot id="extension-consent" /></div></div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap"><div className="product-proof reverse" data-reveal><div className="product-proof-copy"><span className="eyebrow">Use the host surface</span><h2>Panels receive what they need from Zana.</h2><p>Renderer entries use the supplied React instance and ModuleHost. That keeps extensions aligned with the host lifecycle and prevents fragile imports of core implementation details.</p><ul><li>Read selected project context and launch sessions through the host</li><li>Use storage, cache, events, toasts, inbox actions, and external links</li><li>Call only your extension’s main-side capabilities through the host bridge</li></ul></div><ProductShot id="extension-panel-result" /></div></div>
+      </section>
+
+      <section className="guide-next-section"><div className="wrap"><div className="guide-next-card" data-reveal><div><span className="eyebrow">Go deeper</span><h2>The reference contains the exact types, events, and lifecycle behavior.</h2><p>Use it as the source of truth while implementing, and return to these visual guides when you need to orient a new contributor.</p></div><div className="guide-next-actions"><Link className="btn btn-primary" href="/docs/extensions-sdk-reference/">Read SDK reference</Link><Link className="btn btn-ghost" href="/docs/extensions-authoring/">Read authoring guide</Link></div></div></div></section>
+    </>
+  );
+}

--- a/website/app/features/page.tsx
+++ b/website/app/features/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import { FEATURES } from '@/lib/features';
+import { ProductShot } from '../components/ProductShot';
+import type { ProductShotId } from '@/lib/product-shots';
 
 export const metadata: Metadata = {
   title: 'Features',
@@ -15,6 +17,16 @@ export const metadata: Metadata = {
   }
 };
 
+const FEATURE_SHOTS: Partial<Record<string, ProductShotId>> = {
+  cockpit: 'cockpit-overview',
+  'agents-board': 'agents-board',
+  inbox: 'inbox-decision',
+  orchestration: 'team-launch',
+  projects: 'project-setup',
+  scheduler: 'goal-or-ticket',
+  extensions: 'extension-panel-result'
+};
+
 export default function Features() {
   return (
     <>
@@ -27,8 +39,8 @@ export default function Features() {
             Everything the <span className="grad">cockpit</span> gives you.
           </h1>
           <p className="lede">
-            Zana Command Center turns Claude Code from a single terminal into a multi-project hub. Here is what
-            you actually get — grounded in the real app.
+            Zana Command Center turns supported coding harnesses into a multi-project fleet. Here is what you
+            actually get, grounded in the real app.
           </p>
         </div>
       </section>
@@ -42,7 +54,7 @@ export default function Features() {
             className="btn btn-sm btn-ghost"
             style={{ borderColor: 'var(--border)' }}
           >
-            <span aria-hidden="true">{f.ico}</span> {f.title}
+            {f.title}
           </a>
         ))}
       </div>
@@ -50,12 +62,9 @@ export default function Features() {
       {FEATURES.map((f, i) => (
         <section key={f.slug} id={f.slug} style={{ paddingTop: 40, paddingBottom: 40 }}>
           <div className="wrap">
-            <div className={`split ${i % 2 === 1 ? 'rev' : ''}`} data-reveal>
-              <div>
-                <span className="ico" style={{ display: 'inline-grid' }}>
-                  {f.ico}
-                </span>
-                <h2 style={{ marginTop: 14 }}>{f.title}</h2>
+              <div className={`product-proof ${i % 2 === 1 ? 'reverse' : ''}`} data-reveal>
+                <div>
+                <h2>{f.title}</h2>
                 <p style={{ color: 'var(--accent)', fontWeight: 600, marginBottom: 12 }}>{f.tagline}</p>
                 <p>{f.body}</p>
                 {f.docs && (
@@ -66,38 +75,11 @@ export default function Features() {
                   </p>
                 )}
               </div>
-              <div className="visual">
-                <div
-                  style={{
-                    fontSize: 11,
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.08em',
-                    color: 'var(--muted-2)',
-                    fontWeight: 700,
-                    marginBottom: 8
-                  }}
-                >
-                  What you get
-                </div>
-                <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
-                  {f.points.map((p) => (
-                    <li
-                      key={p}
-                      style={{
-                        color: 'var(--text-2)',
-                        padding: '10px 0 10px 28px',
-                        position: 'relative',
-                        fontSize: 14.5,
-                        borderBottom: '1px solid var(--border-soft)'
-                      }}
-                    >
-                      <span style={{ position: 'absolute', left: 0, top: 10, color: 'var(--accent-3)', fontWeight: 700 }}>✓</span>
-                      {p}
-                    </li>
-                  ))}
-                </ul>
+                {(() => {
+                  const shotId = FEATURE_SHOTS[f.slug];
+                  return shotId ? <ProductShot id={shotId} /> : null;
+                })()}
               </div>
-            </div>
           </div>
         </section>
       ))}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -7,48 +7,42 @@
    ========================================================================== */
 
 :root {
-  /* ---- brand ramp (stable across themes) ----
-     The Zana "fairy of the mountains" palette: forest green + moss for the
-     primary/brand gradient, warm gold for ornament & accents, cream ink. */
-  --brand: #2d5f3f;   /* forest */
-  --brand-2: #4a7856; /* moss */
-  --brand-3: #c9a961; /* gold */
-  --brand-ink: #faf6e8; /* cream */
-  /* raw palette (theme-independent) — decorative use */
-  --gold: #c9a961;
-  --gold-soft: #e5d4a1;
-  --forest: #2d5f3f;
-  --moss: #4a7856;
-  --berry: #8b3a4e;
+  /* ---- app-aligned brand ramp ---- */
+  --brand: #2f81f7;
+  --brand-2: #58a6ff;
+  --brand-3: #3fb950;
+  --brand-ink: #ffffff;
+  --gold: #d4a017;
+  --gold-soft: #e3b341;
 
-  /* ---- dark theme (default) — deep forest dusk ---- */
-  --bg: #0e1310;
-  --bg-soft: #131a15;
-  --panel: #161d17;
-  --panel-2: #1b241c;
-  --panel-3: #222c22;
-  --border: #2b352c;
-  --border-soft: #202a21;
-  --text: #f2efe4;
-  --text-2: #d2cdba;
-  --muted: #a7a48f;
-  --muted-2: #9a9682; /* AA: 6.4:1 on --bg #0e1310 (normal text) */
-  --accent: #c9a961;   /* gold — AA 8.4:1 on dark */
-  --accent-2: #e5d4a1; /* gold-soft */
-  --accent-3: #6fa97f; /* light moss — AA 6.9:1 on dark */
-  --accent-soft: rgba(201, 169, 97, 0.13);
-  --accent-border: rgba(201, 169, 97, 0.26);
-  --glow: rgba(201, 169, 97, 0.32);
-  --warn: #febc2e;   /* AA on dark surfaces */
-  --danger: #ff8a8a; /* AA on dark surfaces */
-  --code-bg: #0b0f0c;
-  --code-text: #dcd8c8;
+  /* ---- dark theme (default) — desktop app graphite ---- */
+  --bg: #0b0f15;
+  --bg-soft: #0d1117;
+  --panel: #10151c;
+  --panel-2: #161c25;
+  --panel-3: #1a212c;
+  --border: #2a3340;
+  --border-soft: #1f2731;
+  --text: #e6edf3;
+  --text-2: #c9d1d9;
+  --muted: #8b949e;
+  --muted-2: #8b949e;
+  --accent: #58a6ff;
+  --accent-2: #e3b341;
+  --accent-3: #3fb950;
+  --accent-soft: rgba(47, 129, 247, 0.13);
+  --accent-border: rgba(88, 166, 255, 0.36);
+  --glow: rgba(47, 129, 247, 0.28);
+  --warn: #e3b341;
+  --danger: #ff7b72;
+  --code-bg: #0d1117;
+  --code-text: #c9d1d9;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-md: 0 12px 32px -18px rgba(0, 0, 0, 0.85);
   --shadow-lg: 0 40px 120px -40px rgba(0, 0, 0, 0.9);
-  --ambient-1: rgba(201, 169, 97, 0.12);
-  --ambient-2: rgba(74, 120, 86, 0.1);
-  --selection: rgba(201, 169, 97, 0.3);
+  --ambient-1: rgba(47, 129, 247, 0.16);
+  --ambient-2: rgba(212, 160, 23, 0.08);
+  --selection: rgba(47, 129, 247, 0.34);
 
   /* ---- shared shape/scale ---- */
   --radius: 16px;
@@ -66,34 +60,33 @@
 }
 
 [data-theme="light"] {
-  /* Warm cream parchment — the fairy's daylight. */
-  --bg: #faf6e8;
-  --bg-soft: #f3ebd3;
-  --panel: #fffdf6;
-  --panel-2: #f7f1de;
-  --panel-3: #efe6cc;
-  --border: #e2d6b5;
-  --border-soft: #eaddc0;
-  --text: #1f2a24;   /* ink */
-  --text-2: #2d5f3f; /* forest — AA 6.9:1 on cream */
-  --muted: #5b6b5f;
-  --muted-2: #5f6c63; /* AA: ~4.9:1 on --bg cream (normal text) */
-  --accent: #2d5f3f;   /* forest — AA 6.9:1 on cream */
-  --accent-2: #8b3a4e; /* berry — AA 6.9:1 on cream */
-  --accent-3: #4a7856; /* moss */
-  --accent-soft: rgba(45, 95, 63, 0.08);
-  --accent-border: rgba(201, 169, 97, 0.4); /* gold hairline — decorative */
-  --glow: rgba(201, 169, 97, 0.28);
-  --warn: #9a6700;   /* AA: 4.6:1 on cream */
-  --danger: #8b3a4e; /* berry — AA 6.9:1 on cream */
-  --code-bg: #1f2a24;
-  --code-text: #e5d4a1;
+  --bg: #f6f8fa;
+  --bg-soft: #ffffff;
+  --panel: #ffffff;
+  --panel-2: #f0f3f6;
+  --panel-3: #e6ebf1;
+  --border: #b8c0c8;
+  --border-soft: #d8dee4;
+  --text: #1f2328;
+  --text-2: #343a40;
+  --muted: #57606a;
+  --muted-2: #57606a;
+  --accent: #0969da;
+  --accent-2: #7d5900;
+  --accent-3: #1a7f37;
+  --accent-soft: rgba(9, 105, 218, 0.08);
+  --accent-border: rgba(9, 105, 218, 0.32);
+  --glow: rgba(9, 105, 218, 0.2);
+  --warn: #7d5900;
+  --danger: #cf222e;
+  --code-bg: #0d1117;
+  --code-text: #c9d1d9;
   --shadow-sm: 0 1px 2px rgba(45, 42, 20, 0.06);
   --shadow-md: 0 12px 30px -16px rgba(60, 50, 20, 0.16);
   --shadow-lg: 0 40px 90px -44px rgba(60, 50, 20, 0.24);
-  --ambient-1: rgba(201, 169, 97, 0.16);
-  --ambient-2: rgba(74, 120, 86, 0.1);
-  --selection: rgba(201, 169, 97, 0.32);
+  --ambient-1: rgba(9, 105, 218, 0.12);
+  --ambient-2: rgba(184, 133, 18, 0.08);
+  --selection: rgba(9, 105, 218, 0.22);
   color-scheme: light;
 }
 
@@ -144,6 +137,8 @@ html {
 html, body {
   margin: 0;
   padding: 0;
+  max-width: 100%;
+  overflow-x: clip;
   background: var(--bg);
   color: var(--text);
   font-family: var(--font-sans);
@@ -211,27 +206,19 @@ h1, h2, h3, h4 {
 /* ================= NAV ================= */
 .nav {
   position: sticky; top: 0; z-index: 50;
-  background: color-mix(in srgb, var(--bg) 72%, transparent);
-  backdrop-filter: saturate(160%) blur(14px);
-  -webkit-backdrop-filter: saturate(160%) blur(14px);
+  background: var(--bg);
   border-bottom: 1px solid var(--border-soft);
 }
-.nav .wrap { display: flex; align-items: center; gap: 24px; height: var(--nav-h); }
+.nav .wrap { display: flex; align-items: center; gap: 20px; height: var(--nav-h); }
 .brand {
   font-weight: 700; letter-spacing: -0.02em; font-size: 15px;
   display: flex; align-items: center; gap: 10px; color: var(--text); flex: none;
 }
 .brand:hover { color: var(--text); }
-.brand .mark {
-  width: 28px; height: 28px; border-radius: 9px;
-  background: linear-gradient(135deg, var(--forest), var(--moss));
-  display: grid; place-items: center; font-size: 15px; font-weight: 700; color: var(--brand-ink);
-  font-family: var(--font-display);
-  box-shadow: 0 0 0 1px var(--accent-border), 0 6px 18px var(--glow);
-}
-.nav-links { display: flex; gap: 4px; margin-left: auto; align-items: center; font-size: 14px; }
+.brand-mark { width: 28px; height: 28px; flex: none; }
+.nav-links { display: flex; min-width: 0; gap: 3px; margin-left: auto; align-items: center; font-size: 14px; }
 .nav-links a:not(.btn) {
-  color: var(--muted); font-weight: 500; padding: 8px 12px; border-radius: 8px;
+  flex: none; white-space: nowrap; color: var(--muted); font-weight: 500; padding: 8px 10px; border-radius: 8px;
   transition: color 0.15s var(--ease), background 0.15s var(--ease);
 }
 .nav-links a:not(.btn):hover { color: var(--text); background: var(--panel-3); }
@@ -241,7 +228,7 @@ h1, h2, h3, h4 {
 
 /* theme toggle */
 .theme-toggle {
-  width: 38px; height: 38px; border-radius: 10px; flex: none;
+  width: 42px; height: 42px; border-radius: 10px; flex: none;
   display: grid; place-items: center; cursor: pointer;
   border: 1px solid var(--border); background: var(--panel-2); color: var(--muted);
   transition: all 0.16s var(--ease);
@@ -254,7 +241,7 @@ h1, h2, h3, h4 {
 
 /* mobile menu */
 .nav-burger {
-  display: none; width: 40px; height: 40px; border-radius: 10px;
+  display: none; width: 42px; height: 42px; border-radius: 10px;
   place-items: center; cursor: pointer; border: 1px solid var(--border);
   background: var(--panel-2); color: var(--text);
 }
@@ -264,17 +251,16 @@ h1, h2, h3, h4 {
 }
 .mobile-menu { display: none; }
 .mobile-only-controls { display: none !important; }
-@media (max-width: 780px) {
+@media (max-width: 1060px) {
   .nav-links.desktop { display: none; }
   .mobile-only-controls { display: flex !important; }
   .nav-burger { display: grid; }
   .mobile-menu {
     display: block; overflow: hidden; border-bottom: 1px solid var(--border-soft);
-    background: color-mix(in srgb, var(--bg) 96%, transparent);
-    backdrop-filter: blur(14px);
+    background: var(--bg);
   }
   .mobile-menu a {
-    display: block; padding: 14px 24px; color: var(--text-2); font-weight: 500;
+    display: flex; min-height: 48px; align-items: center; padding: 12px 24px; color: var(--text-2); font-weight: 500;
     border-top: 1px solid var(--border-soft);
   }
   .mobile-menu a:first-child { border-top: none; }
@@ -284,25 +270,21 @@ h1, h2, h3, h4 {
 /* ================= BUTTONS ================= */
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 8px;
-  padding: 12px 22px; border-radius: var(--radius-sm); font-weight: 600; font-size: 14px;
+  min-height: 44px; padding: 10px 22px; border-radius: var(--radius-sm); font-weight: 600; font-size: 14px;
   border: 1px solid var(--border); background: var(--panel-2); color: var(--text);
   cursor: pointer; transition: all 0.16s var(--ease); white-space: nowrap;
 }
 .btn:hover { border-color: var(--accent-border); background: var(--panel-3); color: var(--text); transform: translateY(-1px); }
 .btn:active { transform: translateY(0); }
 .btn-primary {
-  background: linear-gradient(135deg, var(--forest), var(--moss));
+  background: linear-gradient(135deg, #1f6feb, #0969da);
   border-color: transparent; color: var(--brand-ink);
   box-shadow: 0 8px 24px var(--glow);
 }
 .btn-primary:hover { filter: brightness(1.07); color: var(--brand-ink); box-shadow: 0 12px 32px var(--glow); }
-[data-theme="dark"] .btn-primary {
-  background: linear-gradient(135deg, var(--gold), #b8934a); color: #17140b;
-}
-[data-theme="dark"] .btn-primary:hover { color: #17140b; }
 .btn-ghost { background: transparent; }
-.btn-lg { padding: 15px 28px; font-size: 15px; }
-.btn-sm { padding: 8px 14px; font-size: 13px; }
+.btn-lg { min-height: 52px; padding: 13px 28px; font-size: 15px; }
+.btn-sm { min-height: 40px; padding: 7px 14px; font-size: 13px; }
 .btn:disabled, .btn[aria-disabled="true"] {
   opacity: 0.55; cursor: not-allowed; pointer-events: none;
 }
@@ -339,11 +321,11 @@ h1, h2, h3, h4 {
   margin: 0 0 22px; font-weight: 600;
 }
 .hero h1 .grad {
-  background: linear-gradient(110deg, var(--accent) 5%, var(--berry) 95%);
+  background: linear-gradient(110deg, var(--accent) 5%, var(--accent-2) 95%);
   -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
 }
 [data-theme="dark"] .hero h1 .grad {
-  background: linear-gradient(110deg, var(--gold) 5%, var(--gold-soft) 95%);
+  background: linear-gradient(110deg, var(--accent) 5%, var(--gold-soft) 95%);
   -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
 }
 .hero p.lede { font-size: clamp(17px, 2.2vw, 21px); color: var(--muted); max-width: 660px; margin: 0 auto 36px; line-height: 1.55; }
@@ -354,11 +336,11 @@ h1, h2, h3, h4 {
 
 /* ---- ornament (gold, spaced — the "— a fairy of the mountains —" flourish) */
 .ornament {
-  display: block; text-align: center; color: #7d5f1f; /* AA 4.6:1 on cream — a deep gold */
+  display: block; text-align: center; color: var(--accent);
   font-size: 12px; letter-spacing: 0.42em; text-transform: uppercase;
   font-weight: 600; margin-bottom: 18px;
 }
-[data-theme="dark"] .ornament { color: var(--gold); } /* AA 8.3:1 on dark */
+[data-theme="dark"] .ornament { color: var(--accent); }
 .ornament .glyph { color: var(--gold); opacity: 0.85; }
 
 /* ================= THE FAIRY ================= */
@@ -374,9 +356,42 @@ h1, h2, h3, h4 {
 .hero-fairy .hero-copy .sub { justify-content: flex-start; }
 .hero-fairy .hero-copy .lede { margin-left: 0; margin-right: 0; }
 
+.harness-strip {
+  display: flex; align-items: center; gap: 10px; margin-top: 24px; color: var(--muted);
+  font-size: 12px; font-weight: 650; letter-spacing: .04em; text-transform: uppercase;
+}
+.harness-strip ul { display: flex; flex-wrap: wrap; gap: 7px; margin: 0; padding: 0; list-style: none; }
+.harness-strip li { padding: 5px 9px; border: 1px solid var(--border); border-radius: 999px; background: var(--panel-2); color: var(--text-2); font-size: 11px; letter-spacing: 0; text-transform: none; }
+
+/* ================= WORKFLOW INTRO ================= */
+.workflow-intro { padding: 16px 0 24px; }
+.workflow-intro-grid {
+  display: grid; grid-template-columns: minmax(0, 1fr) minmax(360px, 0.9fr); gap: 42px; align-items: center;
+  padding: 32px; border: 1px solid var(--border); border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--panel-2) 92%, transparent), var(--panel));
+  box-shadow: var(--shadow-md);
+}
+.workflow-intro-copy h2 { font-size: clamp(25px, 3vw, 34px); line-height: 1.18; margin: 15px 0 12px; }
+.workflow-intro-copy p { max-width: 600px; margin: 0 0 16px; color: var(--muted); }
+.text-link { display: inline-flex; align-items: center; gap: 7px; font-weight: 650; color: var(--accent); }
+.text-link:hover { color: var(--accent-2); }
+.workflow-preview { margin: 0; padding: 0; list-style: none; border-left: 1px solid var(--border); }
+.workflow-preview li { display: flex; gap: 14px; align-items: flex-start; padding: 13px 0 13px 22px; position: relative; }
+.workflow-preview li + li { border-top: 1px solid var(--border-soft); }
+.workflow-preview-num { font-family: var(--font-mono); font-size: 12px; color: var(--accent); font-weight: 700; padding-top: 2px; }
+.workflow-preview strong, .workflow-preview span { display: block; }
+.workflow-preview strong { font-size: 14px; color: var(--text); }
+.workflow-preview li div > span { margin-top: 2px; font-size: 13px; color: var(--muted); }
+.how-it-works-cta { text-align: center; margin-top: 34px; }
+@media (max-width: 760px) {
+  .workflow-intro-grid { grid-template-columns: 1fr; gap: 24px; padding: 24px; }
+  .workflow-preview { border-left: none; border-top: 1px solid var(--border); padding-top: 8px; }
+  .workflow-preview li { padding-left: 0; }
+}
+
 .fairy-stage {
   position: relative; display: grid; place-items: center;
-  min-height: 460px;
+  min-width: 0; min-height: 460px;
 }
 .fairy-figure {
   width: 100%; max-width: 440px; height: auto; position: relative; z-index: 2;
@@ -435,13 +450,20 @@ h1, h2, h3, h4 {
   .hero-fairy .badge-row,
   .hero-fairy .hero-copy .cta,
   .hero-fairy .hero-copy .sub { justify-content: center; }
+  .harness-strip { justify-content: center; flex-direction: column; }
   /* copy (incl. the download CTA) leads on mobile; the fairy sits below it so
      the primary action isn't pushed under a tall illustration on the fold. */
   .fairy-stage { min-height: 300px; margin-top: 12px; }
   .fairy-figure { max-width: 260px; }
+  .fairy-ring { width: 100%; }
 }
 @media (max-width: 900px) {
   .hero-fairy { padding-top: 72px; }
+}
+@media (max-width: 520px) {
+  .hero-fairy { padding-top: 52px; }
+  .hero-fairy .fairy-stage { min-height: 240px; }
+  .hero-fairy .fairy-figure { max-width: 220px; }
 }
 @media (prefers-reduced-motion: reduce) {
   .fairy-figure, .fairy-ring, .fairy-stage::before,
@@ -468,6 +490,68 @@ h1, h2, h3, h4 {
 .tl.r { background: #ff5f57; } .tl.y { background: #febc2e; } .tl.g { background: #28c840; }
 .mock-bar .title { margin-left: 10px; font-size: 12px; color: var(--muted-2); }
 .mock .demo { display: block; width: 100%; height: auto; }
+
+/* ================= PRODUCT SCREENSHOTS ================= */
+.browser-frame {
+  margin: 0; overflow: hidden; border: 1px solid var(--border); border-radius: 18px;
+  background: var(--panel); box-shadow: var(--shadow-lg), 0 0 0 1px rgba(255,255,255,.025);
+}
+.browser-frame-chrome {
+  display: flex; min-height: 44px; align-items: center; gap: 12px; padding: 0 15px;
+  border-bottom: 1px solid var(--border-soft); background: color-mix(in srgb, var(--panel-3) 80%, transparent);
+}
+.browser-frame-controls { display: inline-flex; gap: 6px; flex: none; }
+.browser-frame-controls i { width: 10px; height: 10px; border-radius: 50%; background: var(--border); }
+.browser-frame-controls i:first-child { background: #d96363; }.browser-frame-controls i:nth-child(2) { background: #d5a949; }.browser-frame-controls i:nth-child(3) { background: #5eaa76; }
+.browser-frame-title { min-width: 0; overflow: hidden; color: var(--muted); font-family: var(--font-mono); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.browser-frame-badge { margin-left: auto; flex: none; color: var(--accent); border: 1px solid var(--accent-border); border-radius: 999px; background: var(--accent-soft); padding: 3px 8px; font-size: 10px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; }
+.browser-frame-content { background: var(--code-bg); }
+.browser-frame figcaption { display: grid; gap: 5px; padding: 14px 16px 15px; border-top: 1px solid var(--border-soft); background: var(--panel); color: var(--muted); font-size: 13px; line-height: 1.5; }
+.browser-frame figcaption strong { color: var(--text-2); font-weight: 550; }
+.product-shot-image { position: relative; min-height: 100%; aspect-ratio: 16 / 10; background: var(--code-bg); }
+.product-shot-image img { object-fit: cover; }
+.product-shot-placeholder { position: relative; isolation: isolate; display: grid; min-height: 380px; padding: 34px; overflow: hidden; align-content: center; gap: 18px; background: linear-gradient(145deg, #10151c, #0b0f15); }
+.product-shot-wide .product-shot-placeholder, .product-shot-wide .product-shot-image { aspect-ratio: 16 / 9; min-height: 0; }
+.product-shot-standard .product-shot-placeholder, .product-shot-standard .product-shot-image { aspect-ratio: 4 / 3; min-height: 0; }
+.product-shot-portrait { max-width: 530px; }.product-shot-portrait .product-shot-placeholder, .product-shot-portrait .product-shot-image { aspect-ratio: 4 / 5; min-height: 0; }
+.product-shot-placeholder-grid { position: absolute; z-index: -1; inset: 0; opacity: .34; background: linear-gradient(rgba(88,166,255,.09) 1px, transparent 1px), linear-gradient(90deg, rgba(88,166,255,.09) 1px, transparent 1px); background-size: 38px 38px; mask-image: radial-gradient(ellipse at 50% 44%, #000 0%, transparent 72%); }
+.product-shot-placeholder::after { content: ""; position: absolute; z-index: -1; width: 52%; aspect-ratio: 1; left: 50%; top: 45%; transform: translate(-50%, -50%); border-radius: 50%; background: var(--glow); filter: blur(42px); opacity: .38; }
+.product-shot-placeholder-panel { max-width: 430px; padding: 20px; border: 1px solid rgba(88,166,255,.22); border-radius: 13px; background: rgba(16,21,28,.88); box-shadow: 0 18px 44px rgba(0,0,0,.28); backdrop-filter: blur(12px); }
+.product-shot-placeholder-panel-main { display: grid; gap: 8px; }.product-shot-placeholder-kicker { color: #58a6ff; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: .11em; }.product-shot-placeholder-panel strong { color: #e6edf3; font-family: var(--font-display); font-size: clamp(21px, 3vw, 30px); line-height: 1.1; }.product-shot-placeholder-panel span:last-child { color: #b1bac4; font-size: 13px; }
+.product-shot-placeholder-panel-meta { margin-left: auto; max-width: min(390px, 92%); }.product-shot-placeholder-panel-meta > span { color: #8b949e; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }.product-shot-placeholder-panel-meta p { margin: 7px 0 0; color: #c9d1d9; font-size: 13px; line-height: 1.5; }
+.product-shot-capture { color: var(--muted-2); font-size: 12px; }
+.product-proof { display: grid; grid-template-columns: minmax(0, .9fr) minmax(0, 1.1fr); gap: 54px; align-items: center; }.product-proof.reverse .product-proof-copy { order: 2; }.product-proof.reverse .product-shot { order: 1; }.product-proof-copy h2 { font-size: clamp(27px, 3.5vw, 40px); line-height: 1.14; margin: 14px 0 12px; }.product-proof-copy > p { color: var(--muted); margin: 0 0 18px; font-size: 16px; }.product-proof-copy ul { margin: 0; padding: 0; list-style: none; }.product-proof-copy li { position: relative; padding: 6px 0 6px 24px; color: var(--text-2); font-size: 14px; }.product-proof-copy li::before { content: ""; position: absolute; top: 13px; left: 1px; width: 7px; height: 7px; border-radius: 50%; background: var(--accent-3); box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-3) 12%, transparent); }
+@media (max-width: 820px) { .product-proof, .product-proof.reverse { grid-template-columns: 1fr; gap: 28px; }.product-proof.reverse .product-proof-copy, .product-proof.reverse .product-shot { order: initial; }.product-shot-portrait { max-width: none; }.product-shot-placeholder { min-height: 0; padding: 22px; }.browser-frame-badge { display: none; } }
+@media (max-width: 500px) { .browser-frame-chrome { min-height: 40px; padding: 0 12px; }.browser-frame-controls i { width: 8px; height: 8px; }.browser-frame-title { font-size: 11px; }.product-shot-placeholder-panel { padding: 15px; }.product-shot-placeholder-panel-meta { max-width: 100%; } }
+@media (max-width: 500px) { .product-shot-placeholder { padding: 16px; }.product-shot-placeholder-panel-meta { margin-left: 24px; } }
+
+/* ================= EXTENSION HUB ================= */
+.extensions-hero, .guide-hero { position: relative; overflow: hidden; padding: 102px 0 78px; }
+.extensions-hero::before, .guide-hero::before { content: ""; position: absolute; inset: 0; pointer-events: none; opacity: .5; background: radial-gradient(700px 400px at 75% 20%, var(--accent-soft), transparent 72%), linear-gradient(90deg, var(--border-soft) 1px, transparent 1px) 50% 0 / 72px 72px, linear-gradient(var(--border-soft) 1px, transparent 1px) 50% 0 / 72px 72px; mask-image: linear-gradient(to bottom, #000, transparent 88%); }
+.extensions-hero .wrap, .guide-hero .wrap { position: relative; display: grid; grid-template-columns: minmax(0, 1fr) minmax(360px, .95fr); align-items: center; gap: 64px; }
+.extensions-hero-copy, .guide-hero-copy { max-width: 660px; }
+.extensions-hero h1, .guide-hero h1 { margin: 16px 0 19px; font-size: clamp(42px, 6vw, 70px); line-height: 1.03; letter-spacing: -.03em; }
+.extensions-hero h1 .grad, .guide-hero h1 .grad { background: linear-gradient(110deg, var(--accent), var(--accent-2)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+.extensions-hero-copy > p, .guide-hero-copy > p { margin: 0 0 29px; color: var(--muted); font-size: 18px; line-height: 1.6; }
+.extensions-hero .cta, .guide-hero .cta { display: flex; flex-wrap: wrap; gap: 12px; }
+.extension-paths-section { padding-top: 28px; }
+.extension-paths { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.extension-path-card { position: relative; display: flex; min-height: 260px; flex-direction: column; padding: 26px; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius); background: linear-gradient(145deg, var(--panel-2), var(--panel)); color: inherit; transition: border-color .18s var(--ease), box-shadow .18s var(--ease), transform .18s var(--ease); }
+.extension-path-card::after { content: ""; position: absolute; right: -30px; bottom: -60px; width: 150px; aspect-ratio: 1; border-radius: 50%; background: var(--accent-soft); filter: blur(2px); }
+.extension-path-card:hover { border-color: var(--accent-border); box-shadow: var(--shadow-md); color: inherit; transform: translateY(-3px); }
+.extension-path-number { color: var(--accent); font-family: var(--font-mono); font-size: 12px; font-weight: 750; letter-spacing: .1em; }
+.extension-path-card h3 { margin: 18px 0 8px; font-size: 23px; }.extension-path-card p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.6; }.extension-path-card .text-link { margin-top: auto; padding-top: 21px; font-size: 14px; }
+.extension-reference { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(300px, .95fr); gap: 42px; padding: 38px; border: 1px solid var(--border); border-radius: var(--radius-lg); background: linear-gradient(145deg, var(--panel-2), var(--panel)); box-shadow: var(--shadow-md); }.extension-reference h2 { font-size: clamp(27px, 3.2vw, 38px); line-height: 1.13; margin: 14px 0 12px; }.extension-reference p { margin: 0; color: var(--muted); }.extension-reference-links { display: grid; align-content: center; gap: 8px; }.extension-reference-links a { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px; border: 1px solid var(--border-soft); border-radius: 10px; color: var(--text-2); background: var(--panel); font-size: 14px; font-weight: 600; }.extension-reference-links a:hover { border-color: var(--accent-border); color: var(--accent); }
+
+/* ================= EXTENSION GUIDES ================= */
+.guide-prerequisites { padding: 0; border-top: 1px solid var(--border-soft); border-bottom: 1px solid var(--border-soft); background: color-mix(in srgb, var(--text) 1.4%, transparent); }.guide-prerequisites .wrap { display: flex; align-items: center; gap: 16px; padding-top: 18px; padding-bottom: 18px; }.guide-prerequisites strong { color: var(--text); font-size: 14px; }.guide-prerequisites span { color: var(--muted); font-size: 14px; }.guide-prerequisites a { margin-left: auto; color: var(--accent); font-size: 14px; font-weight: 650; white-space: nowrap; }
+.guide-steps-section { padding-bottom: 60px; }.guide-steps-head { max-width: 690px; margin-bottom: 42px; }.guide-steps-head h2 { margin: 15px 0 11px; font-size: clamp(31px, 4vw, 45px); line-height: 1.12; }.guide-steps-head p { margin: 0; color: var(--muted); font-size: 17px; }.guide-steps { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; padding: 0; margin: 0; list-style: none; counter-reset: guide-steps; }.guide-steps li { min-width: 0; padding: 20px 16px; border: 1px solid var(--border); border-radius: 13px; background: linear-gradient(160deg, var(--panel-2), var(--panel)); }.guide-steps li > span { display: grid; width: 28px; height: 28px; place-items: center; border: 1px solid var(--accent-border); border-radius: 8px; color: var(--accent); background: var(--accent-soft); font-family: var(--font-mono); font-size: 11px; font-weight: 700; }.guide-steps h3 { margin: 15px 0 7px; font-size: 16px; line-height: 1.2; }.guide-steps p { margin: 0; color: var(--muted); font-size: 13px; line-height: 1.55; }
+.guide-code { margin: 0; padding: 26px; overflow: auto; border: 1px solid var(--border); border-radius: var(--radius); background: var(--code-bg); box-shadow: var(--shadow-md); color: var(--code-text); font-family: var(--font-mono); font-size: 13px; line-height: 1.65; }.guide-next-section { padding-top: 24px; }.guide-next-card { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 44px; padding: 42px; border: 1px solid var(--accent-border); border-radius: var(--radius-lg); background: radial-gradient(580px 260px at 8% 0%, var(--accent-soft), transparent 70%), linear-gradient(145deg, var(--panel-2), var(--panel)); box-shadow: var(--shadow-md); }.guide-next-card h2 { margin: 15px 0 10px; font-size: clamp(26px, 3.3vw, 38px); line-height: 1.14; }.guide-next-card p { max-width: 650px; margin: 0; color: var(--muted); }.guide-next-actions { display: grid; gap: 11px; min-width: 240px; }.guide-next-actions .btn { width: 100%; }
+.install-methods-section { padding-top: 36px; }.install-methods { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }.install-methods article { padding: 24px; border: 1px solid var(--border); border-radius: var(--radius); background: linear-gradient(145deg, var(--panel-2), var(--panel)); }.install-methods h3 { margin: 0 0 8px; font-size: 20px; }.install-methods strong { display: block; color: var(--accent); font-size: 13px; }.install-methods p { margin: 10px 0 0; color: var(--muted); font-size: 14px; line-height: 1.6; }
+.sdk-layers-section { padding-top: 36px; }.sdk-layers { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }.sdk-layers article { padding: 23px; border: 1px solid var(--border); border-radius: var(--radius); background: linear-gradient(145deg, var(--panel-2), var(--panel)); }.sdk-layers article > span { color: var(--accent); font-family: var(--font-mono); font-size: 12px; font-weight: 700; letter-spacing: .1em; }.sdk-layers h3 { margin: 16px 0 8px; font-size: 19px; }.sdk-layers p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.6; }
+@media (max-width: 950px) { .extensions-hero .wrap, .guide-hero .wrap { grid-template-columns: 1fr; gap: 34px; }.extensions-hero .product-shot, .guide-hero .product-shot { max-width: 720px; }.guide-steps { grid-template-columns: repeat(3, 1fr); }.sdk-layers { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 720px) { .extension-paths, .install-methods, .sdk-layers, .extension-reference, .guide-next-card { grid-template-columns: 1fr; }.guide-steps { grid-template-columns: 1fr; }.guide-prerequisites .wrap { display: grid; gap: 5px; }.guide-prerequisites a { margin-left: 0; margin-top: 5px; }.guide-next-actions { min-width: 0; }.extension-reference { padding: 26px; } }
+@media (max-width: 500px) { .extensions-hero, .guide-hero { padding-top: 74px; }.extensions-hero h1, .guide-hero h1 { font-size: 42px; }.extensions-hero .cta .btn, .guide-hero .cta .btn { width: 100%; }.guide-next-card { padding: 26px; } }
 
 /* ================= LOGO / TRUST BAND ================= */
 .band { border-top: 1px solid var(--border-soft); border-bottom: 1px solid var(--border-soft); background: color-mix(in srgb, var(--text) 1.4%, transparent); }
@@ -501,17 +585,11 @@ section .section-lede { color: var(--muted); margin: 0; font-size: 16px; line-he
 .card:hover { border-color: var(--accent-border); transform: translateY(-3px); box-shadow: var(--shadow-md); }
 .card h3 { margin: 0 0 9px; font-size: 17px; letter-spacing: -0.01em; }
 .card p { margin: 0; color: var(--muted); font-size: 14px; }
-.card .ico {
-  width: 46px; height: 46px; border-radius: 12px; display: grid; place-items: center;
-  font-size: 22px; margin-bottom: 16px;
-  background: var(--accent-soft); border: 1px solid var(--accent-border);
-  transition: transform 0.2s var(--ease), box-shadow 0.2s var(--ease);
-}
-.card:hover .ico { transform: translateY(-2px); box-shadow: 0 8px 20px -8px var(--glow); }
 a.card { color: inherit; display: block; }
 
 /* feature split (alternating) */
-.split { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items: center; }
+.split { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 56px; align-items: center; }
+.split > *, .product-proof > * { min-width: 0; }
 .split.rev .visual { order: -1; }
 @media (max-width: 860px) { .split { grid-template-columns: 1fr; gap: 32px; } .split.rev .visual { order: 0; } }
 .split h2, .split h3 { font-family: var(--font-display); font-size: clamp(22px, 3vw, 28px); letter-spacing: -0.01em; margin: 14px 0 12px; font-weight: 600; }
@@ -529,10 +607,11 @@ a.card { color: inherit; display: block; }
   background: linear-gradient(160deg, var(--panel-2), var(--bg-soft)); display: grid; gap: 10px; align-content: center;
   box-shadow: var(--shadow-md);
 }
+.visual.code-visual { min-width: 0; padding: 0; border: none; background: none; box-shadow: none; }
 
 /* SDK code showcase (a faux editor window in a split visual) */
 .code-showcase {
-  border: 1px solid var(--border); border-radius: 14px; overflow: hidden;
+  width: 100%; min-width: 0; border: 1px solid var(--border); border-radius: 14px; overflow: hidden;
   background: var(--code-bg); box-shadow: var(--shadow-md);
   font-family: var(--font-mono); text-align: left;
 }
@@ -546,9 +625,10 @@ a.card { color: inherit; display: block; }
   margin-left: 8px; font-size: 11.5px; color: var(--gold-soft); font-family: var(--font-mono);
 }
 .code-showcase pre {
-  margin: 0; padding: 16px 18px; overflow-x: auto;
+  max-width: 100%; margin: 0; padding: 16px 18px; overflow-x: auto;
   font-size: 12.5px; line-height: 1.7; color: var(--code-text);
 }
+.code-showcase code { display: block; width: max-content; min-width: 100%; }
 
 /* orchestration mock rows */
 .mock-agent { border: 1px solid var(--border-soft); border-radius: 12px; padding: 14px; background: var(--panel); }
@@ -579,6 +659,76 @@ a.card { color: inherit; display: block; }
 .step h3 { font-size: 17px; margin: 0 0 8px; letter-spacing: -0.01em; }
 .step p { color: var(--muted); font-size: 14px; margin: 0; }
 
+/* ================= HOW IT WORKS PAGE ================= */
+.journey-hero { position: relative; overflow: hidden; padding: 108px 0 74px; }
+.journey-hero::before {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background: linear-gradient(90deg, var(--border-soft) 1px, transparent 1px) 50% 0 / 72px 72px,
+    linear-gradient(var(--border-soft) 1px, transparent 1px) 50% 0 / 72px 72px;
+  mask-image: linear-gradient(to bottom, #000, transparent 82%); opacity: 0.45;
+}
+.journey-hero .wrap { position: relative; display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.85fr); gap: 70px; align-items: center; }
+.journey-hero-copy { max-width: 680px; }
+.journey-hero h1 { font-size: clamp(43px, 6.2vw, 72px); line-height: 1.03; margin: 16px 0 21px; letter-spacing: -0.03em; }
+.journey-hero h1 .grad { background: linear-gradient(110deg, var(--accent), var(--accent-2)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+.journey-hero-copy > p { color: var(--muted); font-size: clamp(17px, 2vw, 20px); line-height: 1.6; margin: 0 0 30px; max-width: 620px; }
+.journey-hero .cta { display: flex; flex-wrap: wrap; gap: 12px; }
+.journey-hero-summary {
+  padding: 30px; border: 1px solid var(--accent-border); border-radius: var(--radius-lg);
+  background: linear-gradient(145deg, color-mix(in srgb, var(--panel-2) 90%, var(--accent-soft)), var(--panel));
+  box-shadow: var(--shadow-lg);
+}
+.journey-hero-summary > span { color: var(--accent); font-size: 11px; letter-spacing: 0.12em; font-weight: 750; }
+.journey-hero-summary ol { list-style: none; margin: 20px 0 20px; padding: 0; counter-reset: journey-loop; }
+.journey-hero-summary li { display: flex; align-items: center; gap: 12px; padding: 11px 0; color: var(--text-2); font-weight: 600; }
+.journey-hero-summary li + li { border-top: 1px solid var(--border-soft); }
+.journey-hero-summary li b { width: 28px; height: 28px; display: grid; place-items: center; border-radius: 8px; color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent-border); font-family: var(--font-mono); font-size: 12px; }
+.journey-hero-summary p { margin: 0; padding-top: 17px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; line-height: 1.55; }
+.journey-principles { padding: 0; border-top: 1px solid var(--border-soft); border-bottom: 1px solid var(--border-soft); background: color-mix(in srgb, var(--text) 1.2%, transparent); }
+.journey-principles .wrap { display: grid; grid-template-columns: repeat(3, 1fr); }
+.journey-principles .wrap > div { padding: 27px 28px; }
+.journey-principles .wrap > div + div { border-left: 1px solid var(--border-soft); }
+.journey-principles span, .journey-principles strong { display: block; }
+.journey-principles span { color: var(--muted-2); font-size: 12px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; }
+.journey-principles strong { margin-top: 5px; color: var(--text); font-family: var(--font-display); font-size: 20px; }
+.journey-section { padding: 102px 0 80px; }
+.journey-section-head { max-width: 700px; margin-bottom: 52px; }
+.journey-section-head h2 { font-size: clamp(30px, 4vw, 46px); line-height: 1.12; margin: 16px 0 12px; }
+.journey-section-head p { color: var(--muted); font-size: 17px; margin: 0; }
+.journey-list { display: grid; gap: 72px; }
+.journey-row { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1fr); gap: 70px; align-items: center; }
+.journey-row.reverse .journey-copy { order: 2; }
+.journey-row.reverse .journey-visual { order: 1; }
+.journey-step, .journey-eyebrow { display: block; }
+.journey-step { color: var(--accent); font-family: var(--font-mono); font-weight: 750; letter-spacing: 0.1em; font-size: 13px; }
+.journey-eyebrow { margin-top: 19px; color: var(--muted-2); font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700; }
+.journey-copy h3 { margin: 8px 0 13px; font-size: clamp(27px, 3.2vw, 37px); line-height: 1.13; letter-spacing: -0.02em; }
+.journey-copy > p { color: var(--muted); margin: 0 0 17px; font-size: 16px; }
+.journey-copy ul { padding: 0; margin: 0; list-style: none; }
+.journey-copy li { position: relative; padding: 7px 0 7px 25px; color: var(--text-2); font-size: 14px; }
+.journey-copy li::before { content: ""; position: absolute; top: 14px; left: 1px; width: 8px; height: 8px; border-radius: 50%; background: var(--accent-3); box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-3) 12%, transparent); }
+.journey-visual { min-height: 310px; padding: 19px; border: 1px solid var(--border); border-radius: var(--radius-lg); background: linear-gradient(145deg, var(--panel-2), var(--bg-soft)); box-shadow: var(--shadow-md); }
+.journey-window-bar { display: flex; gap: 6px; align-items: center; height: 24px; border-bottom: 1px solid var(--border-soft); padding-bottom: 13px; }
+.journey-window-bar span { width: 8px; height: 8px; border-radius: 50%; background: var(--border); }
+.journey-window-bar span:first-child { background: #d96363; }.journey-window-bar span:nth-child(2) { background: #d5a949; }.journey-window-bar span:nth-child(3) { background: #5eaa76; }
+.journey-window-bar b { margin-left: 7px; color: var(--muted-2); font-family: var(--font-mono); font-size: 11px; font-weight: 500; }
+.journey-project-list { display: grid; gap: 7px; padding: 18px 0; }
+.journey-project-list div { display: flex; align-items: center; gap: 9px; padding: 13px 12px; border-radius: 10px; color: var(--text-2); background: color-mix(in srgb, var(--panel) 88%, transparent); border: 1px solid var(--border-soft); font-size: 13px; }
+.journey-project-list div:first-child { border-color: var(--accent-border); background: var(--accent-soft); color: var(--text); }
+.journey-project-list em { margin-left: auto; color: var(--muted-2); font-style: normal; font-size: 11px; }
+.project-dot { width: 8px; height: 8px; border-radius: 3px; background: var(--muted-2); }.project-dot.active { background: var(--accent-3); }.project-dot.remote { border-radius: 50%; background: var(--accent); }
+.journey-terminal { display: flex; flex-direction: column; background: var(--code-bg); border-color: color-mix(in srgb, var(--border) 75%, #000); }
+.journey-terminal .journey-window-bar { border-color: rgba(255,255,255,.11); }
+.journey-terminal .journey-window-bar b { color: var(--code-text); }
+.journey-terminal p { margin: 19px 0 0; color: var(--code-text); font-family: var(--font-mono); font-size: 13px; line-height: 1.75; }.journey-terminal p i { color: var(--accent); font-style: normal; }.journey-terminal .terminal-muted { color: #91aa97; max-width: 86%; }
+.terminal-cursor { color: var(--accent); font-family: var(--font-mono); font-size: 17px; margin-top: auto; animation: terminalBlink 1.1s step-end infinite; }@keyframes terminalBlink { 50% { opacity: 0; } }
+.journey-board { display: flex; flex-direction: column; gap: 14px; }.board-head, .inbox-head { display: flex; justify-content: space-between; color: var(--text); font-size: 14px; }.board-head span, .inbox-head span { color: var(--muted-2); font-size: 12px; }.board-lanes { display: grid; grid-template-columns: 0.76fr 1.24fr; gap: 10px; flex: 1; }.board-lanes > div { display: flex; flex-direction: column; gap: 9px; padding: 12px; border-radius: 11px; background: var(--panel); border: 1px solid var(--border-soft); }.board-lanes b { color: var(--muted-2); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }.agent-pill { display: grid; gap: 4px; padding: 10px; border: 1px solid var(--accent-border); border-radius: 8px; background: var(--accent-soft); color: var(--text); font-size: 12px; }.agent-pill.review { border-color: rgba(254,188,46,.36); background: rgba(254,188,46,.09); }.agent-pill small { color: var(--accent-3); font-size: 10px; }.agent-pill.review small { color: var(--warn); }
+.journey-inbox { display: flex; flex-direction: column; gap: 11px; }.journey-inbox article { display: flex; gap: 12px; padding: 15px; border-radius: 11px; background: var(--panel); border: 1px solid var(--accent-border); }.journey-inbox article.inbox-muted { border-color: var(--border-soft); opacity: .77; }.inbox-icon { display: grid; place-items: center; flex: none; width: 28px; height: 28px; border-radius: 8px; color: var(--accent); background: var(--accent-soft); font-weight: 750; }.journey-inbox b { color: var(--text); font-size: 13px; }.journey-inbox p { margin: 3px 0 0; color: var(--muted); font-size: 12px; line-height: 1.45; }.journey-inbox footer { margin-top: 9px; color: var(--accent); font-size: 11px; font-weight: 700; }
+.journey-next { padding: 24px 0 0; }.journey-next-card { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 48px; align-items: center; padding: 48px; border: 1px solid var(--accent-border); border-radius: var(--radius-lg); background: radial-gradient(560px 260px at 10% 0%, var(--accent-soft), transparent 72%), linear-gradient(135deg, var(--panel-2), var(--panel)); box-shadow: var(--shadow-md); }.journey-next-card h2 { font-size: clamp(27px, 3.4vw, 39px); line-height: 1.13; margin: 15px 0 12px; }.journey-next-card p { max-width: 650px; color: var(--muted); margin: 0; }.journey-next-actions { display: flex; flex-direction: column; align-items: flex-start; gap: 13px; min-width: 230px; }
+@media (max-width: 850px) { .journey-hero .wrap, .journey-row, .journey-next-card { grid-template-columns: 1fr; gap: 34px; }.journey-row.reverse .journey-copy, .journey-row.reverse .journey-visual { order: initial; }.journey-hero { padding-top: 78px; }.journey-hero-summary { max-width: 560px; }.journey-next-actions { min-width: 0; }.journey-principles .wrap { grid-template-columns: 1fr; }.journey-principles .wrap > div + div { border-left: 0; border-top: 1px solid var(--border-soft); }.journey-principles .wrap > div { padding: 20px 24px; } }
+@media (max-width: 520px) { .journey-hero h1 { font-size: 42px; }.journey-hero-summary, .journey-next-card { padding: 25px; }.journey-visual { min-height: 270px; }.journey-section { padding-top: 72px; }.journey-list { gap: 56px; }.board-lanes { grid-template-columns: 1fr; }.journey-hero .cta .btn { width: 100%; }.journey-next-actions .btn { width: 100%; } }
+@media (prefers-reduced-motion: reduce) { .terminal-cursor { animation: none; } }
+
 /* ================= CTA STRIP ================= */
 .cta-strip {
   text-align: center; border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 60px 24px;
@@ -588,6 +738,7 @@ a.card { color: inherit; display: block; }
   box-shadow: var(--shadow-md);
 }
 .cta-strip h2 { margin-top: 0; }
+.cta-strip .cta { flex-wrap: wrap; }
 
 /* ================= MARKETPLACE ================= */
 .mk-toolbar { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 28px; }
@@ -601,7 +752,7 @@ a.card { color: inherit; display: block; }
   width: 42px; height: 42px; border-radius: 12px; display: grid; place-items: center;
   font-size: 17px; font-weight: 700; color: var(--brand-ink); flex: none;
   font-family: var(--font-display);
-  background: linear-gradient(135deg, var(--forest), var(--moss));
+  background: linear-gradient(135deg, var(--brand), var(--brand-2));
   box-shadow: 0 6px 18px -6px var(--glow), inset 0 1px 0 rgba(255, 255, 255, 0.2);
   transition: transform 0.2s var(--ease);
 }
@@ -614,7 +765,7 @@ a.card { color: inherit; display: block; }
   border-radius: var(--radius); background: color-mix(in srgb, var(--text) 1.5%, transparent);
 }
 .search-box {
-  flex: 1; min-width: 240px; max-width: 440px; padding: 12px 16px;
+  flex: 1; min-width: min(240px, 100%); max-width: 440px; min-height: 44px; padding: 10px 16px;
   border-radius: var(--radius-sm); border: 1px solid var(--border);
   background: var(--bg-soft); color: var(--text); font-size: 14px; font-family: inherit;
 }
@@ -623,6 +774,7 @@ a.card { color: inherit; display: block; }
 .feed-pill { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 4px 12px; }
 .feed-pill .fdot { width: 7px; height: 7px; border-radius: 50%; background: var(--muted-2); }
 .feed-pill.live .fdot { background: var(--accent-3); box-shadow: 0 0 8px var(--accent-3); }
+.marketplace-install-guide { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 30px; align-items: center; margin: 0 0 30px; padding: 25px 28px; border: 1px solid var(--accent-border); border-radius: var(--radius); background: linear-gradient(145deg, var(--panel-2), var(--panel)); box-shadow: var(--shadow-sm); }.marketplace-install-guide h2 { margin: 12px 0 8px; font-size: clamp(23px, 3vw, 31px); }.marketplace-install-guide p { max-width: 680px; margin: 0; color: var(--muted); font-size: 14px; }.marketplace-install-guide p strong { color: var(--text-2); }.marketplace-install-actions { display: grid; gap: 10px; min-width: 205px; }.marketplace-install-actions .btn { width: 100%; }
 
 /* ================= DOCS ================= */
 .docs-shell { display: grid; grid-template-columns: 250px minmax(0, 1fr) 220px; gap: 40px; padding: 36px 0 64px; align-items: start; }
@@ -640,7 +792,7 @@ a.card { color: inherit; display: block; }
 /* docs sidebar search launcher */
 .docs-search-btn {
   display: flex; align-items: center; gap: 9px; width: 100%; margin-bottom: 20px;
-  padding: 9px 12px; border-radius: 10px; border: 1px solid var(--border);
+  min-height: 42px; padding: 9px 12px; border-radius: 10px; border: 1px solid var(--border);
   background: var(--panel-2); color: var(--muted); font-size: 13px; font-family: inherit;
   cursor: pointer; transition: border-color 0.14s var(--ease), color 0.14s var(--ease);
 }
@@ -709,12 +861,13 @@ a.card { color: inherit; display: block; }
 .docs-pager .dir { font-size: 12px; color: var(--muted-2); }
 .docs-pager .ttl { font-size: 15px; font-weight: 600; color: var(--text); }
 .docs-pager a.next { text-align: right; }
+.docs-hub-hero { position: relative; overflow: hidden; padding: 88px 0 48px; }.docs-hub-hero::before { content: ""; position: absolute; inset: 0; pointer-events: none; opacity: .4; background: radial-gradient(650px 350px at 75% 0%, var(--accent-soft), transparent 74%), linear-gradient(90deg, var(--border-soft) 1px, transparent 1px) 50% 0 / 70px 70px, linear-gradient(var(--border-soft) 1px, transparent 1px) 50% 0 / 70px 70px; mask-image: linear-gradient(to bottom, #000, transparent); }.docs-hub-hero .wrap { position: relative; display: grid; grid-template-columns: minmax(0, 1fr) minmax(360px, .8fr); gap: 52px; align-items: center; }.docs-hub-hero-copy { max-width: 680px; }.docs-hub-hero h1 { margin: 15px 0 15px; font-size: clamp(38px, 5.4vw, 62px); line-height: 1.05; letter-spacing: -.03em; }.docs-hub-hero h1 .grad { background: linear-gradient(110deg, var(--accent), var(--accent-2)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }.docs-hub-hero p { margin: 0; color: var(--muted); font-size: 17px; line-height: 1.6; }.docs-hub-paths { display: grid; gap: 9px; }.docs-hub-paths a { display: grid; gap: 4px; padding: 15px 17px; border: 1px solid var(--border); border-radius: 11px; background: linear-gradient(145deg, var(--panel-2), var(--panel)); color: var(--text); }.docs-hub-paths a:hover { border-color: var(--accent-border); color: var(--accent); }.docs-hub-paths span { color: var(--muted-2); font-size: 11px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; }.docs-hub-paths strong { display: flex; align-items: center; justify-content: space-between; gap: 12px; font-size: 15px; }.docs-hub-paths b { color: var(--accent); }.docs-next-step { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 22px; margin-top: 40px; padding: 22px; border: 1px solid var(--accent-border); border-radius: var(--radius); background: var(--accent-soft); }.docs-next-step span { color: var(--accent); font-size: 11px; font-weight: 750; letter-spacing: .08em; text-transform: uppercase; }.docs-next-step h2 { margin: 8px 0 5px; padding: 0; border: 0; font-size: 21px; }.docs-next-step p { margin: 0; color: var(--muted); font-size: 14px; }
 
 /* mobile docs nav (select) */
 .docs-mobile-nav { display: none; margin: 16px 0 8px; }
 @media (max-width: 820px) { .docs-mobile-nav { display: block; } }
 .docs-mobile-nav select {
-  width: 100%; padding: 12px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border);
+  width: 100%; min-height: 44px; padding: 10px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border);
   background: var(--panel-2); color: var(--text); font-size: 14px; font-family: inherit;
 }
 
@@ -789,6 +942,10 @@ a.card { color: inherit; display: block; }
 .featured { border-color: var(--accent-border); box-shadow: 0 0 0 1px var(--accent-border), var(--shadow-md); }
 .dl-card.wip { opacity: 0.82; }
 .dl-card.wip:hover { transform: none; }
+.dl-card .btn { min-width: 168px; }
+.dl-card.wip .btn { min-width: 168px; }
+.build-source-card pre { max-width: 100%; }
+.build-source-card pre code { display: block; width: max-content; min-width: 100%; }
 .wip-badge {
   position: absolute; top: 14px; right: 14px;
   font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
@@ -798,6 +955,7 @@ a.card { color: inherit; display: block; }
 
 /* ================= FOOTER ================= */
 footer { border-top: 1px solid var(--border-soft); padding: 56px 0 40px; color: var(--muted); font-size: 14px; margin-top: 96px; background: var(--bg-soft); }
+main:has(> .hero:only-child) + footer { margin-top: 24px; }
 .foot-top { display: grid; grid-template-columns: 1.4fr repeat(3, 1fr); gap: 32px; margin-bottom: 40px; }
 @media (max-width: 780px) { .foot-top { grid-template-columns: 1fr 1fr; gap: 28px; } }
 @media (max-width: 480px) { .foot-top { grid-template-columns: 1fr; } }
@@ -807,6 +965,13 @@ footer { border-top: 1px solid var(--border-soft); padding: 56px 0 40px; color: 
 .foot-col a:hover { color: var(--text); }
 .foot-blurb { color: var(--muted); font-size: 13.5px; max-width: 300px; line-height: 1.6; }
 .foot-bottom { display: flex; justify-content: space-between; align-items: center; gap: 16px; flex-wrap: wrap; padding-top: 28px; border-top: 1px solid var(--border-soft); color: var(--muted-2); font-size: 13px; }
+
+@media (max-width: 820px) { .marketplace-install-guide, .docs-hub-hero .wrap, .docs-next-step { grid-template-columns: 1fr; }.marketplace-install-actions { min-width: 0; grid-template-columns: repeat(2, 1fr); }.docs-hub-hero { padding-top: 68px; }.docs-hub-paths { max-width: 620px; } }
+@media (max-width: 520px) { .marketplace-install-guide { padding: 22px; }.marketplace-install-actions { grid-template-columns: 1fr; }.docs-hub-hero h1 { font-size: 40px; }.docs-next-step .btn { width: 100%; } }
+@media (max-width: 520px) {
+  .cta-strip .cta { flex-direction: column; align-items: stretch; }
+  .cta-strip .cta .btn { width: 100%; white-space: normal; }
+}
 
 /* utility */
 .center { text-align: center; }

--- a/website/app/how-it-works/page.tsx
+++ b/website/app/how-it-works/page.tsx
@@ -1,0 +1,149 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { ProductShot } from '../components/ProductShot';
+
+export const metadata: Metadata = {
+  title: 'How it works',
+  description:
+    'A practical tour of how Zana Command Center organizes projects, runs supported coding harnesses in parallel, and brings decisions back to you.',
+  alternates: { canonical: '/how-it-works/' },
+  openGraph: {
+    title: 'How Zana Command Center works',
+    description: 'Organize projects, delegate through your preferred coding harness, and stay in control of the decisions.',
+    url: '/how-it-works/',
+    type: 'website',
+    images: ['/opengraph-image']
+  }
+};
+
+const JOURNEY = [
+  {
+    step: '01',
+    eyebrow: 'Start with real context',
+    title: 'Give every project a place to work.',
+    body:
+      'Add a local folder or remote SSH workspace. Zana keeps its terminals, files, and agents together so you can change projects without losing the thread.',
+    details: ['Use the same project directory your coding tools expect', 'Keep local and remote work in one app', 'Organize a large project list by category'],
+    visual: 'project-setup'
+  },
+  {
+    step: '02',
+    eyebrow: 'Launch with intent',
+    title: 'Delegate outcomes, not your attention.',
+    body:
+      'Open a real Claude Code, OpenCode, Codex, or Pi session in the correct project and give it a focused task. Start more sessions when work can proceed independently, without giving up visibility.',
+    details: ['Every tab is a real terminal session', 'Run several projects in parallel', 'Use personas and teams for repeatable roles'],
+    visual: 'agent-terminal'
+  },
+  {
+    step: '03',
+    eyebrow: 'Operate the fleet',
+    title: 'See progress without reading every terminal.',
+    body:
+      'The Agents board groups sessions by state: working, idle, done, or waiting on you. Jump directly to the task that deserves attention instead of hunting through tabs.',
+    details: ['A global view across every project', 'Clear status makes blocked work obvious', 'Take over any terminal in one click'],
+    visual: 'agents-board'
+  },
+  {
+    step: '04',
+    eyebrow: 'Keep human judgment central',
+    title: 'Let the Inbox carry the decisions.',
+    body:
+      'Agents surface reports, questions, and blocked decisions in one place. Read the context, reply inline, and Zana sends your answer back to the waiting session.',
+    details: ['Questions, reports, and follow-ups share one feed', 'Reply without finding the original terminal', 'Routine events stay folded away from high-signal work'],
+    visual: 'inbox-decision'
+  }
+] as const;
+
+export default function HowItWorksPage() {
+  return (
+    <>
+      <section className="journey-hero">
+        <div className="wrap">
+          <div className="journey-hero-copy" data-reveal>
+            <span className="eyebrow">A practical product tour</span>
+            <h1>More work in motion.<br /><span className="grad">Less work to chase.</span></h1>
+            <p>
+              Zana keeps the native harness workflow you trust, then adds the operating layer a growing set of
+              sessions needs: context, visibility, and a clear path for decisions.
+            </p>
+            <div className="cta">
+              <Link className="btn btn-primary btn-lg" href="/download/">⬇ Download Zana</Link>
+              <a className="btn btn-ghost btn-lg" href="#first-session">Start the tour <span aria-hidden="true">↓</span></a>
+            </div>
+          </div>
+          <div className="journey-hero-summary" data-reveal>
+            <span>THE ZANA LOOP</span>
+            <ol>
+              <li><b>1</b><span>Set project context</span></li>
+              <li><b>2</b><span>Delegate focused work</span></li>
+              <li><b>3</b><span>Monitor the fleet</span></li>
+              <li><b>4</b><span>Make the decisions</span></li>
+            </ol>
+            <p>Built around real harness terminals, not a replacement for them.</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="journey-principles" aria-label="What Zana changes">
+        <div className="wrap">
+          <div data-reveal>
+            <span>Keep your tools</span>
+            <strong>Real harness sessions</strong>
+          </div>
+          <div data-reveal>
+            <span>Gain visibility</span>
+            <strong>One view across projects</strong>
+          </div>
+          <div data-reveal>
+            <span>Stay accountable</span>
+            <strong>You make the calls</strong>
+          </div>
+        </div>
+      </section>
+
+      <section className="journey-section" id="first-session">
+        <div className="wrap">
+          <div className="journey-section-head" data-reveal>
+            <span className="eyebrow">The workflow, step by step</span>
+            <h2>Built for the moment one terminal stops being enough.</h2>
+            <p>Each stage adds structure without hiding the native harness workflow you already know.</p>
+          </div>
+          <div className="journey-list">
+            {JOURNEY.map((item, index) => (
+              <article className={`journey-row ${index % 2 === 1 ? 'reverse' : ''}`} key={item.step} data-reveal>
+                <div className="journey-copy">
+                  <span className="journey-step">{item.step}</span>
+                  <span className="journey-eyebrow">{item.eyebrow}</span>
+                  <h3>{item.title}</h3>
+                  <p>{item.body}</p>
+                  <ul>
+                    {item.details.map((detail) => <li key={detail}>{detail}</li>)}
+                  </ul>
+                </div>
+                <ProductShot id={item.visual} />
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="journey-next">
+        <div className="wrap">
+          <div className="journey-next-card" data-reveal>
+            <div>
+              <span className="eyebrow">Your first day</span>
+              <h2>Start small. Keep the system ready to grow.</h2>
+              <p>Add one project, launch one agent, and use the Inbox when it needs you. When parallel work becomes useful, Zana is already organized for it.</p>
+            </div>
+            <div className="journey-next-actions">
+              <Link className="btn btn-primary btn-lg" href="/download/">⬇ Get Zana</Link>
+              <Link className="btn btn-ghost" href="/docs/getting-started/">Read the setup guide <span aria-hidden="true">→</span></Link>
+              <Link className="text-link" href="/features/">Explore all product capabilities <span aria-hidden="true">→</span></Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -25,13 +25,17 @@ const fraunces = Fraunces({
 export const metadata: Metadata = {
   metadataBase: new URL(site.publicBaseUrl),
   title: {
-    default: `${site.name} — orchestrate Claude Code across every project`,
+    default: `${site.name} — orchestrate AI coding harnesses across every project`,
     template: `%s — ${site.name}`
   },
   description: site.tagline,
   applicationName: site.name,
   keywords: [
     'Claude Code',
+    'OpenCode',
+    'Codex CLI',
+    'Pi coding agent',
+    'AI coding harnesses',
     'AI agents',
     'multi-agent orchestration',
     'developer cockpit',
@@ -46,7 +50,7 @@ export const metadata: Metadata = {
     // Explicit reference so every route inherits the generated card even when a
     // child segment declares its own openGraph block (which otherwise drops the
     // file-convention image). Resolved against metadataBase.
-    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'Zana Command Center — the cockpit for Claude Code' }]
+    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'Zana Command Center — the control plane for AI coding harnesses' }]
   },
   twitter: {
     card: 'summary_large_image',

--- a/website/app/marketplace/MarketplaceClient.tsx
+++ b/website/app/marketplace/MarketplaceClient.tsx
@@ -54,6 +54,18 @@ export function MarketplaceClient() {
           </p>
         </div>
 
+        <div className="marketplace-install-guide" data-reveal>
+          <div>
+            <span className="eyebrow">How installation works</span>
+            <h2>Discover here. Install from Zana.</h2>
+            <p>Use this catalog to evaluate extensions. In the desktop app, open <strong>Settings → Extensions → Marketplace</strong> to install a published extension, or choose a local build when you are developing privately.</p>
+          </div>
+          <div className="marketplace-install-actions">
+            <Link className="btn btn-primary" href="/extensions/install/">See all install paths</Link>
+            <Link className="btn btn-ghost" href="/extensions/">Build an extension</Link>
+          </div>
+        </div>
+
         <div className="mk-toolbar">
           <input
             className="search-box"
@@ -93,7 +105,7 @@ export function MarketplaceClient() {
                   </div>
                 )}
                 <p style={{ fontSize: 13, color: 'var(--text-2)', marginTop: 4 }}>
-                  Install from the app: <code>Settings → Extensions → Marketplace → {e.id}</code>
+                  Install in Zana: <code>Settings → Extensions → Marketplace → {e.id}</code>
                 </p>
               </div>
             ))}

--- a/website/app/opengraph-image.tsx
+++ b/website/app/opengraph-image.tsx
@@ -4,11 +4,11 @@ import { site } from '@/lib/site';
 /**
  * Site-wide default social card, generated at build time via Satori/ImageResponse
  * (no static asset to maintain). Per-page metadata inherits this unless a route
- * defines its own opengraph-image. Palette matches globals.css — the "fairy of
- * the mountains" identity: forest #2d5f3f → moss #4a7856, gold #c9a961 on cream.
+ * defines its own opengraph-image. Palette matches the desktop app's graphite,
+ * blue, and gold system.
  */
 export const runtime = 'nodejs';
-export const alt = 'Zana Command Center — the cockpit for Claude Code';
+export const alt = 'Zana Command Center — the control plane for AI coding harnesses';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -23,8 +23,8 @@ export default function OgImage() {
           flexDirection: 'column',
           justifyContent: 'space-between',
           padding: '72px',
-          background: 'linear-gradient(135deg, #faf6e8 0%, #f3ebd3 55%, #eadfc0 100%)',
-          color: '#1f2a24',
+          background: 'linear-gradient(135deg, #0b0f15 0%, #10151c 58%, #161c25 100%)',
+          color: '#e6edf3',
           fontFamily: 'sans-serif'
         }}
       >
@@ -33,43 +33,39 @@ export default function OgImage() {
             style={{
               width: 68,
               height: 68,
-              borderRadius: 18,
               display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: 40,
-              fontWeight: 700,
-              color: '#e5d4a1',
-              background: 'linear-gradient(135deg, #2d5f3f, #4a7856)'
+              borderRadius: 18,
+              overflow: 'hidden'
             }}
           >
-            Z
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={`${site.publicBaseUrl}/favicon.svg`} alt="" width={68} height={68} />
           </div>
-          <div style={{ fontSize: 30, fontWeight: 600, color: '#5b6b5f' }}>Zana Command Center</div>
+          <div style={{ fontSize: 30, fontWeight: 600, color: '#c9d1d9' }}>Zana Command Center</div>
         </div>
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
-          <div style={{ fontSize: 30, fontWeight: 600, color: '#7d5f1f', letterSpacing: '0.24em', textTransform: 'uppercase' }}>
-— a cockpit for Claude Code —
+          <div style={{ fontSize: 27, fontWeight: 600, color: '#58a6ff', letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+            — a control plane for coding harnesses —
           </div>
-          <div style={{ fontSize: 74, fontWeight: 700, lineHeight: 1.04, letterSpacing: '-0.02em', maxWidth: 980, color: '#2d5f3f' }}>
-            Make the wishes. The work gets done.
+          <div style={{ fontSize: 74, fontWeight: 700, lineHeight: 1.04, letterSpacing: '-0.02em', maxWidth: 980, color: '#e6edf3' }}>
+            Make the work visible. Keep the momentum.
           </div>
-          <div style={{ fontSize: 30, color: '#5b6b5f', maxWidth: 900 }}>{site.tagline}</div>
+          <div style={{ fontSize: 30, color: '#8b949e', maxWidth: 980 }}>{site.tagline}</div>
         </div>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: 18, fontSize: 24, color: '#5b6b5f' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 18, fontSize: 24, color: '#8b949e' }}>
           <span
             style={{
               padding: '8px 18px',
               borderRadius: 999,
-              border: '1px solid #d8c99e',
-              color: '#2d5f3f'
+              border: '1px solid #2a3340',
+              color: '#c9d1d9'
             }}
           >
-            macOS · Windows · Linux
+            macOS today · Windows &amp; Linux soon
           </span>
-          <span style={{ color: '#4a7856' }}>● Free &amp; open</span>
+          <span style={{ color: '#3fb950' }}>● Free &amp; open</span>
         </div>
       </div>
     ),

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from 'next';
 import { site } from '@/lib/site';
 import { FEATURES as ALL_FEATURES, LANDING_FEATURE_SLUGS } from '@/lib/features';
 import { Fairy } from './components/Fairy';
+import { ProductShot } from './components/ProductShot';
+import { HarnessStrip } from './components/HarnessStrip';
 
 export const metadata: Metadata = {
   alternates: { canonical: '/' },
@@ -11,7 +13,7 @@ export const metadata: Metadata = {
 
 const FEATURES = LANDING_FEATURE_SLUGS.map((slug) => {
   const f = ALL_FEATURES.find((x) => x.slug === slug)!;
-  return { slug: f.slug, ico: f.ico, title: f.title, body: f.tagline };
+  return { slug: f.slug, title: f.title, body: f.tagline };
 });
 
 const STATS = [
@@ -44,18 +46,18 @@ export default entry;`;
 const STEPS = [
   {
     n: '1',
-    title: 'Add your projects',
-    body: 'Point the cockpit at local folders or remote SSH boxes. Each becomes a lane with its own terminals, agents, and file explorer.'
+    title: 'Connect the work',
+    body: 'Add local folders or remote SSH projects. Each keeps its own workspace, terminals, agents, and files while staying visible in one cockpit.'
   },
   {
     n: '2',
-    title: 'Spawn & orchestrate',
-    body: 'Launch Claude Code sessions, curated teams, sprints, or goal-driven autopilot — as many as you need, running in parallel.'
+    title: 'Delegate with context',
+    body: 'Launch the coding harness you already use, then give each session a focused outcome. Bring in teams or goals when the work needs parallelism.'
   },
   {
     n: '3',
-    title: 'Stay the executive',
-    body: 'The inbox surfaces what needs a decision. Reply once and the answer routes straight back to the waiting agent.'
+    title: 'Decide, don’t babysit',
+    body: 'The Agents board and Inbox separate active work from decisions that need you. Reply once and your answer routes back to the right session.'
   }
 ];
 
@@ -85,26 +87,26 @@ export default function Home() {
       <section className="hero hero-fairy">
         <div className="wrap">
           <div className="hero-copy">
-            <span className="ornament">
-              <span className="glyph" aria-hidden="true">✧</span>&nbsp;&nbsp;A desktop cockpit for Claude&nbsp;Code&nbsp;&nbsp;<span className="glyph" aria-hidden="true">✧</span>
-            </span>
-            <h1>
-              Make the wishes.
-              <br />
-              <span className="grad">The work gets done.</span>
-            </h1>
-            <p className="lede">
-              Run and orchestrate <strong>many Claude&nbsp;Code sessions</strong> across all your projects — from
-              one window. Spawn agents, hand off work, and reply from a single inbox.
-            </p>
-            <div className="cta">
-              <Link className="btn btn-primary btn-lg" href="/download/">
-                ⬇ Download for free
-              </Link>
-              <Link className="btn btn-ghost btn-lg" href="/marketplace/">
-                Explore the marketplace →
-              </Link>
-            </div>
+              <span className="ornament">
+                <span className="glyph" aria-hidden="true">✧</span>&nbsp;&nbsp;A control plane for AI coding harnesses&nbsp;&nbsp;<span className="glyph" aria-hidden="true">✧</span>
+              </span>
+              <h1>
+                Make the work visible.
+                <br />
+                <span className="grad">Keep the momentum.</span>
+              </h1>
+              <p className="lede">
+                Zana turns sessions from <strong>Claude Code, OpenCode, Codex, and Pi into a managed fleet</strong>.
+                Launch work across projects, see what is moving, and step in only when a decision needs you.
+              </p>
+              <div className="cta">
+                <Link className="btn btn-primary btn-lg" href="/download/">
+                  ⬇ Download for free
+                </Link>
+                <Link className="btn btn-ghost btn-lg" href="/how-it-works/">
+                  See how it works →
+                </Link>
+              </div>
             <p className="sub">
               <span>macOS today · Windows &amp; Linux soon</span>
               <span className="dot" />
@@ -112,6 +114,7 @@ export default function Home() {
               <span className="dot" />
               <span>Auto-updating</span>
             </p>
+            <HarnessStrip />
           </div>
 
           <div className="fairy-stage">
@@ -125,27 +128,51 @@ export default function Home() {
         </div>
       </section>
 
-      {/* PRODUCT DEMO */}
-      <section style={{ paddingTop: 0 }}>
+      <section className="workflow-intro" aria-labelledby="workflow-intro-heading">
         <div className="wrap">
-          <div className="mock" data-reveal>
-            <div className="mock-bar">
-              <span className="tl r" />
-              <span className="tl y" />
-              <span className="tl g" />
-              <span className="title">Zana Command Center</span>
+          <div className="workflow-intro-grid" data-reveal>
+            <div className="workflow-intro-copy">
+              <span className="eyebrow">The operating model</span>
+              <h2 id="workflow-intro-heading">Your terminals keep working. Zana makes the work legible.</h2>
+              <p>
+                Zana does not replace your coding harness or turn engineering into a chat dashboard. It gives every
+                session a home, a status, and a route back to you when judgment is required.
+              </p>
+              <Link className="text-link" href="/how-it-works/">
+                Take the five-minute product tour <span aria-hidden="true">→</span>
+              </Link>
             </div>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              className="demo"
-              src="/demo.gif"
-              alt="Zana Command Center orchestrating multiple Claude Code sessions across projects"
-              width={1400}
-              height={900}
-              loading="lazy"
-              decoding="async"
-            />
+            <ol className="workflow-preview" aria-label="Zana workflow">
+              <li>
+                <span className="workflow-preview-num">01</span>
+                <div>
+                  <strong>Project context</strong>
+                  <span>Local folders and remote workspaces stay organized.</span>
+                </div>
+              </li>
+              <li>
+                <span className="workflow-preview-num">02</span>
+                <div>
+                  <strong>Focused execution</strong>
+                  <span>Independent sessions run at the same time.</span>
+                </div>
+              </li>
+              <li>
+                <span className="workflow-preview-num">03</span>
+                <div>
+                  <strong>Human judgment</strong>
+                  <span>The inbox brings only the right decisions forward.</span>
+                </div>
+              </li>
+            </ol>
           </div>
+        </div>
+      </section>
+
+      {/* PRODUCT DEMO */}
+      <section className="product-hero-shot" style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <ProductShot id="cockpit-overview" priority />
         </div>
       </section>
 
@@ -170,14 +197,13 @@ export default function Home() {
             <span className="eyebrow">Why Zana</span>
             <h2>From a single terminal to a cockpit</h2>
             <p className="section-lede">
-              Spawn, watch, reply, and drive multi-agent workflows — all from one place, built for people who
-              run Claude Code at scale.
+              Spawn, watch, reply, and drive multi-agent workflows from one place, even when your agents run in
+              different supported harnesses.
             </p>
           </div>
           <div className="grid grid-3" data-reveal-stagger>
             {FEATURES.map((f) => (
               <Link className="card" key={f.title} href={`/features#${f.slug}`}>
-                <span className="ico">{f.ico}</span>
                 <h3>{f.title}</h3>
                 <p>{f.body}</p>
               </Link>
@@ -196,8 +222,8 @@ export default function Home() {
         <div className="wrap">
           <div className="section-head center">
             <span className="eyebrow">How it works</span>
-            <h2>Three steps to a fleet</h2>
-            <p className="section-lede">No new mental model — it&apos;s the Claude Code you know, multiplied.</p>
+            <h2>From first project to a calmer workday</h2>
+            <p className="section-lede">A deliberately small loop: organize context, delegate work, and act on what needs your judgment.</p>
           </div>
           <div className="steps" data-reveal-stagger>
             {STEPS.map((s) => (
@@ -207,6 +233,56 @@ export default function Home() {
                 <p>{s.body}</p>
               </div>
             ))}
+          </div>
+          <div className="how-it-works-cta">
+            <Link className="btn btn-ghost" href="/how-it-works/">
+              Walk through the complete workflow →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="wrap">
+          <div className="product-proof" data-reveal>
+            <div className="product-proof-copy">
+              <span className="eyebrow">Operate with context</span>
+              <h2>Know what needs you before you open a terminal.</h2>
+              <p>
+                The Agents board makes parallel work legible. It groups sessions by status across projects, so the
+                next useful action is always easier to find than another tab.
+              </p>
+              <ul>
+                <li>See working, idle, done, and needs-you sessions together</li>
+                <li>Jump into the exact terminal that needs a decision</li>
+                <li>Keep long-running projects visible without interrupting them</li>
+              </ul>
+              <p style={{ marginTop: 20 }}>
+                <Link className="text-link" href="/how-it-works/#first-session">See the operating loop <span aria-hidden="true">→</span></Link>
+              </p>
+            </div>
+            <ProductShot id="agents-board" />
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="product-proof reverse" data-reveal>
+            <div className="product-proof-copy">
+              <span className="eyebrow">Keep judgment human</span>
+              <h2>Let the Inbox carry the decisions, not the noise.</h2>
+              <p>
+                Agents can finish analyses, share reports, or pause on a question. The Inbox gives those moments a
+                shared home and routes your answer back to the waiting session.
+              </p>
+              <ul>
+                <li>Read the context without hunting through scrollback</li>
+                <li>Reply inline to unblock the right agent</li>
+                <li>Keep routine automation folded away from high-signal work</li>
+              </ul>
+            </div>
+            <ProductShot id="inbox-decision" />
           </div>
         </div>
       </section>
@@ -266,11 +342,11 @@ export default function Home() {
                 <li>Install from the marketplace, or publish your own via GitHub</li>
               </ul>
               <div style={{ display: 'flex', gap: 12, marginTop: 20, flexWrap: 'wrap' }}>
-                <Link className="btn btn-primary" href="/docs/extensions-quickstart/">Build your first extension →</Link>
+                <Link className="btn btn-primary" href="/extensions/">Build your first extension →</Link>
                 <Link className="btn btn-ghost" href="/marketplace/">Browse extensions</Link>
               </div>
             </div>
-            <div className="visual" style={{ padding: 0, border: 'none', background: 'none', boxShadow: 'none' }}>
+            <div className="visual code-visual">
               <div className="code-showcase">
                 <div className="cs-bar">
                   <span className="tl r" />
@@ -294,7 +370,7 @@ export default function Home() {
             <span className="eyebrow">Get started</span>
             <h2>Bring every project into one window.</h2>
             <p className="section-lede" style={{ maxWidth: 520, margin: '0 auto 28px' }}>
-              Free, open, and signed. Install in minutes and reopen your Claude Code sessions to light it up.
+              Free, open, and signed. Install in minutes, choose your harness, and put your active projects in motion.
             </p>
             <div className="cta" style={{ display: 'flex', gap: 14, justifyContent: 'center' }}>
               <Link className="btn btn-primary btn-lg" href="/download/">⬇ Download Zana Command Center</Link>

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -9,7 +9,18 @@ import { site } from '@/lib/site';
  */
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = site.publicBaseUrl.replace(/\/$/, '');
-  const staticPaths = ['/', '/features/', '/marketplace/', '/download/', '/docs/'];
+  const staticPaths = [
+    '/',
+    '/how-it-works/',
+    '/features/',
+    '/extensions/',
+    '/extensions/getting-started/',
+    '/extensions/install/',
+    '/extensions/sdk/',
+    '/marketplace/',
+    '/download/',
+    '/docs/'
+  ];
   const docPaths = DOCS.map((d) => `/docs/${d.slug}/`);
   return [...staticPaths, ...docPaths].map((path) => ({
     url: `${base}${path}`,

--- a/website/content/docs/extensions-authoring.md
+++ b/website/content/docs/extensions-authoring.md
@@ -44,7 +44,7 @@ The host discovers extensions under `~/.zcc/extensions/<id>/`:
 | `permissions` | Capabilities the extension intends to use. **Enforced deny-by-default for disk extensions** (P3-B) — see below. |
 | `permissionScopes` | Scopes for `exec`/`fs:*`/`net`/`mcp`/`stream` (`execAllowlist`, `fsRoots`, `egressAllowlist`, `mcpAllowlist`, `streamAllowlist`) — see below. |
 | `projectTab` | Optional. Opt the renderer panel into a **per-project tab** (alongside Terminals / Explorer / Tickets). `{ label?, icon?, order? }`. See [Per-project tabs](#per-project-tabs-projecttab). |
-| `agentPreset` | Optional. Contribute a **framework preset** to the Advanced Quick-Agent launcher — a primer that boots a Claude session already understanding your framework. `{ systemPrompt, label?, description?, icon?, initialPrompt?, model?, baseProfile? }`. See [Framework presets](#framework-presets-agentpreset). |
+| `agentPreset` | Optional. Contribute a **framework preset** to the Advanced Quick-Agent launcher — a primer that boots a supported harness session already understanding your framework. `{ systemPrompt, label?, description?, icon?, initialPrompt?, model?, baseProfile? }`. See [Framework presets](#framework-presets-agentpreset). |
 | `skills` | Optional `SKILL.md` contributions, deployed only with `agent:contribute`. See [Contributing Skills & MCP servers](#contributing-skills--mcp-servers-agentcontribute). |
 | `mcpServers` | Optional MCP server definitions owned by this extension, deployed only with `agent:contribute`. See [Contributing Skills & MCP servers](#contributing-skills--mcp-servers-agentcontribute). |
 
@@ -529,7 +529,7 @@ view).
 Some extensions wrap a whole *way of working* — an orchestration surface, a CLI,
 a decision ritual. Declaring `agentPreset` lets your extension contribute a
 **framework preset** to the Advanced view of the Quick-Agent launcher (Agents →
-"+" → **Advanced** → **Framework**). Picking it spawns a Claude session with your
+"+" → **Advanced** → **Framework**). Picking it spawns a harness session with your
 `systemPrompt` injected via `--append-system-prompt`, so the agent boots already
 fluent in your framework's concepts, tools, and conventions — no per-launch
 copy-paste of a primer.
@@ -632,7 +632,7 @@ Key facts:
 ## Contributing Skills & MCP servers (`agent:contribute`)
 
 Unlike Personas/Teams (pure in-memory data ZCC owns end-to-end), a **skill** is
-a `SKILL.md` file every Claude Code session on the machine can load, and an
+a `SKILL.md` file compatible agent sessions on the machine can load, and an
 **MCP server** contribution is a server *definition* your extension owns (an
 arbitrary `command`/`args`/`url`) — both are artifacts that outlive your
 process and are consumed by `claude` CLI processes ZCC doesn't control. So
@@ -823,7 +823,7 @@ rejected (`PermissionDenied`) and audited.
 | `projects:read` | reading the open-project list / active project |
 | `projects:select` | changing the shell's selected project |
 | `session:reply` | `host.replyToSession(...)` / `host.writeToSession(...)` — writing to an existing terminal |
-| `session:launch` | `host.launchSession(...)` — launching a Claude tab |
+| `session:launch` | `host.launchSession(...)` — launching an agent tab |
 | `external:open` | `host.openExternal(url)` — opening an http(s) URL |
 | `inbox:push` | `host.pushInbox(...)` / `ctx.inbox.push(...)` — pushing a durable inbox entry |
 | `ssh:hosts` | `ctx.sshHosts` — contributing structured SSH hosts to the remote-project picker |

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -1,14 +1,13 @@
 # Getting started
 
-Zana Command Center (ZCC) turns Claude Code from a single terminal into a
-**multi-project cockpit**: run many `claude` sessions at once, see which ones
+Zana Command Center (ZCC) turns supported coding harnesses into a
+**multi-project cockpit**: run many agent sessions at once, see which ones
 need you versus which are still working, reply to them, and drive multi-agent
 workflows — all from one window.
 
 This guide takes you from a fresh install to your first orchestrated agent in
-about five minutes. It assumes you already use [Claude
-Code](https://claude.com/claude-code); ZCC runs real `claude` sessions, not a
-wrapper around them.
+about five minutes. ZCC launches the native CLI for Claude Code, OpenCode,
+Codex, or Pi rather than wrapping the harness in a generic chat UI.
 
 ```mermaid
 flowchart LR
@@ -26,10 +25,9 @@ flowchart LR
 Download the app from the [**Download**](/download/) page and open it. macOS is
 available today; Windows and Linux are on the way.
 
-**Prerequisites:** [Node](https://nodejs.org) 20 or newer, `git`, and the
-[`claude`](https://claude.com/claude-code) CLI on your `PATH`. ZCC launches
-`claude` for every session, so if `claude` works in your terminal, it works in
-ZCC.
+**Prerequisites:** [Node](https://nodejs.org) 20 or newer, `git`, and at least
+one supported harness CLI on your `PATH`: Claude Code, OpenCode, Codex, or Pi.
+If the harness works in your terminal, ZCC can launch its native session.
 
 On first launch the app opens to an empty cockpit — no projects yet. That's the
 next step.
@@ -52,14 +50,13 @@ navigable.
 
 ## 3. Spawn your first agent
 
-Open a project and start a session. Every tab is a **real PTY running
-`claude`** — a genuine Claude Code session, with the same behavior, tools, and
-permissions you already know.
+Open a project and start a session. Every tab is a **real PTY running the
+selected harness** with its native behavior, tools, and permissions.
 
 - Hit **New agent** (or the `+` in the workspace) to open a session in the
   current project.
-- The session starts in the project's directory, so `claude` sees the right
-  files immediately.
+- The session starts in the project's directory, so the selected harness sees
+  the right files immediately.
 - Type your task and let it work — exactly as you would in a standalone
   terminal.
 

--- a/website/content/docs/using-zana.md
+++ b/website/content/docs/using-zana.md
@@ -25,8 +25,8 @@ From the board you can:
   auto-close-idle.
 - **Close** a session when its work is done.
 
-Each tab is a real `claude` PTY, so anything you'd do in a standalone Claude
-Code session works here too.
+Each tab is a real harness PTY, so the native Claude Code, OpenCode, Codex, or
+Pi workflow remains available inside Zana.
 
 ### Keeping the fleet tidy
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -5,9 +5,17 @@
  * do not invent capabilities the app doesn't ship.
  */
 
+export type FeatureSlug =
+  | 'cockpit'
+  | 'agents-board'
+  | 'inbox'
+  | 'orchestration'
+  | 'projects'
+  | 'scheduler'
+  | 'extensions';
+
 export interface FeatureDetail {
-  slug: string;
-  ico: string;
+  slug: FeatureSlug;
   title: string;
   tagline: string;
   body: string;
@@ -20,11 +28,10 @@ export interface FeatureDetail {
 export const FEATURES: FeatureDetail[] = [
   {
     slug: 'cockpit',
-    ico: '🪟',
     title: 'Multi-project cockpit',
     tagline: 'One window for every project and every session.',
     body:
-      'A workspace of tabbed terminals where every tab is a real Claude Code session, not a wrapper. Switch projects without losing anything that is running.',
+      'A workspace of real Claude Code, OpenCode, Codex, and Pi terminals, not a generic chat wrapper. Switch projects or harnesses without losing anything that is running.',
     points: [
       'Real terminals — full shell, not a chat box',
       'Tabbed workspace with a command palette',
@@ -33,7 +40,6 @@ export const FEATURES: FeatureDetail[] = [
   },
   {
     slug: 'agents-board',
-    ico: '🧭',
     title: 'Agents board',
     tagline: 'See who needs you vs. who is still working.',
     body:
@@ -46,7 +52,6 @@ export const FEATURES: FeatureDetail[] = [
   },
   {
     slug: 'inbox',
-    ico: '🔔',
     title: 'Inbox',
     tagline: "Agents come to you — you don't watch every terminal.",
     body:
@@ -59,7 +64,6 @@ export const FEATURES: FeatureDetail[] = [
   },
   {
     slug: 'orchestration',
-    ico: '🤝',
     title: 'Multi-agent orchestration',
     tagline: 'Run a fleet — teams, sprints, and autopilot.',
     body:
@@ -72,7 +76,6 @@ export const FEATURES: FeatureDetail[] = [
   },
   {
     slug: 'projects',
-    ico: '🌐',
     title: 'Local & remote projects',
     tagline: 'Local folders or remote SSH — one explorer for both.',
     body:
@@ -85,7 +88,6 @@ export const FEATURES: FeatureDetail[] = [
   },
   {
     slug: 'scheduler',
-    ico: '⏱️',
     title: 'Scheduler, personas & teams',
     tagline: 'Automate recurring work with reusable crews.',
     body:
@@ -98,7 +100,6 @@ export const FEATURES: FeatureDetail[] = [
   },
   {
     slug: 'extensions',
-    ico: '🧩',
     title: 'Extensions & marketplace',
     tagline: 'Extend the app, or install from the marketplace.',
     body:

--- a/website/lib/product-shots.ts
+++ b/website/lib/product-shots.ts
@@ -1,0 +1,143 @@
+export const PRODUCT_SHOT_IDS = [
+  'cockpit-overview',
+  'project-setup',
+  'agent-terminal',
+  'agents-board',
+  'inbox-decision',
+  'team-launch',
+  'goal-or-ticket',
+  'marketplace-catalog',
+  'extension-install',
+  'extension-consent',
+  'local-extension-workspace',
+  'extension-panel-result',
+  'sdk-main-module'
+] as const;
+
+export type ProductShotId = (typeof PRODUCT_SHOT_IDS)[number];
+
+export interface ProductShotDefinition {
+  id: ProductShotId;
+  title: string;
+  caption: string;
+  alt: string;
+  capture: string;
+  aspectRatio: 'wide' | 'standard' | 'portrait';
+  /** Add a /product-shots/<name>.webp path when a reviewed screenshot is ready. */
+  src?: string;
+}
+
+/**
+ * The only place a product screenshot is named. A placeholder renders until
+ * `src` is set, so replacing a shot never requires touching page layouts.
+ */
+export const PRODUCT_SHOTS: Record<ProductShotId, ProductShotDefinition> = {
+  'cockpit-overview': {
+    id: 'cockpit-overview',
+    title: 'Zana Command Center',
+    caption: 'A single workspace for projects, terminals, agents, and the work that needs attention.',
+    alt: 'Zana Command Center showing projects, active agent sessions, and a terminal workspace.',
+    capture: 'Show the three-column cockpit with several active projects and a focused terminal.',
+    aspectRatio: 'wide'
+  },
+  'project-setup': {
+    id: 'project-setup',
+    title: 'Add a project',
+    caption: 'Connect local folders and remote SSH workspaces without changing how your coding harness starts.',
+    alt: 'The Add project dialog with local folder and remote SSH options.',
+    capture: 'Show local-folder and remote-SSH project options in the Add project flow.',
+    aspectRatio: 'standard'
+  },
+  'agent-terminal': {
+    id: 'agent-terminal',
+    title: 'Focused execution',
+    caption: 'Each tab is a real harness terminal, opened in the project that provides its context.',
+    alt: 'A coding agent task running in a Zana terminal tab.',
+    capture: 'Show a focused supported-harness task running in the correct project directory.',
+    aspectRatio: 'standard'
+  },
+  'agents-board': {
+    id: 'agents-board',
+    title: 'Agents board',
+    caption: 'See which sessions are working, waiting, idle, or complete without inspecting every tab.',
+    alt: 'The Zana Agents board showing sessions grouped by status.',
+    capture: 'Show a realistic mix of needs-you, working, idle, and done sessions.',
+    aspectRatio: 'wide'
+  },
+  'inbox-decision': {
+    id: 'inbox-decision',
+    title: 'Inbox',
+    caption: 'Questions, reports, and follow-ups reach one decision surface where replies route back to the right session.',
+    alt: 'The Zana Inbox with an agent question and an inline reply action.',
+    capture: 'Show a high-context agent question and the inline reply action, with no private data.',
+    aspectRatio: 'standard'
+  },
+  'team-launch': {
+    id: 'team-launch',
+    title: 'Teams',
+    caption: 'Launch a repeatable set of roles when a task needs research, implementation, and review in parallel.',
+    alt: 'A Zana team launch view showing multiple agent roles.',
+    capture: 'Show a team with clearly named roles and an explicit project destination.',
+    aspectRatio: 'standard'
+  },
+  'goal-or-ticket': {
+    id: 'goal-or-ticket',
+    title: 'Goals and tickets',
+    caption: 'Keep work that outlives a single session visible through goals, follow-ups, and project tickets.',
+    alt: 'A Zana goal or project ticket board with progress and ownership.',
+    capture: 'Show a goal or ticket board with progress, ownership, and a clear next action.',
+    aspectRatio: 'wide'
+  },
+  'marketplace-catalog': {
+    id: 'marketplace-catalog',
+    title: 'Extension marketplace',
+    caption: 'Browse extensions that add panels, project tabs, commands, personas, and teams.',
+    alt: 'The Zana extension marketplace showing a searchable extension catalog.',
+    capture: 'Show the marketplace catalog with search, extension metadata, and permission summaries.',
+    aspectRatio: 'wide'
+  },
+  'extension-install': {
+    id: 'extension-install',
+    title: 'Install an extension',
+    caption: 'Install from the marketplace, a local built folder, or a published archive using the same validation flow.',
+    alt: 'The Zana extension installation interface showing install options.',
+    capture: 'Show the extensions settings surface with marketplace, folder, and archive install options.',
+    aspectRatio: 'standard'
+  },
+  'extension-consent': {
+    id: 'extension-consent',
+    title: 'Review permissions',
+    caption: 'Extensions declare the capabilities they need; Zana asks for explicit consent before granting access.',
+    alt: 'A Zana extension permission consent dialog.',
+    capture: 'Show a permission review dialog with scoped capabilities and no sensitive values.',
+    aspectRatio: 'portrait'
+  },
+  'local-extension-workspace': {
+    id: 'local-extension-workspace',
+    title: 'Editable local extension',
+    caption: 'Keep a local source folder connected so a creator or shell session can rebuild and reload your extension live.',
+    alt: 'A local Zana extension source workspace connected to the desktop application.',
+    capture: 'Show an editable extension project with its manifest, source, and reload status.',
+    aspectRatio: 'wide'
+  },
+  'extension-panel-result': {
+    id: 'extension-panel-result',
+    title: 'Your panel in Zana',
+    caption: 'A renderer entry can return a React panel that runs inside the host application without a core rebuild.',
+    alt: 'A custom extension panel running inside Zana Command Center.',
+    capture: 'Show a small finished extension panel mounted inside the Zana application shell.',
+    aspectRatio: 'standard'
+  },
+  'sdk-main-module': {
+    id: 'sdk-main-module',
+    title: 'Brokered main module',
+    caption: 'Optional main-side capabilities are permission-gated and scoped by the host rather than granted as raw Node access.',
+    alt: 'Extension source code showing a Zana main module capability call.',
+    capture: 'Show a concise main-module example and its permission declaration side by side.',
+    aspectRatio: 'standard'
+  }
+};
+
+export function productShot(id: ProductShotId): ProductShotDefinition {
+  return PRODUCT_SHOTS[id];
+}

--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -1,7 +1,7 @@
 /** Central site config — copy + env-driven endpoints, all in one place. */
 export const site = {
   name: 'Zana Command Center',
-  tagline: 'Run and orchestrate many Claude Code sessions across all your projects from one window.',
+  tagline: 'Run and orchestrate Claude Code, OpenCode, Codex, and Pi sessions across every project from one window.',
   repo: 'https://github.com/salesforce/zana',
   /** PUBLIC release feed (github.com) — where the notarized artifacts +
    *  latest-mac.yml live and the auto-updater reads anonymously. */

--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,10 +1,80 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#2d5f3f"/>
-      <stop offset="1" stop-color="#4a7856"/>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fdf6e3"/>
+      <stop offset="100%" stop-color="#f0dfb4"/>
     </linearGradient>
+    <linearGradient id="wing" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6dfa3"/>
+      <stop offset="100%" stop-color="#d9b25c"/>
+    </linearGradient>
+    <linearGradient id="body" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fdf6e3"/>
+      <stop offset="100%" stop-color="#f0dfb4"/>
+    </linearGradient>
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="18" result="b"/>
+      <feMerge>
+        <feMergeNode in="b"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
   </defs>
-  <rect width="64" height="64" rx="16" fill="url(#g)"/>
-  <path d="M20 20h24l-24 24h24" stroke="#e5d4a1" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+
+  <!-- rounded square background -->
+  <rect x="32" y="32" width="960" height="960" rx="200" ry="200" fill="url(#bg)"/>
+
+  <!-- lower wings (larger, behind) -->
+  <g fill="url(#wing)" opacity="0.95">
+    <ellipse cx="330" cy="660" rx="230" ry="150" transform="rotate(-18 330 660)"/>
+    <ellipse cx="694" cy="660" rx="230" ry="150" transform="rotate(18 694 660)"/>
+  </g>
+
+  <!-- upper wings (smaller, in front) -->
+  <g fill="url(#wing)">
+    <ellipse cx="368" cy="470" rx="150" ry="105" transform="rotate(-24 368 470)"/>
+    <ellipse cx="656" cy="470" rx="150" ry="105" transform="rotate(24 656 470)"/>
+  </g>
+
+  <!-- wing vein accents -->
+  <g stroke="#a5773a" stroke-width="4" fill="none" opacity="0.55" stroke-linecap="round">
+    <path d="M330 540 Q 250 610 200 690"/>
+    <path d="M330 540 Q 300 630 260 720"/>
+    <path d="M694 540 Q 774 610 824 690"/>
+    <path d="M694 540 Q 724 630 764 720"/>
+  </g>
+
+  <!-- body / robe -->
+  <path d="M512 470
+           C 566 470 596 512 592 566
+           L 618 830
+           C 620 856 600 876 574 876
+           L 450 876
+           C 424 876 404 856 406 830
+           L 432 566
+           C 428 512 458 470 512 470 Z"
+        fill="url(#body)" stroke="#3f5a45" stroke-width="10"/>
+
+  <!-- head -->
+  <circle cx="512" cy="392" r="90" fill="url(#body)" stroke="#3f5a45" stroke-width="10"/>
+
+  <!-- face -->
+  <g stroke="#2f4436" stroke-width="8" stroke-linecap="round" fill="none">
+    <path d="M474 384 Q 484 372 496 384"/>
+    <path d="M528 384 Q 540 372 550 384"/>
+    <path d="M486 414 Q 512 430 538 414"/>
+  </g>
+
+  <!-- crown -->
+  <path d="M456 320 L 476 288 L 496 316 L 512 280 L 528 316 L 548 288 L 568 320"
+        fill="none" stroke="#d9b25c" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="512" cy="282" r="9" fill="#d9b25c"/>
+
+  <!-- wand + spark -->
+  <path d="M598 500 L 726 388" stroke="#3f5a45" stroke-width="10" stroke-linecap="round"/>
+  <g filter="url(#glow)">
+    <circle cx="748" cy="366" r="34" fill="#2f81f7"/>
+  </g>
+  <circle cx="748" cy="366" r="34" fill="#2f81f7"/>
+  <circle cx="738" cy="354" r="10" fill="#bcdcff" opacity="0.85"/>
 </svg>

--- a/website/public/product-shots/README.md
+++ b/website/public/product-shots/README.md
@@ -1,0 +1,28 @@
+# Product screenshots
+
+`website/lib/product-shots.ts` is the source of truth for every public product
+shot. Each page renders a deliberate browser-frame placeholder until its registry
+entry receives a `src` value.
+
+## Replace a placeholder
+
+1. Capture a screenshot at 2x scale with no customer data, access tokens,
+   personal paths, private repositories, or terminal history visible.
+2. Export as an optimized WebP in this directory. Use the shot id as the
+   filename, for example `agents-board.webp`.
+3. Set `src: '/product-shots/agents-board.webp'` for the matching entry in
+   `website/lib/product-shots.ts`.
+4. Review the entry's `alt` text and update it when the screenshot depicts a
+   different state.
+
+## Capture dimensions
+
+| Frame | Minimum exported size | Intended placements |
+| --- | --- | --- |
+| Wide | 1600 x 1000 | Hero, cockpit, agents board, marketplace |
+| Standard | 1440 x 900 | Features, installation, terminal, inbox |
+| Portrait | 1000 x 1250 | Dialogs, consent, focused settings views |
+
+Keep important details inside the central 80% of the frame. The site preserves
+each frame's ratio on small screens, so a screenshot should remain useful without
+requiring its text to be read for the surrounding page to make sense.

--- a/website/scripts/audit-ui.mjs
+++ b/website/scripts/audit-ui.mjs
@@ -1,0 +1,109 @@
+import { chromium } from '@playwright/test';
+
+const baseUrl = process.env.AUDIT_BASE_URL ?? 'http://127.0.0.1:4321';
+const routes = [
+  '/',
+  '/how-it-works/',
+  '/features/',
+  '/extensions/',
+  '/extensions/getting-started/',
+  '/extensions/install/',
+  '/extensions/sdk/',
+  '/marketplace/',
+  '/download/',
+  '/docs/',
+  '/docs/getting-started/',
+  '/dashboard/'
+];
+const viewports = [
+  { name: 'desktop', width: 1440, height: 1000 },
+  { name: 'tablet', width: 820, height: 1100 },
+  { name: 'mobile', width: 390, height: 844 }
+];
+
+const browser = await chromium.launch({ headless: true });
+const findings = [];
+
+try {
+  for (const theme of ['dark', 'light']) {
+    for (const viewport of viewports) {
+      const context = await browser.newContext({ viewport, colorScheme: theme });
+      await context.addInitScript((value) => localStorage.setItem('zcc-theme', value), theme);
+
+      for (const route of routes) {
+        const page = await context.newPage();
+        const consoleErrors = [];
+        page.on('console', (message) => {
+          if (message.type() === 'error') consoleErrors.push(message.text());
+        });
+        page.on('pageerror', (error) => consoleErrors.push(error.message));
+
+        const response = await page.goto(`${baseUrl}${route}`, { waitUntil: 'networkidle' });
+        const metrics = await page.evaluate(() => {
+          const visible = (element) => {
+            const style = getComputedStyle(element);
+            const rect = element.getBoundingClientRect();
+            return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+          };
+          const selector = 'a.btn, button.btn, .theme-toggle, .nav-burger, .docs-search-btn, input, select';
+          const controls = [...document.querySelectorAll(selector)]
+            .filter(visible)
+            .map((element) => {
+              const rect = element.getBoundingClientRect();
+              return {
+                label: (element.textContent || element.getAttribute('aria-label') || element.getAttribute('placeholder') || element.tagName).trim().replace(/\s+/g, ' '),
+                tag: element.tagName,
+                width: Math.round(rect.width),
+                height: Math.round(rect.height),
+                left: Math.round(rect.left),
+                right: Math.round(rect.right),
+                wraps: element.scrollHeight > rect.height + 2
+              };
+            });
+          const offscreen = [...document.querySelectorAll('main *, footer *')]
+            .filter(visible)
+            .filter((element) => !element.closest('pre'))
+            .map((element) => ({ element, rect: element.getBoundingClientRect() }))
+            .filter(({ rect }) => rect.left < -1 || rect.right > innerWidth + 1)
+            .slice(0, 12)
+            .map(({ element, rect }) => ({
+              tag: element.tagName,
+              className: String(element.className || '').slice(0, 100),
+              text: (element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 100),
+              left: Math.round(rect.left),
+              right: Math.round(rect.right)
+            }));
+          return {
+            pageWidth: document.documentElement.scrollWidth,
+            viewportWidth: innerWidth,
+            controls,
+            offscreen
+          };
+        });
+
+        const smallControls = metrics.controls.filter((control) => control.height < 40 || control.width < 40);
+        const clippedControls = metrics.controls.filter((control) => control.left < -1 || control.right > metrics.viewportWidth + 1 || control.wraps);
+        if (response?.status() !== 200 || metrics.pageWidth > metrics.viewportWidth + 1 || smallControls.length || clippedControls.length || metrics.offscreen.length || consoleErrors.length) {
+          findings.push({
+            route,
+            theme,
+            viewport: viewport.name,
+            status: response?.status(),
+            overflow: metrics.pageWidth - metrics.viewportWidth,
+            smallControls,
+            clippedControls,
+            offscreen: metrics.offscreen,
+            consoleErrors
+          });
+        }
+        await page.close();
+      }
+      await context.close();
+    }
+  }
+} finally {
+  await browser.close();
+}
+
+console.log(JSON.stringify({ audited: routes.length * viewports.length * 2, findings }, null, 2));
+if (findings.length) process.exitCode = 1;


### PR DESCRIPTION
## Summary
- reposition the website around Zana's multi-harness control-plane workflow
- add product-tour and extension guide routes with responsive product-shot framing
- align the site palette, navigation, branding, favicon, and public docs with the desktop app
- remove Cursor from public website and documentation copy

## Verification
- `npm run build --workspace website`
- `npm test --workspace website` (54 tests)
- `node website/scripts/audit-ui.mjs` (72 route/theme/viewport combinations, 0 findings)
- pre-push hook: typecheck and 4,647 tests passed
- `git diff --check`

## Notes
- existing Next.js middleware deprecation and Turbopack NFT warnings remain non-blocking
- Cursor application functionality is unchanged; only public website/documentation references were removed
