### PR TITLE
Fix scheduled run close with background subagents

### DIFF
--- a/apps/desktop/src/host.ts
+++ b/apps/desktop/src/host.ts
@@ -5401,6 +5401,7 @@ async function bootstrapNormal() {
     store,
     inbox: inboxStore,
     logger: logMainError,
+    getPendingSubagentCount: (sessionId) => agentStatus.subagents(sessionId),
     resolvePersona: (id) => personas.list().find((p) => p.id === id)
   });
   scheduler.loadAll(store.listProjects());
@@ -5689,10 +5690,6 @@ async function bootstrapNormal() {
        // A blocked overlay wins over turn completion. The next UserPromptSubmit
        // callback begins a new turn and clears it; clearing here would turn an
        // unanswered permission/question into an incorrect idle state.
-      // A finished turn can have no in-flight sub-agents — reset the count so a
-      // SubagentStop hook that never fired (e.g. a killed sub-agent) can't leave
-      // a phantom badge on the parent.
-      agentStatus.clearSubagents(sessionId);
       // A finished turn can't have a tool still in flight — reset the idle-veto
       // counter so a PostToolUse that never fired (e.g. a killed tool call)
       // can't permanently pin the session's status away from idle.
@@ -5805,11 +5802,11 @@ async function bootstrapNormal() {
       fireTabNamer(sessionId, text);
     },
     // Sub-agent (Task tool) start/stop callback → live "N sub-agents running"
-    // badge. PreToolUse(Task) increments, SubagentStop decrements; the parent's
-    // Stop hook (above) resets the count as a drift guard.
+    // badge. PreToolUse(Task) increments and SubagentStop decrements.
     onSubagentHook: (_projectId: string, sessionId: string, action, identity) => {
       if (action === 'start') agentStatus.subagentStarted(sessionId, identity);
       else agentStatus.subagentStopped(sessionId);
+      scheduler.onSubagentCountChanged(sessionId);
       console.log(`[subagent-hook] session=${sessionId.slice(0, 8)} action=${action}`);
     },
     // Generic tool-activity callback → the idle-veto. `start`/`stop` bracket

--- a/apps/server/src/services/agents/agent-status.ts
+++ b/apps/server/src/services/agents/agent-status.ts
@@ -154,8 +154,7 @@ interface Entry {
   /**
    * How many sub-agents (Task tool spawns) are currently in flight for this
    * session. Incremented by the PreToolUse(Task) hook, decremented by
-   * SubagentStop, and clamped to 0 (a turn can't end with a live sub-agent, so
-   * the parent Stop hook also resets it as a drift guard). A purely
+   * SubagentStop, and clamped to 0. A purely
    * informational counter — kept OFF {@link resolve} so it never changes the
    * session's `working`/`blocked`/`idle` state, only the sub-agent badge.
    *
@@ -555,9 +554,8 @@ export class AgentStatusTracker extends EventEmitter {
   }
 
   /**
-   * Reset the live sub-agent count to 0 AND drain the child records (call on the
-   * parent's Stop hook / on exit — a finished turn can have no in-flight
-   * sub-agents, so this clears any drift from a SubagentStop that never fired).
+   * Reset the live sub-agent count to 0 AND drain child records on terminal PTY
+   * exit. Parent Stop can occur while background Task agents still run.
    * No-op (and no emit) when already clear.
    */
   clearSubagents(sessionId: string): void {

--- a/apps/server/src/services/scheduler/scheduler.test.ts
+++ b/apps/server/src/services/scheduler/scheduler.test.ts
@@ -155,8 +155,10 @@ function makeManager(extraTaskFields?: Record<string, unknown>): {
   manager: SchedulerManager;
   ptys: FakePtyManager;
   task: ReturnType<SchedulerManager['create']>;
+  pendingSubagents: { count: number };
 } {
   const ptys = new FakePtyManager();
+  const pendingSubagents = { count: 0 };
   const project: Project = {
     id: 'proj-1',
     name: 'P',
@@ -174,7 +176,8 @@ function makeManager(extraTaskFields?: Record<string, unknown>): {
   manager.setDeps({
     ptys: ptys as unknown as PtyManager,
     launchTerminal: (opts) => ptys.create(opts as unknown as Record<string, unknown>) as never,
-    store: fakeStore as unknown as Parameters<SchedulerManager['setDeps']>[0]['store']
+    store: fakeStore as unknown as Parameters<SchedulerManager['setDeps']>[0]['store'],
+    getPendingSubagentCount: () => pendingSubagents.count
   });
   const task = manager.create({
     name: 't',
@@ -184,7 +187,7 @@ function makeManager(extraTaskFields?: Record<string, unknown>): {
     enabled: false,
     ...extraTaskFields
   });
-  return { manager, ptys, task };
+  return { manager, ptys, task, pendingSubagents };
 }
 
 describe('SchedulerManager.fire — headless spawn', () => {
@@ -691,6 +694,98 @@ describe('SchedulerManager.onAgentFinished', () => {
     const run = runsOf(manager, task.id).find((r) => r.sessionId === sid)!;
     expect(run.finishedAt).toBeTruthy();
     expect(ptys.closeExpectedCalls).toEqual([sid]);
+  });
+
+  it('waits for a later zero-pending parent Stop after background work completes', () => {
+    const { manager, ptys, task, pendingSubagents } = makeManager({
+      prompt: 'work',
+      autoCloseOnFinish: true
+    });
+    autoFire(manager, task.id);
+    const sid = ptys.sessions[0].id;
+    pendingSubagents.count = 2;
+
+    manager.onAgentFinished(sid);
+    manager.onAgentFinished(sid); // duplicate parent Stop cannot arm another close
+    expect(ptys.closeExpectedCalls).toEqual([]);
+
+    pendingSubagents.count = 0;
+    manager.onSubagentCountChanged(sid);
+    // Child completion alone must leave time for parent result handling/reporting.
+    expect(ptys.closeExpectedCalls).toEqual([]);
+
+    manager.onAgentFinished(sid);
+    expect(ptys.closeExpectedCalls).toEqual([sid]);
+  });
+
+  it('times out a deferred background subagent run with an explicit error', () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, ptys, task, pendingSubagents } = makeManager({
+        prompt: 'work',
+        autoCloseOnFinish: true
+      });
+      autoFire(manager, task.id);
+      const sid = ptys.sessions[0].id;
+      pendingSubagents.count = 1;
+
+      manager.onAgentFinished(sid);
+      vi.advanceTimersByTime(10 * 60 * 1000);
+
+      expect(ptys.closeExpectedCalls).toEqual([sid]);
+      const run = runsOf(manager, task.id).find((candidate) => candidate.sessionId === sid)!;
+      expect(run.result).toBe('error');
+      expect(run.message).toBe('background subagent timed out');
+
+      // A later expected PTY exit cannot overwrite the explicit timeout error.
+      ptys.simulateExit(sid, 0);
+      const finalRun = runsOf(manager, task.id).find((candidate) => candidate.sessionId === sid)!;
+      expect(finalRun.result).toBe('error');
+      expect(finalRun.message).toBe('background subagent timed out');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears a deferred timeout when parent reaches its final Stop', () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, ptys, task, pendingSubagents } = makeManager({
+        prompt: 'work',
+        autoCloseOnFinish: true
+      });
+      autoFire(manager, task.id);
+      const sid = ptys.sessions[0].id;
+      pendingSubagents.count = 1;
+      manager.onAgentFinished(sid);
+
+      pendingSubagents.count = 0;
+      manager.onAgentFinished(sid);
+      vi.advanceTimersByTime(10 * 60 * 1000);
+
+      expect(ptys.closeExpectedCalls).toEqual([sid]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears deferred state on stopAll without closing the session', () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, ptys, task, pendingSubagents } = makeManager({
+        prompt: 'work',
+        autoCloseOnFinish: true
+      });
+      autoFire(manager, task.id);
+      pendingSubagents.count = 1;
+      manager.onAgentFinished(ptys.sessions[0].id);
+
+      manager.stopAll();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(ptys.closeExpectedCalls).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('finishedAt survives the exit-time recordRun merge', () => {

--- a/apps/server/src/services/scheduler/scheduler.ts
+++ b/apps/server/src/services/scheduler/scheduler.ts
@@ -61,6 +61,9 @@ const MAX_CONCURRENT_SCHEDULED_RUNS = 5;
  */
 const SCHEDULED_NONHOOK_MAX_RUNTIME_MS = 30 * 60 * 1000; // 30 min
 
+/** Bound a hook-capable parent that never receives its matching SubagentStop. */
+const SCHEDULED_SUBAGENT_WAIT_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
+
 export { parseEveryShared as parseEvery };
 
 interface Live {
@@ -78,6 +81,12 @@ interface Live {
    *  unboundedly over the app's lifetime. */
   countedRunIds: Set<string>;
 }
+
+type DeferredClose = {
+  taskId: string;
+  runId?: string;
+  timeout: NodeJS.Timeout;
+};
 
 /** Cap on {@link Live.countedRunIds}. Comfortably above any real `retain` so an
  *  in-flight run's id survives long enough to be recognized on exit, but bounded
@@ -99,6 +108,8 @@ type Deps = {
    * resolver = personas unavailable; a task's `personaId` is then ignored.
    */
   resolvePersona?: (id: string) => Persona | undefined;
+  /** Main-owned Task lifecycle state. Never accept this count from a hook request. */
+  getPendingSubagentCount?: (sessionId: string) => number;
 };
 
 /**
@@ -120,6 +131,8 @@ export class SchedulerManager extends EventEmitter {
    * (Rule 3). See {@link SCHEDULED_NONHOOK_MAX_RUNTIME_MS}.
    */
   private nonHookWatchdogs = new Map<string, NodeJS.Timeout>();
+  /** Hook-capable auto-close sessions waiting for background Task completion. */
+  private deferredCloses = new Map<string, DeferredClose>();
   /** Coordinator commits are async; count in-flight launches before PTY appears. */
   private pendingLaunches = 0;
   /** Lazily set after the window opens. We don't fire before then. */
@@ -286,6 +299,7 @@ export class SchedulerManager extends EventEmitter {
 
   remove(id: string) {
     this.disarm(id);
+    this.clearDeferredClosesForTask(id);
     this.live.delete(id);
     if (this.deps) {
       // Our own delete — keep the watcher quiet (mirrors persist()).
@@ -311,6 +325,8 @@ export class SchedulerManager extends EventEmitter {
     // change), not an app shutdown; the ptys have their own teardown (killAll).
     for (const watchdog of this.nonHookWatchdogs.values()) clearTimeout(watchdog);
     this.nonHookWatchdogs.clear();
+    for (const deferred of this.deferredCloses.values()) clearTimeout(deferred.timeout);
+    this.deferredCloses.clear();
   }
 
   /**
@@ -471,6 +487,7 @@ export class SchedulerManager extends EventEmitter {
       if (!live) continue;
       if (live.task.projectId === projectId) {
         this.disarm(id);
+        this.clearDeferredClosesForTask(id);
         this.live.delete(id);
         dropped += 1;
       }
@@ -783,6 +800,7 @@ export class SchedulerManager extends EventEmitter {
         clearTimeout(watchdog);
         this.nonHookWatchdogs.delete(session.id);
       }
+      this.clearDeferredClose(session.id);
       const exitMs = Date.now();
 
       // Exit code 0 alone doesn't mean the run actually completed: a severed
@@ -801,8 +819,14 @@ export class SchedulerManager extends EventEmitter {
         (r) => r.id === runId || r.sessionId === session.id
       );
       const hasReport = !!existingRun?.report || !!existingRun?.reportStatus;
-      const result: ScheduleRun['result'] =
-        exitCode !== 0 ? 'error' : expectsReport && !hasReport ? 'incomplete' : 'success';
+      const terminalError = existingRun?.result === 'error';
+      const result: ScheduleRun['result'] = terminalError
+        ? 'error'
+        : exitCode !== 0
+        ? 'error'
+        : expectsReport && !hasReport
+        ? 'incomplete'
+        : 'success';
 
       const finalRun: ScheduleRun = {
         id: runId,
@@ -811,7 +835,9 @@ export class SchedulerManager extends EventEmitter {
         sessionId: session.id,
         durationMs: exitMs - runStartMs,
         message:
-          exitCode !== 0
+          terminalError
+            ? existingRun?.message
+            : exitCode !== 0
             ? `exit ${exitCode}`
             : result === 'incomplete'
             ? 'exited without filing a schedule_report — possible silent failure'
@@ -824,7 +850,12 @@ export class SchedulerManager extends EventEmitter {
       // always escalates the notice to `loud` regardless of the schedule's
       // configured level, so a quiet schedule's silent failure still surfaces.
       if ((live.task.inboxLevel ?? 'quiet') !== 'silent') {
-        void this.notifyInboxOnExit(live.task, finalRun, project, result === 'incomplete');
+        void this.notifyInboxOnExit(
+          live.task,
+          finalRun,
+          project,
+          result === 'incomplete' || result === 'error'
+        );
       }
     };
     this.deps?.ptys.on('exit', onExit);
@@ -1039,12 +1070,68 @@ export class SchedulerManager extends EventEmitter {
       this.persist(live.task);
       this.emit('changed');
       if (live.task.autoCloseOnFinish) {
-        this.deps?.ptys.closeExpected(sessionId);
+        const pendingSubagents = this.deps?.getPendingSubagentCount?.(sessionId) ?? 0;
+        if (pendingSubagents > 0) {
+          this.deferClose(sessionId, live.task.id, run.id);
+        } else {
+          // Current main-owned count is authoritative for this later parent Stop.
+          this.clearDeferredClose(sessionId);
+          this.deps?.ptys.closeExpected(sessionId);
+        }
       }
       return;
     }
     // A non-scheduled interactive session is finished for now, not exited. Its
     // next UserPromptSubmit begins another lifecycle turn in the same PTY.
+  }
+
+  /**
+   * Re-evaluate a deferred scheduled session after a trusted Task hook transition.
+   * A zero count is intentionally not enough to close: parent must first process
+   * child output and send its later Stop hook.
+   */
+  onSubagentCountChanged(sessionId: string) {
+    // This only records readiness. Parent Stop remains close authorization so it
+    // can process Task output and publish a final result before its PTY closes.
+    if (!this.deferredCloses.has(sessionId)) return;
+    this.deps?.getPendingSubagentCount?.(sessionId);
+  }
+
+  private deferClose(sessionId: string, taskId: string, runId?: string) {
+    if (this.deferredCloses.has(sessionId)) return;
+    const timeout = setTimeout(() => {
+      const deferred = this.deferredCloses.get(sessionId);
+      if (!deferred) return;
+      this.deferredCloses.delete(sessionId);
+      const live = this.live.get(deferred.taskId);
+      if (!live) return;
+      const run = live.task.status.runs.find(
+        (candidate) => candidate.id === deferred.runId || candidate.sessionId === sessionId
+      );
+      if (run) {
+        this.recordRun(deferred.taskId, {
+          ...run,
+          result: 'error',
+          message: 'background subagent timed out'
+        });
+      }
+      this.deps?.ptys.closeExpected(sessionId);
+    }, SCHEDULED_SUBAGENT_WAIT_TIMEOUT_MS);
+    timeout.unref?.();
+    this.deferredCloses.set(sessionId, { taskId, runId, timeout });
+  }
+
+  private clearDeferredClose(sessionId: string) {
+    const deferred = this.deferredCloses.get(sessionId);
+    if (!deferred) return;
+    clearTimeout(deferred.timeout);
+    this.deferredCloses.delete(sessionId);
+  }
+
+  private clearDeferredClosesForTask(taskId: string) {
+    for (const [sessionId, deferred] of this.deferredCloses) {
+      if (deferred.taskId === taskId) this.clearDeferredClose(sessionId);
+    }
   }
 }
 

--- a/docs/scheduled-run-background-agent-lifecycle.md
+++ b/docs/scheduled-run-background-agent-lifecycle.md
@@ -1,0 +1,11 @@
+# Scheduled Run Background-Agent Lifecycle
+
+Hook-capable scheduled runs with `autoCloseOnFinish` now use main-owned Task lifecycle state before closing a session.
+
+1. Parent `Stop` with no pending Task children closes session immediately.
+2. Parent `Stop` with pending children marks run finished and defers close for up to 10 minutes.
+3. `SubagentStop` reducing count to zero does not close session. Parent can process child result, publish inbox/Slack output, and file `schedule_report`.
+4. Later parent `Stop` with zero pending children closes session once.
+5. Missing child completion records `error: background subagent timed out` before expected close. Exit-time reconciliation preserves that error.
+
+Non-hook providers retain existing 30-minute watchdog behavior. Parent Stop callbacks remain fire-and-forget.


### PR DESCRIPTION
## Summary
- defer scheduled auto-close while trusted Task lifecycle reports background subagents
- close only after a later zero-pending parent Stop, preserving result/report handling
- time out stuck background work after 10 minutes with an explicit error that PTY exit cannot overwrite

## Verification
- npm test -- --run src/main/__tests__/scheduler.test.ts src/main/__tests__/agent-status.test.ts
- npm run typecheck
- npm run build

## Known gap
- No new built-Electron HTTP-hook lifecycle E2E: existing fixture does not expose hook injection. Focused scheduler tests cover deferred-close state transitions and cleanup.