### PR TITLE
Point the auto-update feed at salesforce/zana

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,10 +224,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          # Keep the published feed aligned with electron-builder.yml. This
-          # cross-repository release needs a token with contents:write there.
-          repository: grebmann1/zcc-releases
-          token: ${{ secrets.ZCC_RELEASES_TOKEN }}
+          # Keep the published feed aligned with electron-builder.yml
+          # (owner: salesforce, repo: zana). Publish into this repository
+          # with the workflow GITHUB_TOKEN — no cross-repo release token.
           # dmg + zip + blockmap + latest-mac.yml must all be attached:
           # electron-updater reads latest-mac.yml to detect a new version and
           # downloads the zip (the dmg is for first-install only).

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -83,13 +83,13 @@ extraResources:
 # host/owner/repo are explicit (not derived from package.json) so a stale
 # `homepage` can't point the updater at the wrong repo.
 #
-# The release feed is the public github.com repo grebmann1/zcc-releases.
+# The release feed is the public github.com repo salesforce/zana.
 # electron-updater's `GitHubProvider` reads latest-mac.yml and artifacts
 # anonymously (no token, no VPN). Omitting `host:` defaults to public github.com.
 publish:
   provider: github
-  owner: grebmann1
-  repo: zcc-releases
+  owner: salesforce
+  repo: zana
 
 asar: true
 asarUnpack:


### PR DESCRIPTION
## Summary
- Bake `salesforce/zana` into the electron-builder GitHub updater provider so packaged apps check this repo for `latest-mac.yml`, not `grebmann1/zcc-releases`.
- Publish Release workflow artifacts into this repository with `GITHUB_TOKEN` instead of a cross-repo `ZCC_RELEASES_TOKEN`.

## Test plan
- [ ] Confirm `electron-builder.yml` `publish.owner` / `publish.repo` are `salesforce` / `zana`.
- [ ] After packaging, confirm `Zana.app/Contents/Resources/app-update.yml` contains `owner: salesforce` and `repo: zana`.
- [ ] Confirm the Release workflow no longer references `grebmann1/zcc-releases` or `ZCC_RELEASES_TOKEN`.
- [ ] After merge, a tagged release attaches `latest-mac.yml` + artifacts to `salesforce/zana` GitHub Releases.