### PR TITLE
fix(opencode): surface confirmation questions as needs you

### DIFF
--- a/src/main/__tests__/screen-scan-blocked-detector.test.ts
+++ b/src/main/__tests__/screen-scan-blocked-detector.test.ts
@@ -76,6 +76,14 @@ const OC_QUESTION_SCREEN = [
   '↑↓ select  enter submit  esc dismiss'
 ].join('\n');
 
+/** Current OpenCode question cards use "confirm" rather than "submit". */
+const OC_CONFIRM_QUESTION_SCREEN = [
+  'Should I proceed with an implementation-ready design only?',
+  '  1. Design only',
+  '  2. Implement shell',
+  'tab select  enter confirm  esc dismiss'
+].join('\n');
+
 function makeDetector(overrides: Partial<ScreenScanBlockedDeps> = {}) {
   const blocked: string[] = [];
   const clock = makeClock();
@@ -282,6 +290,17 @@ describe('ScreenScanBlockedDetector × AgentStatusTracker × OutputActivity (Ope
     // Paints the question card and goes silent (same behavior as the permission
     // prompt — the gap this closes: it used to settle to `idle`, reading as "done").
     f.feed('oc', '\x1b[2J' + OC_QUESTION_SCREEN);
+    vi.advanceTimersByTime(DEFAULT_IDLE_AFTER_MS + 300);
+    expect(f.tracker.get('oc')).toBe('blocked');
+  });
+
+  it('OpenCode questions with the current "enter confirm" footer surface as `blocked`', () => {
+    const f = makeFusion();
+    f.feed('oc', 'I need a decision before continuing.');
+    vi.advanceTimersByTime(300);
+    expect(f.tracker.get('oc')).toBe('working');
+
+    f.feed('oc', '\x1b[2J' + OC_CONFIRM_QUESTION_SCREEN);
     vi.advanceTimersByTime(DEFAULT_IDLE_AFTER_MS + 300);
     expect(f.tracker.get('oc')).toBe('blocked');
   });

--- a/src/main/harness/__tests__/opencode-provider.test.ts
+++ b/src/main/harness/__tests__/opencode-provider.test.ts
@@ -671,9 +671,16 @@ describe('OpenCodeProvider', () => {
       expect(p.detectBlockedPrompt('opencode', QUESTION_SCREEN)).toBe(true);
     });
 
+    it('matches the current interactive question footer using "enter confirm"', () => {
+      expect(
+        p.detectBlockedPrompt('opencode', 'tab select  enter confirm  esc dismiss')
+      ).toBe(true);
+    });
+
     it('requires BOTH footer phrases — a lone "submit"/"dismiss" cannot trip it', () => {
       // Only one half of the key-hint pair present.
       expect(p.detectBlockedPrompt('opencode', 'press enter submit to continue')).toBe(false);
+      expect(p.detectBlockedPrompt('opencode', 'press enter confirm to continue')).toBe(false);
       expect(p.detectBlockedPrompt('opencode', 'you can esc dismiss this later')).toBe(false);
       // Prose that mentions submit/dismiss but never the contiguous key hints.
       expect(

--- a/src/main/harness/opencode/provider.ts
+++ b/src/main/harness/opencode/provider.ts
@@ -160,7 +160,7 @@ const OPENCODE_ADAPTER: TrustedHarnessAdapter = {
       return (
         (t.includes('permission required') &&
           (t.includes('reject') || t.includes('allow once') || t.includes('allow always'))) ||
-        (t.includes('enter submit') && t.includes('esc dismiss'))
+        ((t.includes('enter submit') || t.includes('enter confirm')) && t.includes('esc dismiss'))
       );
     }
   },
@@ -592,12 +592,11 @@ export class OpenCodeProvider extends BaseLaunchProvider {
    * and read as "done" while actually awaiting the user. The permission text above
    * never appears on this surface, so it needs its own signal. The distinctive,
    * blocking-only tell is the key-hint FOOTER the select/question component renders:
-   * `↑↓ select  enter submit  esc dismiss`. In the binary that bar is composed by
-   * span concatenation — `r("enter ")` + `"submit"` and `r("esc ")` + `"dismiss"`
-   * — so the two phrases `"enter submit"` and `"esc dismiss"` appear contiguously in
-   * the rendered screen text. We require BOTH together: a submit/dismiss key hint
-   * pair is emitted only by an open interactive prompt, never by streamed prose, so
-   * it can't false-positive on ordinary output.
+   * `↑↓ select  enter submit  esc dismiss`. The active question UI can instead
+   * render `enter confirm` (as shown in the terminal's question card), so we
+   * accept either action verb while still requiring the `esc dismiss` companion.
+   * The two phrases appear contiguously in the rendered screen text. Requiring the
+   * action hint AND dismissal hint prevents ordinary streamed prose from matching.
    *
    * LOCALE LIMITATION (v1): the permission `title` AND the footer key-hint labels
    * (`submit`/`dismiss`) are all localized in the binary
@@ -617,8 +616,9 @@ export class OpenCodeProvider extends BaseLaunchProvider {
       return true;
     }
     // Surface 2 — interactive question (ask/QuestionV2): the select-footer key-hint
-    // pair, emitted only while a prompt is open (both phrases required).
-    return t.includes('enter submit') && t.includes('esc dismiss');
+    // pair, emitted only while a prompt is open. OpenCode uses either "submit" or
+    // "confirm" for the Enter action depending on the question component.
+    return (t.includes('enter submit') || t.includes('enter confirm')) && t.includes('esc dismiss');
   }
 
   // guidanceArgs / hookArgs / personaArgs / projectSettingsArgs / authInjection /


### PR DESCRIPTION
## Summary
- detect OpenCode question footers that use `enter confirm` as blocking prompts
- preserve the existing `enter submit` detection
- add provider and end-to-end status-fusion coverage

## Verification
- `npm run typecheck`
- `npm test`