### PR TITLE
feat(app, desktop): local harness relaunch, plugin remove, compiled-module panel fallback

### DIFF
--- a/.claude/skills/sync-internal-repo/SKILL.md
+++ b/.claude/skills/sync-internal-repo/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sync-internal-repo
+description: Mirror github.com/salesforce/zana onto the Salesforce-internal git.soma clone, keeping that clone's README.md. Use when the user wants to sync with the original/internal repo, git.soma, chatbots/zana-command-center, or the legacy remote.
+disable-model-invocation: true
+---
+
+# Sync internal repo
+
+Push this public tree to **https://git.soma.salesforce.com/chatbots/zana-command-center**, except `README.md` (the internal “do not develop here” banner).
+
+GitHub.com/salesforce/zana is the product source. git.soma is a copy.
+
+## Do this
+
+1. Confirm Salesforce VPN (or other git.soma access). This checkout already has remote `legacy` pointing at that URL.
+2. Do **not** invent a merge or copy files by hand. Run the script from the repo root.
+3. Default source is `origin/main` (or `HEAD` if that ref is missing). To mirror the current commit: `SOURCE_REF=HEAD`.
+4. Dry-run first unless the user asked to push immediately:
+
+```bash
+DRY_RUN=1 bash scripts/sync-internal-mirror.sh
+```
+
+5. If that looks right, push:
+
+```bash
+bash scripts/sync-internal-mirror.sh
+```
+
+The script uses a temp index (`GIT_INDEX_FILE`); it does not dirty the working tree.
+
+## Env (optional)
+
+| Variable | Meaning |
+| --- | --- |
+| `SOURCE_REF` | Commit-ish to copy |
+| `INTERNAL_URL` | Defaults to the git.soma URL above |
+| `INTERNAL_REMOTE` | Tracking name, default `legacy` |
+| `INTERNAL_BRANCH` | Default `main` |
+| `SOMA_GIT_TOKEN` | PAT for HTTPS if `gh`/netrc is not enough |
+| `DRY_RUN=1` or `PUSH=0` | Build the commit, do not push |
+
+## Afterward
+
+Tell the user the source SHA, whether git.soma was already in sync, or the new internal commit SHA that was pushed. If fetch/push fails, it is almost always VPN or git.soma credentials — do not fall back to rewriting README or force-pushing.

--- a/.cursor/skills/sync-internal-repo/SKILL.md
+++ b/.cursor/skills/sync-internal-repo/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sync-internal-repo
+description: Mirror github.com/salesforce/zana onto the Salesforce-internal git.soma clone, keeping that clone's README.md. Use when the user wants to sync with the original/internal repo, git.soma, chatbots/zana-command-center, or the legacy remote.
+disable-model-invocation: true
+---
+
+# Sync internal repo
+
+Push this public tree to **https://git.soma.salesforce.com/chatbots/zana-command-center**, except `README.md` (the internal “do not develop here” banner).
+
+GitHub.com/salesforce/zana is the product source. git.soma is a copy.
+
+## Do this
+
+1. Confirm Salesforce VPN (or other git.soma access). This checkout already has remote `legacy` pointing at that URL.
+2. Do **not** invent a merge or copy files by hand. Run the script from the repo root.
+3. Default source is `origin/main` (or `HEAD` if that ref is missing). To mirror the current commit: `SOURCE_REF=HEAD`.
+4. Dry-run first unless the user asked to push immediately:
+
+```bash
+DRY_RUN=1 bash scripts/sync-internal-mirror.sh
+```
+
+5. If that looks right, push:
+
+```bash
+bash scripts/sync-internal-mirror.sh
+```
+
+The script uses a temp index (`GIT_INDEX_FILE`); it does not dirty the working tree.
+
+## Env (optional)
+
+| Variable | Meaning |
+| --- | --- |
+| `SOURCE_REF` | Commit-ish to copy |
+| `INTERNAL_URL` | Defaults to the git.soma URL above |
+| `INTERNAL_REMOTE` | Tracking name, default `legacy` |
+| `INTERNAL_BRANCH` | Default `main` |
+| `SOMA_GIT_TOKEN` | PAT for HTTPS if `gh`/netrc is not enough |
+| `DRY_RUN=1` or `PUSH=0` | Build the commit, do not push |
+
+## Afterward
+
+Tell the user the source SHA, whether git.soma was already in sync, or the new internal commit SHA that was pushed. If fetch/push fails, it is almost always VPN or git.soma credentials — do not fall back to rewriting README or force-pushing.

--- a/apps/app/src/lib/__tests__/product-client-hosts-relaunch.guard.test.ts
+++ b/apps/app/src/lib/__tests__/product-client-hosts-relaunch.guard.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('product-client hosts.relaunchLocal', () => {
+  it('prefers the desktop host-utility IPC over loopback HTTP steal', () => {
+    const source = readFileSync(new URL('../product-client.ts', import.meta.url), 'utf8');
+    expect(source).toContain("name === 'hosts'");
+    expect(source).toContain('relaunchLocal');
+    expect(source).toContain("'/hosts/relaunch-local'");
+    const hostsStart = source.indexOf("if (name === 'hosts')");
+    const hostsBlock = source.slice(hostsStart, source.indexOf("if (name === 'threads'", hostsStart));
+    expect(hostsBlock).toContain('hasDesktopBridge()');
+    expect(hostsBlock).toContain('desktop?.relaunchLocal');
+  });
+});

--- a/apps/app/src/lib/__tests__/product-client-plugin-apps.guard.test.ts
+++ b/apps/app/src/lib/__tests__/product-client-plugin-apps.guard.test.ts
@@ -6,6 +6,7 @@ describe('product-client pluginApps', () => {
     const source = readFileSync(new URL('../product-client.ts', import.meta.url), 'utf8');
     expect(source).toContain("apiJson<{ apps?: PluginAppEntry[] }>('/plugin-apps')");
     expect(source).toContain('/plugin-apps/${encodeURIComponent(id)}/');
+    expect(source).toContain('/plugin-apps/${encodeURIComponent(id)}/remove');
     expect(source).toContain("'/plugin-apps/updates'");
     expect(source).toContain('/plugin-apps/${encodeURIComponent(pluginId)}/rpc');
     expect(source).toContain('/plugin-apps/${encodeURIComponent(pluginId)}/settings');

--- a/apps/app/src/lib/product-client.ts
+++ b/apps/app/src/lib/product-client.ts
@@ -499,7 +499,11 @@ function httpProduct(): Pick<
         `/hosts/${encodeURIComponent(id)}/ssh-identity`,
         { method: 'PATCH', body: JSON.stringify(patch) }
       ),
-      onChanged: (cb) => subscribeProductEvent<Host[] | undefined>('hosts:changed', cb)
+      onChanged: (cb) => subscribeProductEvent<Host[] | undefined>('hosts:changed', cb),
+      relaunchLocal: async () => apiJson<{ ok: true } | { ok: false; message: string }>(
+        '/hosts/relaunch-local',
+        { method: 'POST', body: '{}' }
+      )
     } as CcApi['hosts'],
     relay: {
       status: async () => apiJson<{
@@ -889,6 +893,23 @@ function httpProduct(): Pick<
           };
         }
       },
+      remove: async (id) => {
+        try {
+          await apiJson(`/plugin-apps/${encodeURIComponent(id)}/remove`, {
+            method: 'POST',
+            body: '{}'
+          });
+          const listed = await apiJson<{ apps?: PluginAppEntry[] }>('/plugin-apps');
+          emitPluginApps(Array.isArray(listed.apps) ? listed.apps : []);
+          return { ok: true as const, value: true as const };
+        } catch (error) {
+          return {
+            ok: false as const,
+            code: 'WRITE_FAILED',
+            message: error instanceof Error ? error.message : String(error)
+          };
+        }
+      },
       callRpc: async (pluginId, method, args) => {
         const body = await apiJson<{ value?: unknown }>(
           `/plugin-apps/${encodeURIComponent(pluginId)}/rpc`,
@@ -1015,7 +1036,18 @@ function stubFamily(family: string): unknown {
 export const product: CcApi = new Proxy({} as CcApi, {
   get(_target, family: string | symbol) {
     const name = String(family);
-    if (name === 'threads' || name === 'environments' || name === 'hosts' || name === 'relay' || name === 'marketplaces' || name === 'cliSkills') {
+    if (name === 'hosts') {
+      const http = httpProduct().hosts;
+      if (hasDesktopBridge()) {
+        const desktop = (window.cc as unknown as CcApi).hosts;
+        return withStubs('hosts', {
+          ...http,
+          relaunchLocal: desktop?.relaunchLocal ?? http.relaunchLocal
+        });
+      }
+      return withStubs('hosts', http);
+    }
+    if (name === 'threads' || name === 'environments' || name === 'relay' || name === 'marketplaces' || name === 'cliSkills') {
       const http = httpProduct() as unknown as Record<string, unknown>;
       return withStubs(name, http[name] as object);
     }

--- a/apps/app/src/modules/ModulePanelHost.tsx
+++ b/apps/app/src/modules/ModulePanelHost.tsx
@@ -20,7 +20,7 @@ import { useUi } from '../store.js';
 import { useMergedModules } from './index.js';
 import { createModuleHost, createMountScopedHost, clearModuleCache } from './host.js';
 import { ErrorBoundary } from '../components/ErrorBoundary.js';
-import type { ModuleHost } from '@zana-ai/zcc-extension-sdk/renderer';
+import type { AppModule, ModuleHost } from '@zana-ai/zcc-extension-sdk/renderer';
 import { listNavPanels } from '../plugins/plugin-slots.js';
 import { PluginSlotBoundary } from '../plugins/PluginSlotBoundary.js';
 import { useRouteState } from '../hooks/useRouteState.js';
@@ -31,32 +31,31 @@ function generationFor(pluginId: string): number {
   return listNavPanels().find((panel) => panel.pluginId === pluginId)?.generation ?? 0;
 }
 
-export function ModulePanelHost() {
-  const nav = useUi((s) => s.nav);
-  const route = useRouteState();
-  const location = useLocation();
+/**
+ * Compiled-in / leftover disk-extension panel. Plugin nav URLs are split
+ * workspace routes, so {@link ModulePanelHost} sits out; the split pane falls
+ * back here when the plugin never registered a navPanel slot (Docs is the
+ * built-in example: UI lives in `apps/app`, `plugins/docs` only ships skills).
+ */
+export function AppModulePanel({ moduleId }: { moduleId: string }) {
   const modules = useMergedModules();
-  const pluginPanel = useHasPluginNavPanel(route.nav || nav);
-  const mod = useMemo(() => modules.find((m) => m.id === nav), [modules, nav]);
+  const mod = useMemo(() => modules.find((m) => m.id === moduleId), [modules, moduleId]);
+  return <ModulePanelBody mod={mod ?? null} extraHostClass="split-plugin-pane" />;
+}
 
-  // W1-6: wrap the cached base host in a per-MOUNT cleanup scope so the panel's
-  // `on`/`subscribe`/`register` subscriptions auto-dispose when this panel
-  // unmounts (nav switch / module change). Re-created per module id; the base
-  // host + its cache/storage are still the shared singleton.
+function ModulePanelBody({
+  mod,
+  extraHostClass
+}: {
+  mod: AppModule | null;
+  extraHostClass?: string;
+}) {
   const scoped = useMemo(() => (mod ? createMountScopedHost(getHost(mod.id)) : null), [mod]);
   const host: ModuleHost | null = scoped?.host ?? null;
   useEffect(() => () => scoped?.dispose(), [scoped]);
 
-  if (isSplitWorkspacePath(location.pathname) || pluginPanel) return null;
-
   if (!mod || !host) return null;
 
-  // As of the Phase 2 contract `panel` is optional: a module may contribute
-  // only `commands` and/or a `navBadge`. Such a module still owns a nav entry
-  // (for its badge + palette commands), so selecting it must not crash —
-  // ListPane has already bowed out of the content area for any merged module.
-  // We render a tasteful placeholder rather than nothing so the empty content
-  // area doesn't read as a broken view.
   const Panel = mod.panel;
   if (!Panel) {
     return (
@@ -71,14 +70,9 @@ export function ModulePanelHost() {
     );
   }
 
-  // Own the shell-grid placement HERE so every extension panel fills the content
-  // area (columns 2→3, full height) without each extension having to know the
-  // app-shell's grid secret. The list column returns null for a module nav, so a
-  // bare panel would otherwise auto-place into the narrow list track (col 2) and
-  // leave col 3 empty. This slot spans both — the extension's own root just needs
-  // to fill 100% (which `width:auto`/block already does inside a stretched slot).
+  const hostClass = extraHostClass ? `module-panel-host ${extraHostClass}` : 'module-panel-host';
   return (
-    <div className="module-panel-host">
+    <div className={hostClass}>
       <div className="module-panel-slot panel-body--full">
         <PluginSlotBoundary pluginId={mod.id} generation={generationFor(mod.id)}>
           <ErrorBoundary key={`${mod.id}:${generationFor(mod.id)}`}>
@@ -88,6 +82,19 @@ export function ModulePanelHost() {
       </div>
     </div>
   );
+}
+
+export function ModulePanelHost() {
+  const nav = useUi((s) => s.nav);
+  const route = useRouteState();
+  const location = useLocation();
+  const modules = useMergedModules();
+  const pluginPanel = useHasPluginNavPanel(route.nav || nav);
+  const mod = useMemo(() => modules.find((m) => m.id === nav), [modules, nav]);
+
+  if (isSplitWorkspacePath(location.pathname) || pluginPanel) return null;
+
+  return <ModulePanelBody mod={mod ?? null} />;
 }
 
 const hosts = new Map<string, ModuleHost>();

--- a/apps/app/src/styles/global.css
+++ b/apps/app/src/styles/global.css
@@ -8297,7 +8297,15 @@ body.resizing-col .ext-hub-resizer::before {
   padding: 4px 8px;
 }
 .ext-installed-row-chevron {
-  width: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
   opacity: 0;
   color: var(--text-muted);
   flex-shrink: 0;

--- a/apps/app/src/views/extensions/ExtensionsHub.tsx
+++ b/apps/app/src/views/extensions/ExtensionsHub.tsx
@@ -62,6 +62,7 @@ import {
   type InstalledPublisherFilter
 } from './installed-plugins.js';
 import { reportPluginEnabledFailure, setHubRowEnabled } from './plugin-row-enabled.js';
+import { uninstallHubRow } from './plugin-row-uninstall.js';
 import {
   applyHubPluginUpdate,
   pluginAvailableVersion,
@@ -624,7 +625,15 @@ function InstalledPluginRow({ row, onOpen }: { row: HubRow; onOpen: () => void }
         ) : (
           <span className="ext-installed-switch-spacer" aria-hidden="true" />
         )}
-        <ChevronRight size={14} className="ext-installed-row-chevron" aria-hidden="true" />
+        <button
+          type="button"
+          className="ext-installed-row-chevron"
+          onClick={onOpen}
+          tabIndex={-1}
+          aria-hidden="true"
+        >
+          <ChevronRight size={14} />
+        </button>
       </span>
     </div>
   );
@@ -929,6 +938,7 @@ function AboutCard({ row }: { row: HubRow }) {
   const openPanel = () => useUi.getState().setNav(module.id);
 
   const canToggle = plugin != null || entry != null;
+  const canUninstall = plugin != null || entry != null;
   const enabled = plugin ? plugin.enabled : (entry?.enabled ?? true);
   const toggleEnabled = () => {
     void setHubRowEnabled({ module, entry: entry ?? null, plugin: plugin ?? null }, !enabled, product)
@@ -1007,11 +1017,11 @@ function AboutCard({ row }: { row: HubRow }) {
     }
   };
   const uninstall = async () => {
-    if (!entry) return;
+    if (!canUninstall) return;
     setRemoving(true);
     setRemoveError(null);
     try {
-      const res = await product.extensions.uninstall(entry.id);
+      const res = await uninstallHubRow({ module, entry: entry ?? null, plugin: plugin ?? null }, product);
       if (!res.ok) {
         setRemoveError(res.message ?? 'Uninstall failed');
         setRemoving(false);
@@ -1183,7 +1193,7 @@ function AboutCard({ row }: { row: HubRow }) {
               </button>
             )}
           </div>
-          {entry && (
+          {canUninstall && (
             <div className="ext-actions ext-actions--end">
               {confirmRemove ? (
                 <>
@@ -1210,7 +1220,7 @@ function AboutCard({ row }: { row: HubRow }) {
                   type="button"
                   className="settings-btn danger-ghost"
                   onClick={() => setConfirmRemove(true)}
-                  title="Uninstall this extension"
+                  title="Uninstall this plugin"
                 >
                   <Trash2 size={14} />
                   Uninstall

--- a/apps/app/src/views/extensions/ExtensionsView.test.ts
+++ b/apps/app/src/views/extensions/ExtensionsView.test.ts
@@ -83,4 +83,11 @@ describe('ExtensionsView aurora background', () => {
     expect(hub).toContain('setHubRowEnabled');
     expect(hub).not.toContain('.catch(() => {}).finally(() => setPending(null))');
   });
+
+  it('opens plugin details from the trailing chevron as well as the row', () => {
+    expect(hub).toContain('className="ext-installed-row-chevron"');
+    expect(hub).toContain('onClick={onOpen}');
+    const chevron = hub.slice(hub.indexOf('ext-installed-row-chevron'));
+    expect(chevron.startsWith('ext-installed-row-chevron"\n          onClick={onOpen}')).toBe(true);
+  });
 });

--- a/apps/app/src/views/extensions/buildHubRows.test.ts
+++ b/apps/app/src/views/extensions/buildHubRows.test.ts
@@ -96,14 +96,13 @@ describe('buildHubRows — union of loaded modules + discovered entries', () => 
     expect(rows.filter((r) => r.module.id === 'foo-0001')).toHaveLength(1);
   });
 
-  it('keeps built-ins (no entry) alongside extension rows, sorted by title', () => {
+  it('keeps built-in compiled modules out of Installed unless they are actually installed', () => {
     const rows = buildHubRows(
-      [mod('slack', 'Slack')],
+      [mod('docs', 'Docs')],
       [entry('aaa-0001', { manifest: { id: 'aaa-0001', title: 'Aardvark', icon: 'Box', engines: { zccApi: '^1' }, entry: { renderer: 'r.js' } } } as unknown as Partial<ExtensionEntry>)]
     );
-    expect(rows.map((r) => r.module.title)).toEqual(['Aardvark', 'Slack']);
-    // The built-in row has no disk entry.
-    expect(rows.find((r) => r.module.id === 'slack')?.entry).toBeNull();
+    expect(rows.map((r) => r.module.title)).toEqual(['Aardvark']);
+    expect(rows.find((r) => r.module.id === 'docs')).toBeUndefined();
   });
 });
 

--- a/apps/app/src/views/extensions/installed-plugins.test.ts
+++ b/apps/app/src/views/extensions/installed-plugins.test.ts
@@ -86,6 +86,7 @@ describe('buildHubRows — PluginService snapshot union', () => {
     expect(local?.plugin).toBeNull();
     expect(installedPublisher(local!)).toBe('local');
     expect(publisherLabel('local')).toBe('Local');
+    expect(rows.find((row) => row.module.id === 'slack')).toBeUndefined();
   });
 });
 

--- a/apps/app/src/views/extensions/installed-plugins.ts
+++ b/apps/app/src/views/extensions/installed-plugins.ts
@@ -65,8 +65,9 @@ export function displayIcon(name: string): string {
  * Loaded modules keep their real (executable) module. Every disk entry or
  * installed plugin whose id is NOT already covered by a loaded module gets a
  * display-only placeholder so an unconsented / disabled / no-UI plugin stays
- * visible and manageable. Exported for unit tests — this join is the fix for
- * the disappearing-row bug and the Installed collection's "list every builtin".
+ * visible and manageable. Compiled-in app modules with no plugin snapshot and
+ * no disk entry are omitted — Installed lists what is installed, not the
+ * renderer registry.
  */
 export function buildHubRows(
   modules: (AppModule & { loadError?: string })[],
@@ -81,6 +82,7 @@ export function buildHubRows(
   for (const id of ids) {
     const plugin = byPlugin.get(id) ?? null;
     const entry = byEntry.get(id) ?? null;
+    if (!plugin && !entry) continue;
     const loaded = byModule.get(id);
     const module =
       loaded ?? (plugin ? placeholderFromPlugin(plugin) : placeholderModule(entry!));

--- a/apps/app/src/views/extensions/plugin-row-uninstall.test.ts
+++ b/apps/app/src/views/extensions/plugin-row-uninstall.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AppModule } from '@zana-ai/zcc-extension-sdk/renderer';
+import type { ExtensionEntry, PluginAppEntry } from '@zana-ai/zcc-domain/product';
+import { uninstallHubRow, type PluginUninstallApi } from './plugin-row-uninstall.js';
+import type { HubRow } from './installed-plugins.js';
+
+function row(over: Partial<HubRow> = {}): HubRow {
+  const module: AppModule = { id: 'docs', title: 'Docs', icon: 'Library' };
+  return { module, entry: null, plugin: null, ...over };
+}
+
+function plugin(id = 'docs'): PluginAppEntry {
+  return {
+    id,
+    name: id,
+    description: '',
+    icon: 'Puzzle',
+    enabled: true,
+    provenance: 'builtin',
+    status: 'running',
+    appUrl: null
+  };
+}
+
+function entry(id = 'docs'): ExtensionEntry {
+  return {
+    id,
+    enabled: true,
+    loaded: true,
+    consented: true,
+    needsConsent: null,
+    path: `/ext/${id}`
+  } as ExtensionEntry;
+}
+
+function api(over: Partial<PluginUninstallApi> = {}): PluginUninstallApi {
+  return {
+    pluginApps: { remove: vi.fn(async () => ({ ok: true as const, value: true as const })) },
+    extensions: { uninstall: vi.fn(async () => ({ ok: true as const, value: true as const })) },
+    ...over
+  };
+}
+
+describe('uninstallHubRow', () => {
+  it('removes a PluginService plugin even when no disk entry exists', async () => {
+    const host = api();
+    await expect(uninstallHubRow(row({ plugin: plugin('docs') }), host)).resolves.toEqual({
+      ok: true,
+      value: true
+    });
+    expect(host.pluginApps.remove).toHaveBeenCalledWith('docs');
+    expect(host.extensions.uninstall).not.toHaveBeenCalled();
+  });
+
+  it('uninstalls a leftover disk extension when there is no plugin snapshot', async () => {
+    const host = api();
+    await uninstallHubRow(row({ entry: entry('zana') }), host);
+    expect(host.extensions.uninstall).toHaveBeenCalledWith('zana');
+    expect(host.pluginApps.remove).not.toHaveBeenCalled();
+  });
+
+  it('removes both layers when a plugin and a leftover sidecar share an id', async () => {
+    const host = api();
+    await uninstallHubRow(row({ plugin: plugin('zana'), entry: entry('zana') }), host);
+    expect(host.pluginApps.remove).toHaveBeenCalledWith('zana');
+    expect(host.extensions.uninstall).toHaveBeenCalledWith('zana');
+  });
+
+  it('treats a missing leftover sidecar as success after the plugin is gone', async () => {
+    const host = api({
+      extensions: {
+        uninstall: vi.fn(async () => ({ ok: false as const, code: 'NOT_FOUND', message: 'not found' }))
+      }
+    });
+    await expect(
+      uninstallHubRow(row({ plugin: plugin('docs'), entry: entry('docs') }), host)
+    ).resolves.toEqual({ ok: true, value: true });
+  });
+
+  it('rejects a display-only row with no uninstall API', async () => {
+    await expect(uninstallHubRow(row(), api())).resolves.toMatchObject({
+      ok: false,
+      code: 'UNAVAILABLE'
+    });
+  });
+});

--- a/apps/app/src/views/extensions/plugin-row-uninstall.ts
+++ b/apps/app/src/views/extensions/plugin-row-uninstall.ts
@@ -1,0 +1,40 @@
+import type { HubRow } from './installed-plugins.js';
+
+export interface PluginUninstallApi {
+  pluginApps: {
+    remove: (
+      id: string
+    ) => Promise<{ ok: true } | { ok: false; code?: string; message?: string }>;
+  };
+  extensions: {
+    uninstall: (
+      id: string
+    ) => Promise<{ ok: true } | { ok: false; code?: string; message?: string }>;
+  };
+}
+
+function alreadyGone(
+  res: { ok: true } | { ok: false; code?: string; message?: string }
+): boolean {
+  if (res.ok) return false;
+  return res.code === 'NOT_FOUND' || /not found|unknown/i.test(res.message ?? '');
+}
+
+export async function uninstallHubRow(row: HubRow, api: PluginUninstallApi) {
+  if (!row.plugin && !row.entry) {
+    return {
+      ok: false as const,
+      code: 'UNAVAILABLE' as const,
+      message: 'This plugin cannot be uninstalled'
+    };
+  }
+  if (row.plugin) {
+    const removed = await api.pluginApps.remove(row.plugin.id);
+    if (!removed.ok) return removed;
+  }
+  if (row.entry) {
+    const leftover = await api.extensions.uninstall(row.entry.id);
+    if (!leftover.ok && !alreadyGone(leftover)) return leftover;
+  }
+  return { ok: true as const, value: true as const };
+}

--- a/apps/app/src/views/settings/MachineCard.tsx
+++ b/apps/app/src/views/settings/MachineCard.tsx
@@ -15,7 +15,7 @@ import {
   type MachineProviderCliRow,
   type ProviderCliTone
 } from './machine-provider-clis.js';
-import { machineCanReconnect } from './machine-reconnect.js';
+import { machineCanReconnect, machineCanRelaunchLocal } from './machine-reconnect.js';
 import { machineConnectionCopy, permissionLabel } from './machine-status.js';
 
 function StatusIcon({ tone }: { tone: ProviderCliTone | 'error' }) {
@@ -120,6 +120,8 @@ export function MachineCard({
   renameValue,
   reconnecting,
   reconnectError,
+  relaunching = false,
+  relaunchError = null,
   onRenameValue,
   onRenameStart,
   onRenameCommit,
@@ -127,6 +129,7 @@ export function MachineCard({
   onRetryUpdate,
   onRemove,
   onReconnect,
+  onRelaunch,
   onInstall
 }: {
   host: Host;
@@ -139,6 +142,8 @@ export function MachineCard({
   renameValue: string;
   reconnecting: boolean;
   reconnectError: string | null;
+  relaunching?: boolean;
+  relaunchError?: string | null;
   onRenameValue: (value: string) => void;
   onRenameStart: () => void;
   onRenameCommit: () => void;
@@ -146,12 +151,14 @@ export function MachineCard({
   onRetryUpdate: () => void;
   onRemove: () => void;
   onReconnect: () => void;
+  onRelaunch?: () => void;
   onInstall: (provider: ProviderCliKey, actionKind: ProviderCliInstallActionKind) => void;
 }) {
   const connection = machineConnectionCopy(host, now);
   const HostIcon = host.isPrimary ? Laptop : Monitor;
   const projectLabel = `${projectCount} ${projectCount === 1 ? 'project' : 'projects'}`;
   const showReconnect = machineCanReconnect(host);
+  const showRelaunch = machineCanRelaunchLocal(host);
 
   return (
     <li className={`machine-card${host.status === 'connected' ? ' machine-card--online' : ''}`}>
@@ -225,6 +232,19 @@ export function MachineCard({
               {reconnecting ? 'Reconnecting…' : 'Reconnect'}
             </button>
           ) : null}
+          {showRelaunch ? (
+            <button
+              type="button"
+              className="settings-btn"
+              disabled={relaunching}
+              onClick={onRelaunch}
+              aria-label={`Relaunch the local harness on ${host.name}`}
+              data-testid={`machine-relaunch-${host.id}`}
+            >
+              <RefreshCw size={13} aria-hidden="true" className={relaunching ? 'spinning' : undefined} />
+              {relaunching ? 'Relaunching…' : 'Relaunch harness'}
+            </button>
+          ) : null}
           {host.lastRejectedProtocolVersion ? (
             <button type="button" className="settings-btn" onClick={onRetryUpdate}>
               Retry update
@@ -245,18 +265,26 @@ export function MachineCard({
         </div>
       </div>
       {host.status === 'connected' ? (
-        <MachineCliInventory
-          hostId={host.id}
-          rows={cliRows}
-          busyKey={busyKey}
-          installErrors={installErrors}
-          onInstall={onInstall}
-        />
+        <>
+          <MachineCliInventory
+            hostId={host.id}
+            rows={cliRows}
+            busyKey={busyKey}
+            installErrors={installErrors}
+            onInstall={onInstall}
+          />
+          {relaunchError ? (
+            <p className="machine-reconnect-error" role="alert">{relaunchError}</p>
+          ) : null}
+        </>
       ) : (
         <div className="machine-cli-offline-wrap">
           <p className="machine-cli-offline">Connect this machine to see harness CLI versions.</p>
           {reconnectError ? (
             <p className="machine-reconnect-error" role="alert">{reconnectError}</p>
+          ) : null}
+          {relaunchError ? (
+            <p className="machine-reconnect-error" role="alert">{relaunchError}</p>
           ) : null}
         </div>
       )}

--- a/apps/app/src/views/settings/MachinesSettingsView.test.tsx
+++ b/apps/app/src/views/settings/MachinesSettingsView.test.tsx
@@ -21,7 +21,8 @@ vi.mock('../../lib/product-client.js', () => ({
       update: async () => undefined,
       updatePermissionCeiling: async () => undefined,
       retryUpdate: async () => undefined,
-      remove: async () => undefined
+      remove: async () => undefined,
+      relaunchLocal: async () => ({ ok: true as const })
     },
     relay: {
       status: async () => ({ state: 'unconfigured' }),
@@ -142,6 +143,8 @@ describe('MachinesTab', () => {
     expect(html).toContain('this machine');
     expect(html).toContain('2 projects');
     expect(html).toContain('Permission ceiling');
+    expect(html).toContain('Relaunch harness');
+    expect(html).toContain('data-testid="machine-relaunch-h1"');
     expect(html).not.toContain('data-testid="machines-empty"');
   });
 
@@ -293,6 +296,7 @@ describe('MachineCard', () => {
     expect(html).toContain('Rename');
     expect(html).toContain('Remove');
     expect(html).not.toContain('Reconnect');
+    expect(html).not.toContain('Relaunch harness');
     expect(html).not.toContain('this machine</span>');
     expect(html).toContain('Harness CLIs');
   });
@@ -351,7 +355,36 @@ describe('MachineCard', () => {
     expect(html).toContain('Connect this machine to see harness CLI versions');
     expect(html).not.toContain('Remove');
     expect(html).not.toContain('Reconnect');
+    expect(html).toContain('Relaunch harness');
     expect(html).not.toContain('Harness CLIs');
+  });
+
+  it('shows Relaunching… while the local daemon restarts', () => {
+    const html = renderToStaticMarkup(
+      <MachineCard
+        host={host({ isPrimary: true, name: 'MacBook' })}
+        projectCount={1}
+        now={Date.now()}
+        cliRows={[]}
+        busyKey={null}
+        renaming={false}
+        renameValue=""
+        reconnecting={false}
+        reconnectError={null}
+        relaunching
+        relaunchError="daemon.lock is held"
+        onRenameValue={vi.fn()}
+        onRenameStart={vi.fn()}
+        onRenameCommit={vi.fn()}
+        onPermissionChange={vi.fn()}
+        onRetryUpdate={vi.fn()}
+        onRemove={vi.fn()}
+        onReconnect={vi.fn()}
+        onInstall={vi.fn()}
+      />
+    );
+    expect(html).toContain('Relaunching…');
+    expect(html).toContain('daemon.lock is held');
   });
 
   it('offers retry update and an inline rename field', () => {

--- a/apps/app/src/views/settings/MachinesSettingsView.tsx
+++ b/apps/app/src/views/settings/MachinesSettingsView.tsx
@@ -131,6 +131,8 @@ export function MachinesSettingsView({
   const [installErrors, setInstallErrors] = useState<Record<string, string>>({});
   const [repairingId, setRepairingId] = useState<string | null>(null);
   const [repairError, setRepairError] = useState<{ hostId: string; message: string } | null>(null);
+  const [relaunchingId, setRelaunchingId] = useState<string | null>(null);
+  const [relaunchError, setRelaunchError] = useState<{ hostId: string; message: string } | null>(null);
   const [sshPick, setSshPick] = useState<{ hostId: string; name: string } | null>(null);
   const now = Date.now();
   const counts = useMemo(() => {
@@ -189,6 +191,24 @@ export function MachinesSettingsView({
       setRepairError({ hostId: host.id, message: result.message });
     } finally {
       setRepairingId(null);
+    }
+  }
+
+  async function runRelaunch(hostId: string): Promise<void> {
+    setRelaunchError(null);
+    setRelaunchingId(hostId);
+    try {
+      const result = await product.hosts.relaunchLocal();
+      if (!result.ok) {
+        setRelaunchError({ hostId, message: result.message });
+      }
+    } catch (err) {
+      setRelaunchError({
+        hostId,
+        message: err instanceof Error ? err.message : 'Could not relaunch this machine'
+      });
+    } finally {
+      setRelaunchingId(null);
     }
   }
 
@@ -307,7 +327,10 @@ export function MachinesSettingsView({
               onRetryUpdate={() => void product.hosts.retryUpdate(host.id)}
               reconnecting={repairingId === host.id}
               reconnectError={repairError?.hostId === host.id ? repairError.message : null}
+              relaunching={relaunchingId === host.id}
+              relaunchError={relaunchError?.hostId === host.id ? relaunchError.message : null}
               onReconnect={() => void runReconnect(host.id)}
+              onRelaunch={() => void runRelaunch(host.id)}
               onRemove={() => {
                 if (window.confirm(`Remove ${host.name}?`)) {
                   void product.hosts.remove(host.id);

--- a/apps/app/src/views/settings/machine-reconnect.test.ts
+++ b/apps/app/src/views/settings/machine-reconnect.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Host } from '@zana-ai/zcc-domain/thread-runtime';
 import {
   machineCanReconnect,
+  machineCanRelaunchLocal,
   reconnectMachine
 } from './machine-reconnect.js';
 
@@ -27,6 +28,14 @@ describe('machineCanReconnect', () => {
     expect(machineCanReconnect(host())).toBe(true);
     expect(machineCanReconnect(host({ status: 'connected' }))).toBe(false);
     expect(machineCanReconnect(host({ isPrimary: true }))).toBe(false);
+  });
+});
+
+describe('machineCanRelaunchLocal', () => {
+  it('offers relaunch on this machine only', () => {
+    expect(machineCanRelaunchLocal(host({ isPrimary: true }))).toBe(true);
+    expect(machineCanRelaunchLocal(host({ isPrimary: true, status: 'connected' }))).toBe(true);
+    expect(machineCanRelaunchLocal(host())).toBe(false);
   });
 });
 

--- a/apps/app/src/views/settings/machine-reconnect.ts
+++ b/apps/app/src/views/settings/machine-reconnect.ts
@@ -5,6 +5,10 @@ export function machineCanReconnect(host: Host): boolean {
   return !host.isPrimary && host.status !== 'connected';
 }
 
+export function machineCanRelaunchLocal(host: Host): boolean {
+  return host.isPrimary;
+}
+
 export type MachineReconnectResult =
   | { ok: true; hostId: string }
   | { ok: false; message: string; needsSshPick?: boolean };

--- a/apps/app/src/views/thread-detail/PluginPanelPaneView.test.tsx
+++ b/apps/app/src/views/thread-detail/PluginPanelPaneView.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const slots = vi.hoisted(() => ({
+  panels: [] as Array<{
+    pluginId: string;
+    id: string;
+    path?: string;
+    generation: number;
+    component: (props: { pluginId: string; subPath: string }) => unknown;
+  }>,
+  modules: [] as Array<{ id: string; title: string }>
+}));
+
+vi.mock('../../plugins/plugin-slots.js', () => ({
+  subscribePluginSlots: (listener: () => void) => {
+    listener();
+    return () => undefined;
+  },
+  listNavPanels: () => slots.panels
+}));
+
+vi.mock('../../modules/index.js', () => ({
+  useMergedModules: () => slots.modules
+}));
+
+vi.mock('../../modules/ModulePanelHost.js', () => ({
+  AppModulePanel: ({ moduleId }: { moduleId: string }) => (
+    <div data-testid="compiled-module">{moduleId}</div>
+  )
+}));
+
+vi.mock('../../plugins/PluginSlotBoundary.js', () => ({
+  PluginSlotBoundary: ({ children }: { children: unknown }) => children
+}));
+
+import { PluginPanelPaneView } from './PluginPanelPaneView.js';
+
+describe('PluginPanelPaneView', () => {
+  it('renders a plugin navPanel slot when one is registered', () => {
+    slots.panels = [
+      {
+        pluginId: 'tasks',
+        id: 'panel',
+        path: 'panel',
+        generation: 1,
+        component: ({ pluginId }) => <div>slot:{pluginId}</div>
+      }
+    ];
+    slots.modules = [];
+    const html = renderToStaticMarkup(
+      <PluginPanelPaneView pluginId="tasks" panelPath="panel" subPath="" />
+    );
+    expect(html).toContain('slot:tasks');
+    expect(html).not.toContain('compiled-module');
+    slots.panels = [];
+  });
+
+  it('falls back to the compiled AppModule panel when Docs has no navPanel slot', () => {
+    slots.panels = [];
+    slots.modules = [{ id: 'docs', title: 'Docs' }];
+    const html = renderToStaticMarkup(
+      <PluginPanelPaneView pluginId="docs" panelPath="panel" subPath="" />
+    );
+    expect(html).toContain('compiled-module');
+    expect(html).toContain('docs');
+    expect(html).not.toContain('This plugin panel is not available');
+    slots.modules = [];
+  });
+
+  it('shows the empty state when neither a slot nor an AppModule exists', () => {
+    slots.panels = [];
+    slots.modules = [];
+    const html = renderToStaticMarkup(
+      <PluginPanelPaneView pluginId="missing" panelPath="panel" subPath="" />
+    );
+    expect(html).toContain('This plugin panel is not available');
+  });
+});

--- a/apps/app/src/views/thread-detail/PluginPanelPaneView.tsx
+++ b/apps/app/src/views/thread-detail/PluginPanelPaneView.tsx
@@ -1,4 +1,6 @@
 import { useMemo, useSyncExternalStore } from 'react';
+import { AppModulePanel } from '../../modules/ModulePanelHost.js';
+import { useMergedModules } from '../../modules/index.js';
 import { listNavPanels, subscribePluginSlots } from '../../plugins/plugin-slots.js';
 import { PluginSlotBoundary } from '../../plugins/PluginSlotBoundary.js';
 
@@ -12,23 +14,29 @@ export function PluginPanelPaneView({
   subPath: string;
 }) {
   const panels = useSyncExternalStore(subscribePluginSlots, listNavPanels, listNavPanels);
+  const modules = useMergedModules();
   const panel = useMemo(() => {
     const forPlugin = panels.filter((row) => row.pluginId === pluginId);
     if (forPlugin.length === 0) return null;
     return forPlugin.find((row) => (row.path ?? row.id) === panelPath) ?? forPlugin[0] ?? null;
   }, [panelPath, panels, pluginId]);
 
-  if (!panel) {
-    return <div className="split-pane-empty">This plugin panel is not available.</div>;
-  }
-  const Component = panel.component;
-  return (
-    <div className="module-panel-host split-plugin-pane">
-      <div className="module-panel-slot panel-body--full">
-        <PluginSlotBoundary pluginId={panel.pluginId} generation={panel.generation}>
-          <Component pluginId={panel.pluginId} subPath={subPath} />
-        </PluginSlotBoundary>
+  if (panel) {
+    const Component = panel.component;
+    return (
+      <div className="module-panel-host split-plugin-pane">
+        <div className="module-panel-slot panel-body--full">
+          <PluginSlotBoundary pluginId={panel.pluginId} generation={panel.generation}>
+            <Component pluginId={panel.pluginId} subPath={subPath} />
+          </PluginSlotBoundary>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
+
+  if (modules.some((row) => row.id === pluginId)) {
+    return <AppModulePanel moduleId={pluginId} />;
+  }
+
+  return <div className="split-pane-empty">This plugin panel is not available.</div>;
 }

--- a/apps/desktop/src/ipc/__tests__/hosts-relaunch-ipc.guard.test.ts
+++ b/apps/desktop/src/ipc/__tests__/hosts-relaunch-ipc.guard.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('hosts:relaunchLocal IPC', () => {
+  it('relaunches the packaged host utility instead of stealing its lock over HTTP', () => {
+    const source = readFileSync(new URL('../app.ts', import.meta.url), 'utf8');
+    expect(source).toContain('IPC.hosts.relaunchLocal');
+    expect(source).toContain('relaunchEnrolledHost');
+    expect(source).toContain('api/v1/hosts/relaunch-local');
+    const relaunchIdx = source.indexOf('relaunchEnrolledHost');
+    const httpIdx = source.indexOf('api/v1/hosts/relaunch-local');
+    expect(relaunchIdx).toBeGreaterThan(-1);
+    expect(httpIdx).toBeGreaterThan(relaunchIdx);
+  });
+});

--- a/apps/desktop/src/ipc/app.ts
+++ b/apps/desktop/src/ipc/app.ts
@@ -2,6 +2,7 @@
 import { ipcMain } from 'electron';
 import { IPC } from '@zana-ai/zcc-desktop-contract';
 import { ctx } from './ctx.js';
+import { productServerUrl } from '../window/renderer-url.js';
 import { microVmPlatformSupported } from '@zana-ai/zcc-host-daemon/harness/microvm-environment';
 import { getReleaseNotes } from '../release-notes.js';
 import { store } from '@zana-ai/zcc-server/services/projects/store';
@@ -144,6 +145,32 @@ export function registerAppIpc(): void {
       ctx.doctor?.dismiss();
     },
     () => undefined
+  );
+
+  ctx.safeHandle(
+    IPC.hosts.relaunchLocal,
+    async (): Promise<{ ok: true } | { ok: false; message: string }> => {
+      if (typeof ctx.runtimeSupervisor?.relaunchEnrolledHost === 'function') {
+        return ctx.runtimeSupervisor.relaunchEnrolledHost();
+      }
+      try {
+        const response = await fetch(new URL('api/v1/hosts/relaunch-local', productServerUrl()), {
+          method: 'POST'
+        });
+        const body = await response.json() as { ok?: boolean; message?: string };
+        if (body.ok === true) return { ok: true };
+        return {
+          ok: false,
+          message: typeof body.message === 'string' ? body.message : 'Could not relaunch this machine'
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          message: error instanceof Error ? error.message : 'Could not relaunch this machine'
+        };
+      }
+    },
+    () => ({ ok: false, message: 'Could not relaunch this machine' })
   );
 }
 

--- a/apps/desktop/src/ipc/plugin-apps-loopback.test.ts
+++ b/apps/desktop/src/ipc/plugin-apps-loopback.test.ts
@@ -5,6 +5,7 @@ import {
   setPluginAppEnabledOnProductServer,
   checkPluginUpdatesFromProductServer,
   applyPluginUpdateOnProductServer,
+  removePluginAppOnProductServer,
   callPluginRpcOnProductServer,
   getPluginSettingsFromProductServer,
   setPluginSettingsOnProductServer
@@ -112,6 +113,24 @@ describe('plugin-apps product-server fallback', () => {
     ).resolves.toMatchObject({ ok: false, code: 'NOT_FOUND' });
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/api/v1/plugin-apps/updates');
     expect(String(fetchMock.mock.calls[1]?.[0])).toContain('/api/v1/plugin-apps/docs/update');
+  });
+
+  it('POSTs plugin remove and maps failures', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/docs/remove')) return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      return new Response(JSON.stringify({ error: 'plugin not installed: missing' }), { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(removePluginAppOnProductServer('docs', 'http://127.0.0.1:8780/')).resolves.toEqual({
+      ok: true,
+      value: true
+    });
+    await expect(removePluginAppOnProductServer('missing', 'http://127.0.0.1:8780/')).resolves.toMatchObject({
+      ok: false,
+      code: 'NOT_FOUND'
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/api/v1/plugin-apps/docs/remove');
   });
 
   it('POSTs plugin RPC and maps host errors', async () => {

--- a/apps/desktop/src/ipc/plugin-apps-loopback.ts
+++ b/apps/desktop/src/ipc/plugin-apps-loopback.ts
@@ -107,6 +107,30 @@ export async function applyPluginUpdateOnProductServer(
   };
 }
 
+export async function removePluginAppOnProductServer(
+  id: string,
+  baseUrl = loopbackProductServerUrl()
+): Promise<Result<true>> {
+  if (!baseUrl) {
+    return { ok: false, code: 'UNAVAILABLE', message: 'plugin host is unavailable' };
+  }
+  const response = await fetch(
+    new URL(`api/v1/plugin-apps/${encodeURIComponent(id)}/remove`, baseUrl),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}'
+    }
+  );
+  if (response.ok) return { ok: true, value: true };
+  const message = await productServerError(response, `plugin host returned ${response.status}`);
+  return {
+    ok: false,
+    code: response.status === 404 ? 'NOT_FOUND' : 'WRITE_FAILED',
+    message
+  };
+}
+
 const EMPTY_PLUGIN_SETTINGS = { descriptors: {}, values: {} } as const;
 
 export async function callPluginRpcOnProductServer(

--- a/apps/desktop/src/ipc/plugins.ts
+++ b/apps/desktop/src/ipc/plugins.ts
@@ -12,6 +12,7 @@ import {
   setPluginAppEnabledOnProductServer,
   checkPluginUpdatesFromProductServer,
   applyPluginUpdateOnProductServer,
+  removePluginAppOnProductServer,
   callPluginRpcOnProductServer,
   getPluginSettingsFromProductServer,
   setPluginSettingsOnProductServer
@@ -145,6 +146,34 @@ export function registerPluginsIpc(): void {
         }
       }
       return applyPluginUpdateOnProductServer(id);
+    },
+    (err): Result<true> => ({
+      ok: false,
+      code: 'WRITE_FAILED',
+      message: err instanceof Error ? err.message : String(err)
+    })
+  );
+  ctx.safeHandle(
+    IPC.pluginApps.remove,
+    async (id: string) => {
+      if (ctx.runtimeSupervisor) {
+        try {
+          await ctx.runtimeSupervisor.removePlugin(id);
+          return { ok: true as const, value: true as const };
+        } catch (err) {
+          return {
+            ok: false as const,
+            code: 'WRITE_FAILED',
+            message: err instanceof Error ? err.message : String(err)
+          };
+        }
+      }
+      const result = await removePluginAppOnProductServer(id);
+      if (result.ok) {
+        const apps = await listPluginAppsFromProductServer();
+        ctx.safeSend(IPC.pluginApps.onChanged, apps);
+      }
+      return result;
     },
     (err): Result<true> => ({
       ok: false,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -267,7 +267,8 @@ const api: CcApi = {
     cloneDefaultPath: async () => ({ path: '/' }),
     providerCliStatus: async () => ({}),
     installProviderCli: async () => [],
-    onChanged: () => () => {}
+    onChanged: () => () => {},
+    relaunchLocal: () => ipcRenderer.invoke(IPC.hosts.relaunchLocal)
   },
   relay: {
     status: async () => ({ state: 'unconfigured' as const }),
@@ -725,6 +726,7 @@ const api: CcApi = {
     setSettings: (pluginId, values) => ipcRenderer.invoke(IPC.pluginApps.setSettings, pluginId, values),
     checkUpdates: () => ipcRenderer.invoke(IPC.pluginApps.checkUpdates),
     applyUpdate: (id) => ipcRenderer.invoke(IPC.pluginApps.applyUpdate, id),
+    remove: (id) => ipcRenderer.invoke(IPC.pluginApps.remove, id),
     onChanged: (cb) => {
       const handler = (_e: unknown, entries: PluginAppEntry[]) => cb(entries);
       ipcRenderer.on(IPC.pluginApps.onChanged, handler);

--- a/apps/desktop/src/runtime/runtime-supervisor.test.ts
+++ b/apps/desktop/src/runtime/runtime-supervisor.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -25,6 +25,10 @@ describe('runtime supervisor', () => {
     expect(runtime.hostToken).toHaveLength(43);
     expect(runtime.hostSigningKey).toHaveLength(43);
     await expect(runtime.appVersion()).resolves.toBe('');
+    await expect(runtime.relaunchEnrolledHost()).resolves.toEqual({
+      ok: false,
+      message: 'This session does not run a packaged host daemon'
+    });
     await expect(runtime.listProjects()).resolves.toEqual([]);
     await expect(fetch(runtime.rendererUrl).then((response) => response.text())).resolves.toContain('runtime');
     await expect(fetch(`${runtime.hostUrl}/health`).then((response) => response.json())).resolves.toEqual({ ok: true });
@@ -95,5 +99,14 @@ describe('runtime supervisor', () => {
     expect(await runtime.recordTerminalEvent({ kind: 'output', protocolVersion: TERMINAL_HOST_PROTOCOL_VERSION, binding, sessionId, launchEpoch: 0, sequence: 99, data: 'late' })).toBe(true);
     expect(await runtime.recordTerminalEvent({ kind: 'output', protocolVersion: TERMINAL_HOST_PROTOCOL_VERSION, binding, sessionId, launchEpoch: 0, sequence: 99, data: 'duplicate' })).toBe(false);
     expect(await runtime.recordTerminalEvent({ kind: 'output', protocolVersion: TERMINAL_HOST_PROTOCOL_VERSION, binding, sessionId, launchEpoch: 1, sequence: 100, data: 'stale' })).toBe(false);
+  });
+
+  it('retries a failed desktop host enroll in the background', () => {
+    const source = readFileSync(new URL('./runtime-supervisor.ts', import.meta.url), 'utf8');
+    expect(source).toContain('host daemon enroll failed');
+    expect(source).toContain('setInterval');
+    expect(source).toContain('enrollOnce');
+    expect(source).toContain("'relaunch'");
+    expect(source).toContain('relaunchEnrolledHost');
   });
 });

--- a/apps/desktop/src/runtime/runtime-supervisor.ts
+++ b/apps/desktop/src/runtime/runtime-supervisor.ts
@@ -37,6 +37,7 @@ export interface RuntimeSupervisor {
   readonly hostUrl: string;
   readonly hostToken: string;
   readonly hostSigningKey: string;
+  relaunchEnrolledHost(): Promise<{ ok: true } | { ok: false; message: string }>;
   appVersion(): Promise<string>;
   listProjects(): Promise<RuntimeProject[]>;
   addProject(path: string): Promise<RuntimeProject>;
@@ -156,6 +157,12 @@ export async function startRuntimeSupervisor(options: StartRuntimeSupervisorOpti
     hostUrl: host.url,
     hostToken: token,
     hostSigningKey: signingKey,
+    async relaunchEnrolledHost() {
+      return {
+        ok: false as const,
+        message: 'This session does not run a packaged host daemon'
+      };
+    },
     appVersion: async () => options.version ?? '',
     listProjects: async () => [],
     addProject: async () => { throw new Error('runtime project storage is unavailable'); },
@@ -204,6 +211,7 @@ export async function startRuntimeSupervisor(options: StartRuntimeSupervisorOpti
 interface UtilityChild {
   postMessage(message: unknown): void;
   on(event: 'message', listener: (message: unknown) => void): void;
+  off?(event: 'message', listener: (message: unknown) => void): void;
   on(event: 'error', listener: (error: Error) => void): void;
   once(event: 'exit', listener: () => void): void;
   once(event: 'spawn', listener: () => void): void;
@@ -306,7 +314,8 @@ function startUtility(
 
 function enrollHostUtility(
   child: UtilityChild,
-  input: { serverUrl: string; token: string; dataDir: string }
+  input: { serverUrl: string; token: string; dataDir: string },
+  type: 'enroll' | 'relaunch' = 'enroll'
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -314,10 +323,14 @@ function enrollHostUtility(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      child.off?.('message', onMessage);
       if (error) reject(error);
       else resolve();
     };
-    const timer = setTimeout(() => finish(new Error('host enroll timed out')), 15_000);
+    const timer = setTimeout(
+      () => finish(new Error(type === 'relaunch' ? 'host relaunch timed out' : 'host enroll timed out')),
+      type === 'relaunch' ? 20_000 : 15_000
+    );
     const onMessage = (message: unknown) => {
       const data = message as { type?: string; message?: string };
       if (data.type === 'enrolled') {
@@ -325,12 +338,12 @@ function enrollHostUtility(
         return;
       }
       if (data.type === 'error') {
-        finish(new Error(data.message ?? 'host enroll failed'));
+        finish(new Error(data.message ?? (type === 'relaunch' ? 'host relaunch failed' : 'host enroll failed')));
       }
     };
     child.on('message', onMessage);
     child.postMessage({
-      type: 'enroll',
+      type,
       protocolVersion: SERVER_RUNTIME_PROTOCOL_VERSION,
       serverUrl: input.serverUrl,
       token: input.token,
@@ -376,17 +389,29 @@ async function startUtilityRuntime(options: StartRuntimeSupervisorOptions & { to
     renderer.child.kill();
     throw new Error('runtime dataDir is required to enroll the host daemon');
   }
+  let enrollRetry: NodeJS.Timeout | null = null;
+  const enrollInput = {
+    serverUrl: renderer.url,
+    token: readEnrollToken(options.dataDir!),
+    dataDir: options.dataDir!
+  };
+  const enrollOnce = () => enrollHostUtility(host.child, enrollInput);
   try {
-    await enrollHostUtility(host.child, {
-      serverUrl: renderer.url,
-      token: readEnrollToken(options.dataDir),
-      dataDir: options.dataDir
-    });
+    await enrollOnce();
   } catch (error) {
     // The renderer can still boot; thread spawn surfaces host-unavailable if
     // the handshake never completes. Blocking the window here makes Electron
-    // E2E hang in firstWindow() with no diagnostic.
+    // E2E hang in firstWindow() with no diagnostic. Keep retrying so this
+    // machine is not stuck Offline after a transient enroll failure.
     console.error('host daemon enroll failed', error);
+    enrollRetry = setInterval(() => {
+      void enrollOnce().then(() => {
+        if (enrollRetry) {
+          clearInterval(enrollRetry);
+          enrollRetry = null;
+        }
+      }).catch(() => undefined);
+    }, 5_000);
   }
   const server = createUtilityRuntime(renderer);
   const hostRuntime = createUtilityRuntime(host);
@@ -501,7 +526,34 @@ async function startUtilityRuntime(options: StartRuntimeSupervisorOptions & { to
     callPluginRpc: (pluginId, method, args) => server.request('plugins-call-rpc', pluginId, method, args),
     getPluginSettings: (pluginId) => server.request('plugins-settings-get', pluginId),
     setPluginSettings: (pluginId, values) => server.request('plugins-settings-set', pluginId, values),
+    async relaunchEnrolledHost() {
+      if (enrollRetry) {
+        clearInterval(enrollRetry);
+        enrollRetry = null;
+      }
+      try {
+        await enrollHostUtility(host.child, enrollInput, 'relaunch');
+        return { ok: true as const };
+      } catch (error) {
+        enrollRetry = setInterval(() => {
+          void enrollOnce().then(() => {
+            if (enrollRetry) {
+              clearInterval(enrollRetry);
+              enrollRetry = null;
+            }
+          }).catch(() => undefined);
+        }, 5_000);
+        return {
+          ok: false as const,
+          message: error instanceof Error ? error.message : 'Could not relaunch this machine'
+        };
+      }
+    },
     async close(): Promise<void> {
+      if (enrollRetry) {
+        clearInterval(enrollRetry);
+        enrollRetry = null;
+      }
       await Promise.allSettled([server.stop(), hostRuntime.stop()]);
     }
   };

--- a/apps/host-daemon/src/enroll-runtime.test.ts
+++ b/apps/host-daemon/src/enroll-runtime.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { readHostAuth, writeHostAuth, enrollDaemonHost, persistHostId, startEnrolledHostConnection } = vi.hoisted(() => ({
+  readHostAuth: vi.fn(),
+  writeHostAuth: vi.fn(),
+  enrollDaemonHost: vi.fn(),
+  persistHostId: vi.fn(),
+  startEnrolledHostConnection: vi.fn()
+}));
+
+vi.mock('./lock.js', () => ({
+  acquireDaemonLock: () => () => undefined
+}));
+vi.mock('./machine-auth.js', () => ({
+  readHostAuth,
+  writeHostAuth
+}));
+vi.mock('./enroll.js', () => ({ enrollDaemonHost }));
+vi.mock('./identity.js', () => ({
+  detectHostName: () => 'test-host',
+  persistHostId,
+  resolveHostId: () => '11111111-1111-4111-8111-111111111111'
+}));
+vi.mock('./server-connection.js', () => ({ startEnrolledHostConnection }));
+
+import { startEnrolledHostDaemon } from './enroll-runtime.js';
+
+function openConnection(): { ready: Promise<void>; close: () => Promise<void> } {
+  return {
+    ready: Promise.resolve(),
+    close: async () => undefined
+  };
+}
+
+function closedConnection(): { ready: Promise<void>; close: () => Promise<void> } {
+  return {
+    ready: Promise.reject(new Error('host websocket closed before hello')),
+    close: async () => undefined
+  };
+}
+
+describe('startEnrolledHostDaemon', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('re-enrolls with the loopback token when stored auth cannot open the hub', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'zcc-enroll-reauth-'));
+    readHostAuth.mockReturnValue({
+      hostId: '11111111-1111-4111-8111-111111111111',
+      hostKey: 'stale-key',
+      hostName: 'test-host'
+    });
+    enrollDaemonHost.mockResolvedValue({
+      protocolVersion: 19,
+      hostId: '11111111-1111-4111-8111-111111111111',
+      hostKey: 'fresh-key'
+    });
+    startEnrolledHostConnection
+      .mockImplementationOnce(() => closedConnection())
+      .mockImplementationOnce(() => openConnection());
+
+    const daemon = await startEnrolledHostDaemon({
+      dataDir,
+      serverUrl: 'http://127.0.0.1:8780/',
+      token: 'enroll-token-enroll-token-enroll'
+    });
+    expect(enrollDaemonHost).toHaveBeenCalledOnce();
+    expect(writeHostAuth).toHaveBeenCalledWith(dataDir, expect.objectContaining({ hostKey: 'fresh-key' }));
+    expect(startEnrolledHostConnection).toHaveBeenCalledTimes(2);
+    await daemon.close();
+  });
+});

--- a/apps/host-daemon/src/enroll-runtime.ts
+++ b/apps/host-daemon/src/enroll-runtime.ts
@@ -14,69 +14,141 @@ export interface EnrolledHostDaemon {
   close(): Promise<void>;
 }
 
+async function waitForHello(connection: EnrolledHostConnection, timeoutMs: number): Promise<void> {
+  let openTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      connection.ready,
+      new Promise<never>((_, reject) => {
+        openTimer = setTimeout(() => reject(new Error('host websocket did not open')), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (openTimer) clearTimeout(openTimer);
+  }
+}
+
+async function mintCredentials(options: {
+  dataDir: string;
+  serverUrl: string;
+  token: string;
+  hostId?: string;
+  hostName?: string;
+  instanceId: string;
+}): Promise<{ hostId: string; hostKey: string }> {
+  const requestedHostId = options.hostId ?? resolveHostId(options.dataDir);
+  const enrolled = await enrollDaemonHost({
+    serverUrl: options.serverUrl,
+    token: options.token,
+    hostName: options.hostName ?? detectHostName(),
+    instanceId: options.instanceId,
+    hostId: requestedHostId
+  });
+  persistHostId(options.dataDir, enrolled.hostId);
+  writeHostAuth(options.dataDir, {
+    hostId: enrolled.hostId,
+    hostKey: enrolled.hostKey,
+    hostName: options.hostName ?? detectHostName()
+  });
+  return { hostId: enrolled.hostId, hostKey: enrolled.hostKey };
+}
+
+async function openSession(options: {
+  dataDir: string;
+  serverUrl: string;
+  hostId: string;
+  hostKey: string;
+  instanceId: string;
+  onSocketClose?: (code: number) => void;
+}): Promise<EnrolledHostConnection> {
+  const connection = startEnrolledHostConnection({
+    serverUrl: options.serverUrl,
+    hostId: options.hostId,
+    hostKey: options.hostKey,
+    instanceId: options.instanceId,
+    dataDir: options.dataDir,
+    onSocketClose: options.onSocketClose
+  });
+  void connection.ready.catch(() => {
+    /* close() may reject after a timeout wins the race */
+  });
+  try {
+    await waitForHello(connection, 10_000);
+    return connection;
+  } catch (error) {
+    await connection.close();
+    throw error;
+  }
+}
+
 export async function startEnrolledHostDaemon(options: {
   dataDir: string;
   serverUrl: string;
   token?: string;
   hostId?: string;
   hostName?: string;
+  /** Desktop co-started daemon: replace another holder of this data dir. */
+  stealLock?: boolean;
   onSocketClose?: (code: number) => void;
 }): Promise<EnrolledHostDaemon> {
-  const releaseLock = acquireDaemonLock(options.dataDir);
+  const releaseLock = acquireDaemonLock(options.dataDir, { steal: options.stealLock === true });
   try {
     const instanceId = randomUUID();
     const existing = readHostAuth(options.dataDir);
     let hostId: string;
-    let hostKey: string;
+    let connection: EnrolledHostConnection;
     if (existing) {
-      hostId = existing.hostId;
-      hostKey = existing.hostKey;
+      try {
+        connection = await openSession({
+          dataDir: options.dataDir,
+          serverUrl: options.serverUrl,
+          hostId: existing.hostId,
+          hostKey: existing.hostKey,
+          instanceId,
+          onSocketClose: options.onSocketClose
+        });
+        hostId = existing.hostId;
+      } catch (error) {
+        if (!options.token) throw error;
+        const minted = await mintCredentials({
+          dataDir: options.dataDir,
+          serverUrl: options.serverUrl,
+          token: options.token,
+          hostId: options.hostId ?? existing.hostId,
+          hostName: options.hostName,
+          instanceId
+        });
+        hostId = minted.hostId;
+        connection = await openSession({
+          dataDir: options.dataDir,
+          serverUrl: options.serverUrl,
+          hostId: minted.hostId,
+          hostKey: minted.hostKey,
+          instanceId,
+          onSocketClose: options.onSocketClose
+        });
+      }
     } else {
       if (!options.token) {
         throw new Error('host enroll token is missing and auth.json is absent');
       }
-      const requestedHostId = options.hostId ?? resolveHostId(options.dataDir);
-      const enrolled = await enrollDaemonHost({
+      const minted = await mintCredentials({
+        dataDir: options.dataDir,
         serverUrl: options.serverUrl,
         token: options.token,
-        hostName: options.hostName ?? detectHostName(),
+        hostId: options.hostId,
+        hostName: options.hostName,
+        instanceId
+      });
+      hostId = minted.hostId;
+      connection = await openSession({
+        dataDir: options.dataDir,
+        serverUrl: options.serverUrl,
+        hostId: minted.hostId,
+        hostKey: minted.hostKey,
         instanceId,
-        hostId: requestedHostId
+        onSocketClose: options.onSocketClose
       });
-      persistHostId(options.dataDir, enrolled.hostId);
-      writeHostAuth(options.dataDir, {
-        hostId: enrolled.hostId,
-        hostKey: enrolled.hostKey,
-        hostName: options.hostName ?? detectHostName()
-      });
-      hostId = enrolled.hostId;
-      hostKey = enrolled.hostKey;
-    }
-    const connection = startEnrolledHostConnection({
-      serverUrl: options.serverUrl,
-      hostId,
-      hostKey,
-      instanceId,
-      dataDir: options.dataDir,
-      onSocketClose: options.onSocketClose
-    });
-    void connection.ready.catch(() => {
-      /* close() may reject after a timeout wins the race */
-    });
-    let openTimer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        connection.ready,
-        new Promise<never>((_, reject) => {
-          openTimer = setTimeout(() => reject(new Error('host websocket did not open')), 10_000);
-        })
-      ]);
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    } catch (error) {
-      await connection.close();
-      throw error;
-    } finally {
-      if (openTimer) clearTimeout(openTimer);
     }
     return {
       hostId,

--- a/apps/host-daemon/src/lock.test.ts
+++ b/apps/host-daemon/src/lock.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -19,5 +20,29 @@ describe('daemon.lock', () => {
     writeFileSync(join(dataDir, 'daemon.lock'), '999999999\n', { mode: 0o600 });
     const release = acquireDaemonLock(dataDir);
     release();
+  });
+
+  it('steals a live lock so the desktop daemon can own this machine', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'zcc-daemon-steal-'));
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore'
+    });
+    if (!child.pid) throw new Error('holder pid missing');
+    writeFileSync(join(dataDir, 'daemon.lock'), `${child.pid}\n`, { mode: 0o600 });
+    expect(() => acquireDaemonLock(dataDir)).toThrow(DaemonLockError);
+    const release = acquireDaemonLock(dataDir, { steal: true });
+    expect(() => acquireDaemonLock(dataDir)).toThrow(DaemonLockError);
+    child.kill('SIGKILL');
+    release();
+  });
+
+  it('desktop enroll steals the lock; join/enroll-entry do not', () => {
+    const utility = readFileSync(new URL('./utility-entry.ts', import.meta.url), 'utf8');
+    const enrollEntry = readFileSync(new URL('./enroll-entry.ts', import.meta.url), 'utf8');
+    const joinCli = readFileSync(new URL('./join-cli.ts', import.meta.url), 'utf8');
+    expect(utility).toContain('stealLock: true');
+    expect(utility).toContain("type === 'relaunch'");
+    expect(enrollEntry).not.toContain('stealLock');
+    expect(joinCli).not.toContain('stealLock');
   });
 });

--- a/apps/host-daemon/src/lock.ts
+++ b/apps/host-daemon/src/lock.ts
@@ -19,18 +19,64 @@ function pidIsAlive(pid: number): boolean {
   }
 }
 
-export function acquireDaemonLock(dataDir: string): () => void {
+function readLockPid(lockPath: string): number | null {
+  try {
+    const pid = Number(readFileSync(lockPath, 'utf8').trim());
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function signalPid(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+  }
+}
+
+function waitUntilDead(pid: number, timeoutMs: number): boolean {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidIsAlive(pid)) return true;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+  return !pidIsAlive(pid);
+}
+
+function unlinkIfOwner(lockPath: string, pid: number): void {
+  try {
+    if (readLockPid(lockPath) === pid) unlinkSync(lockPath);
+  } catch {
+    /* already gone or stolen */
+  }
+}
+
+/**
+ * Exclusive lock for one enrolled host-daemon per data dir. A stale lock
+ * (dead pid) is replaced. `steal: true` is for the desktop co-started daemon:
+ * it must take over ~/.zcc even if a leftover `enroll-entry` from `pnpm start`
+ * still holds the file, otherwise this machine stays Offline in the app that
+ * the user is actually looking at.
+ */
+export function acquireDaemonLock(dataDir: string, options?: { steal?: boolean }): () => void {
   mkdirSync(dataDir, { recursive: true, mode: 0o700 });
   const lockPath = join(dataDir, DAEMON_LOCK_FILE_NAME);
-  try {
-    const existing = readFileSync(lockPath, 'utf8').trim();
-    const pid = Number(existing);
-    if (Number.isInteger(pid) && pid > 0 && pidIsAlive(pid)) {
-      throw new DaemonLockError(`another host-daemon holds ${lockPath} (pid ${pid})`);
+  const existingPid = readLockPid(lockPath);
+  if (existingPid !== null && pidIsAlive(existingPid)) {
+    if (existingPid === process.pid || !options?.steal) {
+      throw new DaemonLockError(`another host-daemon holds ${lockPath} (pid ${existingPid})`);
     }
+    signalPid(existingPid, 'SIGTERM');
+    if (!waitUntilDead(existingPid, 1_500)) signalPid(existingPid, 'SIGKILL');
+    waitUntilDead(existingPid, 300);
+  }
+  unlinkIfOwner(lockPath, existingPid ?? -1);
+  try {
     unlinkSync(lockPath);
   } catch (error) {
-    if (error instanceof DaemonLockError) throw error;
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
   }
 
@@ -46,10 +92,6 @@ export function acquireDaemonLock(dataDir: string): () => void {
   return () => {
     if (released) return;
     released = true;
-    try {
-      unlinkSync(lockPath);
-    } catch {
-      /* already gone */
-    }
+    unlinkIfOwner(lockPath, process.pid);
   };
 }

--- a/apps/host-daemon/src/server-connection.test.ts
+++ b/apps/host-daemon/src/server-connection.test.ts
@@ -66,6 +66,32 @@ describe('enrolled host websocket', () => {
     await connection.close();
   });
 
+  it('rejects ready when the socket closes before hello', async () => {
+    class ClosedSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+      readyState = 3;
+      addEventListener(type: string, fn: (event?: unknown) => void) {
+        if (type === 'close') queueMicrotask(() => fn({ code: 1006 }));
+      }
+      close() {}
+      send() {}
+    }
+    globalThis.WebSocket = ClosedSocket as unknown as typeof WebSocket;
+    const dataDir = mkdtempSync(join(tmpdir(), 'zcc-ws-closed-'));
+    const connection = startEnrolledHostConnection({
+      serverUrl: 'http://127.0.0.1:1/',
+      hostId: '11111111-1111-4111-8111-111111111111',
+      hostKey: 'key-1',
+      dataDir,
+      runtime: stubRuntime(dataDir)
+    });
+    await expect(connection.ready).rejects.toThrow(/closed before hello/);
+    await connection.close();
+  });
+
   it('fetches plugin host artifacts through the enrolled HTTP client', () => {
     const source = readFileSync(new URL('./server-connection.ts', import.meta.url), 'utf8');
     expect(source).toContain('createPluginHostArtifactHttpClient');

--- a/apps/host-daemon/src/server-connection.ts
+++ b/apps/host-daemon/src/server-connection.ts
@@ -58,10 +58,10 @@ export function startEnrolledHostConnection(options: {
     };
   });
 
-  function markReady(): void {
+  function markReady(error?: Error): void {
     if (readySettled) return;
     readySettled = true;
-    settleReady?.();
+    settleReady?.(error);
   }
 
   const sink: EventSink = createEventSink({
@@ -215,6 +215,10 @@ export function startEnrolledHostConnection(options: {
         heartbeatTimer = null;
       }
       options.onSocketClose?.(event.code);
+      if (!readySettled) {
+        markReady(new Error('host websocket closed before hello'));
+        return;
+      }
       if (closed) return;
       const delay = BACKOFF_MS[Math.min(attempt, BACKOFF_MS.length - 1)]!;
       attempt += 1;
@@ -232,10 +236,7 @@ export function startEnrolledHostConnection(options: {
     ready,
     async close() {
       closed = true;
-      if (!readySettled) {
-        readySettled = true;
-        settleReady?.(new Error('host connection closed before hello'));
-      }
+      markReady(new Error('host connection closed before hello'));
       if (reconnectTimer) clearTimeout(reconnectTimer);
       if (heartbeatTimer) clearInterval(heartbeatTimer);
       adapter?.dispose();

--- a/apps/host-daemon/src/utility-entry.ts
+++ b/apps/host-daemon/src/utility-entry.ts
@@ -34,7 +34,7 @@ parentPort.on('message', async ({ data }) => {
     ghBinary?: string;
   };
   if (
-    (message.type === 'start' || message.type === 'enroll' || message.type === 'stop')
+    (message.type === 'start' || message.type === 'enroll' || message.type === 'relaunch' || message.type === 'stop')
     && message.protocolVersion !== SERVER_RUNTIME_PROTOCOL_VERSION
   ) {
     parentPort.postMessage({ type: 'error', protocolVersion: SERVER_RUNTIME_PROTOCOL_VERSION, message: 'incompatible host runtime protocol version' });
@@ -78,7 +78,31 @@ parentPort.on('message', async ({ data }) => {
       enrolled = await startEnrolledHostDaemon({
         dataDir: message.dataDir,
         serverUrl: message.serverUrl,
-        token: message.token
+        token: message.token,
+        stealLock: true
+      });
+      parentPort.postMessage({
+        type: 'enrolled',
+        protocolVersion: SERVER_RUNTIME_PROTOCOL_VERSION,
+        hostId: enrolled.hostId
+      });
+    } catch (error) {
+      parentPort.postMessage({
+        type: 'error',
+        protocolVersion: SERVER_RUNTIME_PROTOCOL_VERSION,
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+  if (message.type === 'relaunch' && message.serverUrl && message.token && message.dataDir) {
+    try {
+      await enrolled?.close();
+      enrolled = null;
+      enrolled = await startEnrolledHostDaemon({
+        dataDir: message.dataDir,
+        serverUrl: message.serverUrl,
+        token: message.token,
+        stealLock: true
       });
       parentPort.postMessage({
         type: 'enrolled',

--- a/apps/server/src/http/host-enroll.integration.test.ts
+++ b/apps/server/src/http/host-enroll.integration.test.ts
@@ -616,6 +616,15 @@ describe('host enroll hub and thread create', () => {
     });
     try {
       expect(server!.ctx.hostHub.connectedHostIds()).toContain(daemon.hostId);
+      const listed = await fetch(`${server!.url}api/v1/hosts`).then((response) => response.json()) as Array<{
+        id: string;
+        status: string;
+        lastSeenAt: number | null;
+      }>;
+      const row = listed.find((host) => host.id === daemon.hostId);
+      expect(row?.status).toBe('connected');
+      expect(row?.lastSeenAt).toEqual(expect.any(Number));
+      expect(Date.now() - (row?.lastSeenAt ?? 0)).toBeLessThan(10_000);
     } finally {
       await daemon.close();
     }

--- a/apps/server/src/http/host-hub.ts
+++ b/apps/server/src/http/host-hub.ts
@@ -25,6 +25,7 @@ import {
   getLatestSessionForHost,
   getThread,
   markHostProtocolRejected,
+  markHostSeen,
   openHostSession,
   updateConversationThreadStatus,
   updateThreadStatus,
@@ -166,6 +167,7 @@ export function createHostHub(
       options?.onNewHostInstance?.(hostId);
     }
     openHostSession(db, { hostId, instanceId, hostName: getHost(db, hostId)?.name ?? 'host' });
+    markHostSeen(db, hostId);
     sessions.set(hostId, { hostId, instanceId, socket });
     hub.emit('hosts:changed', undefined);
     const waiters = connectWaiters.get(hostId);

--- a/apps/server/src/http/hosts-api.ts
+++ b/apps/server/src/http/hosts-api.ts
@@ -19,6 +19,7 @@ import {
 import { readJsonBody, sendJson, sendNdjson } from './json.js';
 import type { ProductHttpContext } from './product-context.js';
 import { listPublicHosts, parseHostRename, toPublicHost } from '../services/hosts/host-public.js';
+import { relaunchLocalHostDaemon } from '../services/hosts/host-relaunch.js';
 import { HostUnavailableError } from './host-hub.js';
 import { bootstrapHostForProject, parseSshIdentity, repairHost } from '../services/hosts/host-bootstrap.js';
 
@@ -97,6 +98,12 @@ export async function handleHostsApi(
     }
     const events = await bootstrapHostForProject(ctx, parsed.data.projectId);
     sendNdjson(response, events);
+    return true;
+  }
+
+  if (path === '/api/v1/hosts/relaunch-local' && method === 'POST') {
+    const result = await relaunchLocalHostDaemon(ctx);
+    sendJson(response, result.ok ? 200 : 503, result);
     return true;
   }
 

--- a/apps/server/src/http/plugin-apps-route.guard.test.ts
+++ b/apps/server/src/http/plugin-apps-route.guard.test.ts
@@ -10,6 +10,7 @@ describe('plugin-apps HTTP surface', () => {
     expect(source).toContain("routeParams(path, '/api/v1/plugin-apps/:id/disable')");
     expect(source).toContain("path === '/api/v1/plugin-apps/updates'");
     expect(source).toContain("routeParams(path, '/api/v1/plugin-apps/:id/update')");
+    expect(source).toContain("routeParams(path, '/api/v1/plugin-apps/:id/remove')");
     expect(source).toContain("routeParams(path, '/api/v1/plugin-apps/:id/rpc')");
     expect(source).toContain("routeParams(path, '/api/v1/plugin-apps/:id/settings')");
   });

--- a/apps/server/src/http/product-api.test.ts
+++ b/apps/server/src/http/product-api.test.ts
@@ -1113,6 +1113,41 @@ describe('product HTTP plugins', () => {
     expect(missing.status).toBe(404);
   });
 
+  it('removes a plugin app through POST /plugin-apps/:id/remove', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'zcc-product-plugin-remove-'));
+    server = await startTestProductServer({
+      dataDir,
+      origins: { serverPort: 0, devAppPort: 5173 }
+    });
+    const apps = new Map([['docs', true]]);
+    server.ctx.plugins = {
+      snapshot: () =>
+        [...apps.keys()].map((id) => ({
+          id,
+          name: 'Docs',
+          description: 'library',
+          icon: 'Library',
+          enabled: true,
+          provenance: 'builtin',
+          status: 'running',
+          appUrl: '/plugins/docs/app.js'
+        })),
+      remove: async (id: string) => {
+        if (!apps.has(id)) throw new Error(`plugin not installed: ${id}`);
+        apps.delete(id);
+      }
+    } as never;
+
+    const removed = await fetch(`${server.url}api/v1/plugin-apps/docs/remove`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}'
+    });
+    await expect(removed.json()).resolves.toEqual({ ok: true, value: true });
+    const after = await fetch(`${server.url}api/v1/plugin-apps`);
+    await expect(after.json()).resolves.toEqual({ apps: [] });
+  });
+
   it('calls plugin RPC and reads or writes settings', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'zcc-product-plugin-rpc-'));
     server = await startTestProductServer({

--- a/apps/server/src/http/product-api.ts
+++ b/apps/server/src/http/product-api.ts
@@ -1810,6 +1810,21 @@ export async function handleProductHttp(
       }
       return true;
     }
+    const pluginAppRemove = routeParams(path, '/api/v1/plugin-apps/:id/remove');
+    if (pluginAppRemove && method === 'POST') {
+      if (!ctx.plugins) {
+        sendJson(response, 503, { error: 'plugin host is unavailable' });
+        return true;
+      }
+      try {
+        await ctx.plugins.remove(pluginAppRemove.id);
+        sendJson(response, 200, { ok: true as const, value: true as const });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        sendJson(response, 400, { error: message });
+      }
+      return true;
+    }
     const pluginAppRpc = routeParams(path, '/api/v1/plugin-apps/:id/rpc');
     if (pluginAppRpc && method === 'POST') {
       await handlePluginAppRpc(request, response, ctx, pluginAppRpc.id);

--- a/apps/server/src/http/product-context.ts
+++ b/apps/server/src/http/product-context.ts
@@ -25,6 +25,7 @@ import { createJoinCodeStore, type JoinCodeStore } from '../services/hosts/join-
 import type { PluginService } from '../plugins/plugin-service.js';
 import { PluginHostArtifactRegistry } from '../plugins/plugin-host-artifact-registry.js';
 import { flushHeldConversationSends } from '../services/threads/conversation-lifecycle.js';
+import { disposeLocalHostDaemon } from '../services/hosts/host-relaunch.js';
 
 export interface ProductTerminalRecord extends TerminalSession {
   hostId: string;
@@ -169,6 +170,7 @@ export function createProductHttpContext(
     pluginHostArtifacts: new PluginHostArtifactRegistry(),
     toProjects: () => projects.list() as unknown as Project[],
     dispose: () => {
+      disposeLocalHostDaemon(ctx);
       promptRegistry.stop();
       ctx.plugins?.stop?.();
     }

--- a/apps/server/src/plugins/builtin-registry.test.ts
+++ b/apps/server/src/plugins/builtin-registry.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { OFFICIAL_PLUGINS, RETIRED_FIRST_PARTY_PLUGIN_IDS, isRetiredFirstPartyPluginId } from './builtin-registry.js';
+
+describe('retired first-party plugins', () => {
+  it('names the leftover hub rows and never overlaps the official catalog', () => {
+    expect([...RETIRED_FIRST_PARTY_PLUGIN_IDS].sort()).toEqual(['consensus', 'slack', 'zana', 'zana-hub']);
+    const official = new Set(OFFICIAL_PLUGINS.map((plugin) => plugin.pluginId));
+    for (const id of RETIRED_FIRST_PARTY_PLUGIN_IDS) {
+      expect(official.has(id)).toBe(false);
+      expect(isRetiredFirstPartyPluginId(id)).toBe(true);
+    }
+    expect(isRetiredFirstPartyPluginId('docs')).toBe(false);
+    expect(isRetiredFirstPartyPluginId('salesforce')).toBe(false);
+  });
+});

--- a/apps/server/src/plugins/builtin-registry.ts
+++ b/apps/server/src/plugins/builtin-registry.ts
@@ -166,3 +166,14 @@ export const OFFICIAL_PLUGINS: BundledPluginDefinition[] = [
 export function bundledPluginByName(name: string): BundledPluginDefinition | undefined {
   return [...BUILTIN_PLUGINS, ...OFFICIAL_PLUGINS].find((plugin) => plugin.name === name);
 }
+
+/**
+ * First-party plugins we used to seed into `~/.zcc/extensions` / PluginService
+ * and no longer ship. Start() uninstalls them so leftover hub rows cannot
+ * come back. Local-authored working dirs (local.json) are left alone.
+ */
+export const RETIRED_FIRST_PARTY_PLUGIN_IDS = ['consensus', 'slack', 'zana', 'zana-hub'] as const;
+
+export function isRetiredFirstPartyPluginId(id: string): boolean {
+  return (RETIRED_FIRST_PARTY_PLUGIN_IDS as readonly string[]).includes(id);
+}

--- a/apps/server/src/plugins/plugin-service.test.ts
+++ b/apps/server/src/plugins/plugin-service.test.ts
@@ -742,6 +742,57 @@ describe('PluginService', () => {
     expect(installed.map((row) => row.id)).not.toContain('tasks');
     expect(service.get('tasks')).toBeUndefined();
   });
+
+  it('does not auto-reinstall a builtin after uninstall', async () => {
+    const dataDir = root();
+    const bundled = root();
+    writePlugin(join(bundled, 'docs'), 'docs');
+    const service = createPluginService({ dataDir, bundledRoot: bundled });
+    await service.reconcileBuiltins();
+    expect(service.get('docs')?.id).toBe('docs');
+    await service.remove('docs');
+    expect(service.get('docs')).toBeUndefined();
+    const again = await service.reconcileBuiltins();
+    expect(again).toEqual([]);
+    expect(service.get('docs')).toBeUndefined();
+    await service.install(join(bundled, 'docs'));
+    expect(service.get('docs')?.id).toBe('docs');
+  });
+
+  it('auto-uninstalls retired first-party leftovers instead of migrating them', async () => {
+    const dataDir = root();
+    const sidecar = join(dataDir, 'extensions', 'zana');
+    writePlugin(sidecar, 'zana');
+    const leftover = writePlugin(join(root(), 'consensus'), 'consensus');
+    const keep = writePlugin(join(root(), 'keep'), 'keep');
+    const bundled = root();
+    writePlugin(join(bundled, 'docs'), 'docs');
+    const service = createPluginService({ dataDir, bundledRoot: bundled });
+    await service.install(leftover);
+    await service.install(keep);
+    await service.start();
+    expect(service.get('zana')).toBeUndefined();
+    expect(service.get('consensus')).toBeUndefined();
+    expect(existsSync(sidecar)).toBe(false);
+    expect(service.get('keep')?.id).toBe('keep');
+  });
+
+  it('leaves a local-authored retired id in place', async () => {
+    const dataDir = root();
+    const sidecar = join(dataDir, 'extensions', 'zana');
+    writePlugin(sidecar, 'zana');
+    mkdirSync(join(dataDir, 'extensions'), { recursive: true });
+    writeFileSync(
+      join(dataDir, 'extensions', 'local.json'),
+      JSON.stringify({ zana: { workingDir: sidecar } })
+    );
+    const bundled = root();
+    writePlugin(join(bundled, 'docs'), 'docs');
+    const service = createPluginService({ dataDir, bundledRoot: bundled });
+    await service.start();
+    expect(existsSync(sidecar)).toBe(true);
+    expect(service.get('zana')).toBeUndefined();
+  });
 });
 
 describe('defaultPluginDataDir', () => {

--- a/apps/server/src/plugins/plugin-service.ts
+++ b/apps/server/src/plugins/plugin-service.ts
@@ -48,7 +48,12 @@ import {
 import { PluginHostArtifactRegistry } from './plugin-host-artifact-registry.js';
 import { loadPluginHostArtifactSnapshot } from './plugin-host-artifact.js';
 import { discoverPluginSkillNames } from './plugin-skills.js';
-import { BUILTIN_PLUGINS, OFFICIAL_PLUGINS, bundledPluginByName } from './builtin-registry.js';
+import {
+  BUILTIN_PLUGINS,
+  OFFICIAL_PLUGINS,
+  bundledPluginByName,
+  isRetiredFirstPartyPluginId
+} from './builtin-registry.js';
 import { defaultCloneGit, defaultFetchJson, defaultSpawnNpm } from './plugin-process.js';
 import { readPluginLogTail } from './plugin-log.js';
 import {
@@ -57,6 +62,7 @@ import {
   type InstalledPluginRow,
   type PluginStore
 } from './plugin-store.js';
+import { createPluginUninstalledStore, pluginUninstalledPath } from './plugin-uninstalled.js';
 import {
   generatedSkillsRootPath,
   syncPluginCommandsSkill,
@@ -335,6 +341,7 @@ function resolveBundledDir(bundledRoot: string, name: string): string {
 
 export function createPluginService(opts: PluginServiceOptions): PluginService {
   const store: PluginStore = createPluginStore({ file: pluginStorePath(opts.dataDir) });
+  const uninstalled = createPluginUninstalledStore({ file: pluginUninstalledPath(opts.dataDir) });
   const marketplaces: MarketplaceStore = createMarketplaceStore({
     file: marketplaceStorePath(opts.dataDir)
   });
@@ -883,6 +890,7 @@ export function createPluginService(opts: PluginServiceOptions): PluginService {
       installedAt: existing?.installedAt ?? ts,
       updatedAt: ts
     };
+    await uninstalled.forget(manifest.id);
     await store.upsert(row);
     await loadOne(row);
     await emitCapabilities();
@@ -974,6 +982,32 @@ export function createPluginService(opts: PluginServiceOptions): PluginService {
     }
   }
 
+  async function retireRetiredFirstPartyPlugins(): Promise<void> {
+    const ids = new Set<string>();
+    for (const row of store.list()) {
+      if (isRetiredFirstPartyPluginId(row.id)) ids.add(row.id);
+    }
+    const legacyRoot = join(opts.dataDir, 'extensions');
+    if (existsSync(legacyRoot) && statSync(legacyRoot).isDirectory()) {
+      for (const name of readdirSync(legacyRoot)) {
+        if (name.endsWith('.json') || !isRetiredFirstPartyPluginId(name)) continue;
+        ids.add(name);
+      }
+    }
+    for (const id of ids) {
+      if (isLocalSidecar(opts.dataDir, id)) continue;
+      availableUpdates.delete(id);
+      await disposeOne(id);
+      const row = await store.remove(id);
+      await uninstalled.add(id);
+      if (row && row.sourceKind !== 'path' && row.rootDir.startsWith(join(opts.dataDir, 'plugins'))) {
+        rmSync(row.rootDir, { recursive: true, force: true });
+      }
+      removeInstalledPluginCopy(opts.dataDir, id);
+      removeLeftoverSidecar(opts.dataDir, id);
+    }
+  }
+
   const service: PluginService = {
     list: () => store.list(),
     get: (id) => store.get(id),
@@ -1034,9 +1068,11 @@ export function createPluginService(opts: PluginServiceOptions): PluginService {
       availableUpdates.delete(id);
       await disposeOne(id);
       const row = await store.remove(id);
+      await uninstalled.add(id);
       if (row && row.sourceKind !== 'path' && row.rootDir.startsWith(join(opts.dataDir, 'plugins'))) {
         rmSync(row.rootDir, { recursive: true, force: true });
       }
+      removeLeftoverSidecar(opts.dataDir, id);
       await emitCapabilities();
       await emitAppsChanged();
       await syncCliSkill();
@@ -1059,6 +1095,7 @@ export function createPluginService(opts: PluginServiceOptions): PluginService {
       const installed: InstalledPluginRow[] = [];
       for (const def of BUILTIN_PLUGINS) {
         if (!def.autoInstall) continue;
+        if (uninstalled.has(def.pluginId)) continue;
         if (store.get(def.pluginId)) continue;
         try {
           installed.push(await installParsed({ kind: 'builtin', name: def.name }, def.defaultEnabled));
@@ -1069,7 +1106,7 @@ export function createPluginService(opts: PluginServiceOptions): PluginService {
       return installed;
     },
     async start() {
-      await migrateLegacySidecars(opts.dataDir, installParsed, store);
+      await retireRetiredFirstPartyPlugins();
       await this.reconcileBuiltins();
       await seedOfficialMarketplace();
       for (const row of store.list()) {
@@ -1264,41 +1301,31 @@ export function createPluginService(opts: PluginServiceOptions): PluginService {
   return service;
 }
 
-async function migrateLegacySidecars(
-  dataDir: string,
-  installParsed: (source: ParsedPluginSource, enable: boolean) => Promise<InstalledPluginRow>,
-  store: PluginStore
-): Promise<void> {
-  const legacyRoot = join(dataDir, 'extensions');
-  if (!existsSync(legacyRoot) || !statSync(legacyRoot).isDirectory()) return;
-  let enabled: Record<string, boolean> = {};
+function removeInstalledPluginCopy(dataDir: string, id: string): void {
+  if (!isPluginId(id)) return;
+  const copy = join(dataDir, 'plugins', id);
+  if (!existsSync(copy) || !statSync(copy).isDirectory()) return;
+  rmSync(copy, { recursive: true, force: true });
+}
+
+function isLocalSidecar(dataDir: string, id: string): boolean {
   try {
-    const raw = JSON.parse(readFileSync(join(legacyRoot, 'enabled.json'), 'utf8')) as {
-      enabled?: Record<string, boolean>;
+    const locals = JSON.parse(readFileSync(join(dataDir, 'extensions', 'local.json'), 'utf8')) as {
+      [key: string]: { workingDir?: string };
     };
-    enabled = raw.enabled ?? {};
+    const workingDir = locals[id]?.workingDir;
+    return typeof workingDir === 'string' && workingDir.length > 0;
   } catch {
-    /* optional */
+    return false;
   }
-  let locals: Record<string, { workingDir?: string }> = {};
-  try {
-    locals = JSON.parse(readFileSync(join(legacyRoot, 'local.json'), 'utf8')) as typeof locals;
-  } catch {
-    /* optional */
-  }
-  for (const name of readdirSync(legacyRoot)) {
-    if (name.endsWith('.json')) continue;
-    const dir = join(legacyRoot, name);
-    if (!statSync(dir).isDirectory()) continue;
-    if (store.get(name)) continue;
-    const localDir = locals[name]?.workingDir;
-    const sourceDir = localDir && existsSync(localDir) ? localDir : dir;
-    try {
-      await installParsed({ kind: 'path', path: sourceDir }, enabled[name] !== false);
-    } catch {
-      /* skip unreadable legacy dirs */
-    }
-  }
+}
+
+/** Drop a leftover `~/.zcc/extensions/<id>` copy so discovery cannot resurrect it. */
+function removeLeftoverSidecar(dataDir: string, id: string): void {
+  if (!isPluginId(id) || isLocalSidecar(dataDir, id)) return;
+  const sidecar = join(dataDir, 'extensions', id);
+  if (!existsSync(sidecar) || !statSync(sidecar).isDirectory()) return;
+  rmSync(sidecar, { recursive: true, force: true });
 }
 
 export function defaultBundledRoot(): string {

--- a/apps/server/src/plugins/plugin-uninstalled.test.ts
+++ b/apps/server/src/plugins/plugin-uninstalled.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createPluginUninstalledStore, pluginUninstalledPath } from './plugin-uninstalled.js';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const dir of roots.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('plugin uninstall tombstone', () => {
+  it('persists ids and forgets them on reinstall', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'zcc-uninstalled-'));
+    roots.push(dataDir);
+    const store = createPluginUninstalledStore({ file: pluginUninstalledPath(dataDir) });
+    expect(store.has('docs')).toBe(false);
+    await store.add('docs');
+    expect(store.has('docs')).toBe(true);
+    const persisted = JSON.parse(readFileSync(pluginUninstalledPath(dataDir), 'utf8')) as {
+      ids: string[];
+    };
+    expect(persisted.ids).toEqual(['docs']);
+    await store.forget('docs');
+    expect(store.has('docs')).toBe(false);
+  });
+
+  it('ignores invalid plugin ids', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'zcc-uninstalled-'));
+    roots.push(dataDir);
+    const store = createPluginUninstalledStore({ file: pluginUninstalledPath(dataDir) });
+    await store.add('../etc');
+    expect(store.has('../etc')).toBe(false);
+  });
+});

--- a/apps/server/src/plugins/plugin-uninstalled.ts
+++ b/apps/server/src/plugins/plugin-uninstalled.ts
@@ -1,0 +1,57 @@
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { isPluginId } from '@zana-ai/zcc-domain';
+import { atomicDurableWrite, createSerializedTransactionQueue } from '../durable-store.js';
+
+interface UninstalledFile {
+  version: 1;
+  ids: string[];
+}
+
+export function pluginUninstalledPath(dataDir: string): string {
+  return join(dataDir, 'plugins', 'uninstalled.json');
+}
+
+export function createPluginUninstalledStore(opts: { file: string }): {
+  has(id: string): boolean;
+  add(id: string): Promise<void>;
+  forget(id: string): Promise<void>;
+} {
+  const queue = createSerializedTransactionQueue();
+
+  function read(): UninstalledFile {
+    if (!existsSync(opts.file)) return { version: 1, ids: [] };
+    try {
+      const parsed = JSON.parse(readFileSync(opts.file, 'utf8')) as UninstalledFile;
+      if (parsed?.version !== 1 || !Array.isArray(parsed.ids)) return { version: 1, ids: [] };
+      return { version: 1, ids: parsed.ids.filter((id) => typeof id === 'string' && isPluginId(id)) };
+    } catch {
+      return { version: 1, ids: [] };
+    }
+  }
+
+  function write(file: UninstalledFile): void {
+    mkdirSync(dirname(opts.file), { recursive: true });
+    atomicDurableWrite(opts.file, Buffer.from(`${JSON.stringify(file, null, 2)}\n`, 'utf8'));
+  }
+
+  return {
+    has(id) {
+      return read().ids.includes(id);
+    },
+    add(id) {
+      if (!isPluginId(id)) return Promise.resolve();
+      return queue.run(async () => {
+        const file = read();
+        if (file.ids.includes(id)) return;
+        write({ version: 1, ids: [...file.ids, id].sort() });
+      });
+    },
+    forget(id) {
+      return queue.run(async () => {
+        const file = read();
+        write({ version: 1, ids: file.ids.filter((item) => item !== id) });
+      });
+    }
+  };
+}

--- a/apps/server/src/services/hosts/host-relaunch.test.ts
+++ b/apps/server/src/services/hosts/host-relaunch.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('local host daemon relaunch', () => {
+  it('steals the data-dir lock so Settings can recover this machine', () => {
+    const source = readFileSync(new URL('./host-relaunch.ts', import.meta.url), 'utf8');
+    expect(source).toContain('stealLock: true');
+    expect(source).toContain('startEnrolledHostDaemon');
+  });
+
+  it('is wired on POST /api/v1/hosts/relaunch-local', () => {
+    const api = readFileSync(new URL('../../http/hosts-api.ts', import.meta.url), 'utf8');
+    expect(api).toContain("path === '/api/v1/hosts/relaunch-local'");
+    expect(api).toContain('relaunchLocalHostDaemon');
+  });
+});

--- a/apps/server/src/services/hosts/host-relaunch.ts
+++ b/apps/server/src/services/hosts/host-relaunch.ts
@@ -1,0 +1,44 @@
+import { startEnrolledHostDaemon, type EnrolledHostDaemon } from '@zana-ai/zcc-host-daemon/enroll-runtime';
+import type { ProductHttpContext } from '../../http/product-context.js';
+
+const inflight = new WeakMap<ProductHttpContext, Promise<void>>();
+const live = new WeakMap<ProductHttpContext, EnrolledHostDaemon>();
+
+export function disposeLocalHostDaemon(ctx: ProductHttpContext): void {
+  const daemon = live.get(ctx);
+  live.delete(ctx);
+  void daemon?.close();
+}
+
+export async function relaunchLocalHostDaemon(
+  ctx: ProductHttpContext
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const previous = inflight.get(ctx);
+  if (previous) await previous.catch(() => undefined);
+  const work = (async () => {
+    const current = live.get(ctx);
+    live.delete(ctx);
+    await current?.close().catch(() => undefined);
+    const port = ctx.origins.serverPort;
+    if (!port) throw new Error('product HTTP is not listening');
+    const daemon = await startEnrolledHostDaemon({
+      dataDir: ctx.dataDir,
+      serverUrl: `http://127.0.0.1:${port}/`,
+      token: ctx.enrollToken,
+      stealLock: true
+    });
+    live.set(ctx, daemon);
+  })();
+  inflight.set(ctx, work);
+  try {
+    await work;
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : 'Could not relaunch this machine'
+    };
+  } finally {
+    if (inflight.get(ctx) === work) inflight.delete(ctx);
+  }
+}

--- a/apps/server/src/static-host.test.ts
+++ b/apps/server/src/static-host.test.ts
@@ -184,6 +184,14 @@ describe('startStaticHost', () => {
       instanceId
     }));
     await expect.poll(() => product.hostHub.connectedHostIds()).toContain(enrolled.hostId);
+    const listed = await fetch(`${host.url}api/v1/hosts`).then((response) => response.json()) as Array<{
+      id: string;
+      status: string;
+      lastSeenAt: number | null;
+    }>;
+    const row = listed.find((item) => item.id === enrolled.hostId);
+    expect(row?.status).toBe('connected');
+    expect(Date.now() - (row?.lastSeenAt ?? 0)).toBeLessThan(10_000);
     socket.close();
     product.hostHub.close();
     product.db.close();

--- a/packages/desktop-contract/src/cc-api.ts
+++ b/packages/desktop-contract/src/cc-api.ts
@@ -333,6 +333,12 @@ export interface CcApi {
       request: { provider: ProviderCliKey; actionKind: ProviderCliInstallActionKind }
     ): Promise<ProviderCliInstallEvent[]>;
     onChanged(cb: (hosts: Host[] | undefined) => void): () => void;
+    /**
+     * Restart this laptop's enrolled host-daemon and reconnect it to the
+     * product hub. Desktop uses the co-started host utility; loopback HTTP
+     * is the fallback when that process is not running.
+     */
+    relaunchLocal(): Promise<{ ok: true } | { ok: false; message: string }>;
   };
   /**
    * Outbound pairing-relay tunnel to the public origin (Heroku front door).
@@ -1327,6 +1333,7 @@ export interface CcApi {
       marketplace: string;
     }>>;
     applyUpdate(id: string): Promise<Result<true>>;
+    remove(id: string): Promise<Result<true>>;
   };
   /**
    * Runtime extensions discovered under `~/.zcc/extensions/<id>/`.

--- a/packages/desktop-contract/src/ipc.ts
+++ b/packages/desktop-contract/src/ipc.ts
@@ -28,6 +28,9 @@ export const IPC = {
     listHosts: 'ssh:listHosts',
     syncHosts: 'ssh:syncHosts'
   },
+  hosts: {
+    relaunchLocal: 'hosts:relaunchLocal'
+  },
   terminals: {
     list: 'terminals:list',
     verifyTmux: 'terminals:verifyTmux',
@@ -328,7 +331,8 @@ export const IPC = {
     getSettings: 'pluginApps:getSettings',
     setSettings: 'pluginApps:setSettings',
     checkUpdates: 'pluginApps:checkUpdates',
-    applyUpdate: 'pluginApps:applyUpdate'
+    applyUpdate: 'pluginApps:applyUpdate',
+    remove: 'pluginApps:remove'
   },
   /**
    * Runtime extensions under `~/.zcc/extensions/<id>/`. Mirrors the

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -625,6 +625,12 @@ export const publicApiRoutes = {
       request: noRequest(),
       response: jsonResponse<Host[]>(),
     }),
+    relaunchLocal: defineRoute({
+      path: "/hosts/relaunch-local",
+      method: "post",
+      request: noRequest(),
+      response: jsonResponse<{ ok: true } | { ok: false; message: string }>(),
+    }),
     get: defineRoute({
       path: "/hosts/:id",
       method: "get",

--- a/plugins/pr-monitor/app.meta.json
+++ b/plugins/pr-monitor/app.meta.json
@@ -5,7 +5,7 @@
   "pluginId": "pr-monitor",
   "pluginVersion": "0.1.0",
   "builtWith": {
-    "zccVersion": "1.0.10",
+    "zccVersion": "2.0.0",
     "pluginSdkVersion": "0.1.0"
   }
 }

--- a/plugins/pr-monitor/server.meta.json
+++ b/plugins/pr-monitor/server.meta.json
@@ -5,7 +5,7 @@
   "pluginId": "pr-monitor",
   "pluginVersion": "0.1.0",
   "builtWith": {
-    "zccVersion": "1.0.10",
+    "zccVersion": "2.0.0",
     "pluginSdkVersion": "0.1.0"
   }
 }

--- a/plugins/salesforce/app.meta.json
+++ b/plugins/salesforce/app.meta.json
@@ -5,7 +5,7 @@
   "pluginId": "salesforce",
   "pluginVersion": "0.1.0",
   "builtWith": {
-    "zccVersion": "1.0.10",
+    "zccVersion": "2.0.0",
     "pluginSdkVersion": "0.1.0"
   }
 }

--- a/scripts/sync-internal-mirror.sh
+++ b/scripts/sync-internal-mirror.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Mirror this checkout onto the Salesforce-internal clone, keeping that clone's
+# README.md (the "this is an internal copy" banner). GitHub.com/salesforce/zana
+# is the product source; git.soma is the keep-in-sync copy.
+#
+# Usage (from the repo, with VPN / git.soma credentials):
+#   bash scripts/sync-internal-mirror.sh
+#
+# Env:
+#   SOURCE_REF          Commit-ish to copy (default: origin/main, or HEAD)
+#   INTERNAL_URL        Default: https://git.soma.salesforce.com/chatbots/zana-command-center.git
+#   INTERNAL_REMOTE     Tracking name for refs/remotes/<name>/… (default: legacy)
+#   INTERNAL_BRANCH     Branch to update on the internal remote (default: main)
+#   SOMA_GIT_TOKEN      Optional PAT; used as https://x-access-token:… for fetch/push
+#   DRY_RUN=1           Build the commit but do not push
+#   PUSH=0              Same as DRY_RUN for the push step
+set -euo pipefail
+
+INTERNAL_URL="${INTERNAL_URL:-https://git.soma.salesforce.com/chatbots/zana-command-center.git}"
+INTERNAL_REMOTE="${INTERNAL_REMOTE:-legacy}"
+INTERNAL_BRANCH="${INTERNAL_BRANCH:-main}"
+DRY_RUN="${DRY_RUN:-0}"
+PUSH="${PUSH:-1}"
+
+if [[ -z "${SOURCE_REF:-}" ]]; then
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    SOURCE_REF=origin/main
+  else
+    SOURCE_REF=HEAD
+  fi
+fi
+
+git_url() {
+  if [[ -n "${SOMA_GIT_TOKEN:-}" ]]; then
+    # Token lives only in this function's output; callers must not echo it.
+    printf '%s\n' "https://x-access-token:${SOMA_GIT_TOKEN}@git.soma.salesforce.com/chatbots/zana-command-center.git"
+    return
+  fi
+  if git remote get-url "$INTERNAL_REMOTE" >/dev/null 2>&1; then
+    git remote get-url "$INTERNAL_REMOTE"
+    return
+  fi
+  printf '%s\n' "$INTERNAL_URL"
+}
+
+SOURCE_COMMIT="$(git rev-parse "${SOURCE_REF}^{commit}")"
+
+FETCH_URL="$(git_url)"
+# Fetch into a remote-tracking ref without printing the URL (it may contain a token).
+git fetch --quiet "$FETCH_URL" "+refs/heads/${INTERNAL_BRANCH}:refs/remotes/${INTERNAL_REMOTE}/${INTERNAL_BRANCH}"
+
+INTERNAL_COMMIT="$(git rev-parse "refs/remotes/${INTERNAL_REMOTE}/${INTERNAL_BRANCH}^{commit}")"
+
+README_LINE="$(git ls-tree "$INTERNAL_COMMIT" README.md || true)"
+if [[ -z "$README_LINE" ]]; then
+  echo "error: ${INTERNAL_REMOTE}/${INTERNAL_BRANCH} has no README.md to preserve" >&2
+  exit 1
+fi
+README_MODE="$(awk '{ print $1 }' <<<"$README_LINE")"
+README_BLOB="$(awk '{ print $3 }' <<<"$README_LINE")"
+
+TMP_INDEX="$(mktemp)"
+cleanup() { rm -f "$TMP_INDEX"; }
+trap cleanup EXIT
+
+GIT_INDEX_FILE="$TMP_INDEX" git read-tree "$SOURCE_COMMIT"
+GIT_INDEX_FILE="$TMP_INDEX" git update-index --cacheinfo "$README_MODE" "$README_BLOB" README.md
+NEW_TREE="$(GIT_INDEX_FILE="$TMP_INDEX" git write-tree)"
+OLD_TREE="$(git rev-parse "${INTERNAL_COMMIT}^{tree}")"
+
+if [[ "$NEW_TREE" == "$OLD_TREE" ]]; then
+  echo "internal ${INTERNAL_BRANCH} already matches ${SOURCE_COMMIT:0:12} (README preserved)"
+  exit 0
+fi
+
+MSG="$(cat <<EOF
+chore: mirror salesforce/zana ${SOURCE_COMMIT:0:12}
+
+Keep the internal README.md; copy every other path from the public tree.
+EOF
+)"
+
+NEW_COMMIT="$(git commit-tree "$NEW_TREE" -p "$INTERNAL_COMMIT" -m "$MSG")"
+
+if [[ "$DRY_RUN" == "1" || "$PUSH" == "0" ]]; then
+  echo "dry-run: would push ${NEW_COMMIT:0:12} → ${INTERNAL_REMOTE}/${INTERNAL_BRANCH}"
+  echo "$NEW_COMMIT"
+  exit 0
+fi
+
+git push --quiet "$FETCH_URL" "${NEW_COMMIT}:refs/heads/${INTERNAL_BRANCH}"
+echo "pushed ${NEW_COMMIT:0:12} to ${INTERNAL_BRANCH} (source ${SOURCE_COMMIT:0:12})"

--- a/scripts/sync-internal-mirror.test.ts
+++ b/scripts/sync-internal-mirror.test.ts
@@ -1,0 +1,189 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, afterEach } from 'vitest';
+
+const script = join(dirname(fileURLToPath(import.meta.url)), 'sync-internal-mirror.sh');
+
+const gitEnv = {
+  GIT_AUTHOR_NAME: 'sync-test',
+  GIT_AUTHOR_EMAIL: 'sync-test@example.com',
+  GIT_COMMITTER_NAME: 'sync-test',
+  GIT_COMMITTER_EMAIL: 'sync-test@example.com',
+};
+
+function git(cwd: string, args: string[], extraEnv: NodeJS.ProcessEnv = {}): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...gitEnv, ...extraEnv }
+  }).trim();
+}
+
+function initBare(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+  git(dir, ['init', '--bare']);
+}
+
+function initWork(work: string, originBare: string): void {
+  mkdirSync(work, { recursive: true });
+  git(work, ['init', '-b', 'main']);
+  git(work, ['remote', 'add', 'origin', originBare]);
+}
+
+function commitAll(work: string, message: string): void {
+  git(work, ['add', '-A']);
+  git(work, ['commit', '-m', message]);
+  git(work, ['push', '-u', 'origin', 'HEAD:main']);
+}
+
+describe('sync-internal-mirror.sh', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function setupPair(): {
+    srcWork: string;
+    dstBare: string;
+    dstWork: string;
+  } {
+    const root = mkdtempSync(join(tmpdir(), 'sync-internal-'));
+    roots.push(root);
+    const srcBare = join(root, 'src.git');
+    const dstBare = join(root, 'dst.git');
+    initBare(srcBare);
+    initBare(dstBare);
+
+    const srcWork = join(root, 'src');
+    initWork(srcWork, srcBare);
+    writeFileSync(join(srcWork, 'README.md'), 'public readme\n');
+    writeFileSync(join(srcWork, 'app.txt'), 'from public\n');
+    mkdirSync(join(srcWork, 'pkg'), { recursive: true });
+    writeFileSync(join(srcWork, 'pkg', 'a.ts'), 'export const a = 1;\n');
+    commitAll(srcWork, 'public tree');
+
+    const dstWork = join(root, 'dst');
+    initWork(dstWork, dstBare);
+    writeFileSync(join(dstWork, 'README.md'), 'internal banner\n');
+    writeFileSync(join(dstWork, 'app.txt'), 'stale\n');
+    writeFileSync(join(dstWork, 'only-internal.txt'), 'should be deleted\n');
+    commitAll(dstWork, 'internal tree');
+
+    return { srcWork, dstBare, dstWork };
+  }
+
+  it('copies every path except README.md and deletes paths gone from source', () => {
+    const { srcWork, dstBare, dstWork } = setupPair();
+
+    execFileSync('bash', [script], {
+      cwd: srcWork,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ...gitEnv,
+        INTERNAL_URL: dstBare,
+        INTERNAL_REMOTE: 'internal',
+        INTERNAL_BRANCH: 'main',
+        SOURCE_REF: 'HEAD'
+      }
+    });
+
+    git(dstWork, ['pull', '--ff-only']);
+    const readme = execFileSync('git', ['show', 'HEAD:README.md'], {
+      cwd: dstWork,
+      encoding: 'utf8'
+    });
+    const app = execFileSync('git', ['show', 'HEAD:app.txt'], {
+      cwd: dstWork,
+      encoding: 'utf8'
+    });
+    const pkg = execFileSync('git', ['show', 'HEAD:pkg/a.ts'], {
+      cwd: dstWork,
+      encoding: 'utf8'
+    });
+
+    expect(readme).toBe('internal banner\n');
+    expect(app).toBe('from public\n');
+    expect(pkg).toBe('export const a = 1;\n');
+    expect(() =>
+      execFileSync('git', ['cat-file', '-e', 'HEAD:only-internal.txt'], { cwd: dstWork })
+    ).toThrow();
+  });
+
+  it('is a no-op when the internal tree already matches', () => {
+    const { srcWork, dstBare } = setupPair();
+    const env = {
+      ...process.env,
+      ...gitEnv,
+      INTERNAL_URL: dstBare,
+      INTERNAL_REMOTE: 'internal',
+      INTERNAL_BRANCH: 'main',
+      SOURCE_REF: 'HEAD'
+    };
+    execFileSync('bash', [script], { cwd: srcWork, encoding: 'utf8', env });
+    const first = git(dstBare, ['rev-parse', 'main']);
+    const out = execFileSync('bash', [script], { cwd: srcWork, encoding: 'utf8', env });
+    expect(out).toMatch(/already matches/);
+    expect(git(dstBare, ['rev-parse', 'main'])).toBe(first);
+  });
+
+  it('fails when the internal branch has no README.md', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sync-internal-'));
+    roots.push(root);
+    const srcBare = join(root, 'src.git');
+    const dstBare = join(root, 'dst.git');
+    initBare(srcBare);
+    initBare(dstBare);
+
+    const srcWork = join(root, 'src');
+    initWork(srcWork, srcBare);
+    writeFileSync(join(srcWork, 'README.md'), 'public\n');
+    writeFileSync(join(srcWork, 'app.txt'), 'x\n');
+    commitAll(srcWork, 'public');
+
+    const dstWork = join(root, 'dst');
+    initWork(dstWork, dstBare);
+    writeFileSync(join(dstWork, 'only.txt'), 'no readme\n');
+    commitAll(dstWork, 'internal without readme');
+
+    expect(() =>
+      execFileSync('bash', [script], {
+        cwd: srcWork,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ...gitEnv,
+          INTERNAL_URL: dstBare,
+          INTERNAL_REMOTE: 'internal',
+          INTERNAL_BRANCH: 'main',
+          SOURCE_REF: 'HEAD'
+        }
+      })
+    ).toThrow(/no README\.md to preserve/);
+  });
+
+  it('dry-run does not update the internal branch', () => {
+    const { srcWork, dstBare } = setupPair();
+    const before = git(dstBare, ['rev-parse', 'main']);
+    execFileSync('bash', [script], {
+      cwd: srcWork,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ...gitEnv,
+        INTERNAL_URL: dstBare,
+        INTERNAL_REMOTE: 'internal',
+        INTERNAL_BRANCH: 'main',
+        SOURCE_REF: 'HEAD',
+        DRY_RUN: '1'
+      }
+    });
+    expect(git(dstBare, ['rev-parse', 'main'])).toBe(before);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -73,6 +73,10 @@
   "exclude": [
     "plugins/**/*.test.ts",
     "plugins/**/*.test.tsx",
+    // Glob `*.ts` also matches `*.d.ts`. The vendored `declare module` stub
+    // would otherwise override the real `@zana-ai/zcc-plugin-sdk` exports
+    // (ZccPluginApi, slot registrations, etc.) for the whole program.
+    "plugins/**/types/zcc-plugin-sdk.d.ts",
     "apps/server/src/**/*.test.ts",
     "packages/db/src/**/*.test.ts",
     "packages/contracts/src/**/*.test.ts",

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -18,6 +18,12 @@ ENV npm_config_registry=https://registry.npmjs.org/
 # nested esbuild binaries, so `npm install` honors the lock while filling
 # those in on the linux build.
 COPY package.json package-lock.json* ./
+# Lockfiles from Salesforce machines pin `resolved` to Nexus; rewrite those
+# tarball URLs so npm actually hits registry.npmjs.org (the registry env
+# alone does not override lockfile `resolved` fields).
+RUN if [ -f package-lock.json ]; then \
+      sed -i 's#https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/#https://registry.npmjs.org/#g' package-lock.json; \
+    fi
 RUN npm install --no-audit --no-fund
 
 # NEXT_PUBLIC_* are inlined at build time, so pass them as build args when the


### PR DESCRIPTION
## Summary
- Add `hosts.relaunchLocal` and a Settings → Machines “Relaunch harness” action for the primary machine, with desktop IPC fallback to the product server.
- Add `pluginApps.remove` and an Extensions Hub uninstall flow that removes PluginService plugins and leftover disk entries, and hides built-in compiled modules from Installed unless they are actually installed.
- Fall split-workspace plugin panels back to the compiled `AppModulePanel` when a plugin registers no `navPanel` slot; exclude vendored `zcc-plugin-sdk.d.ts` stubs from `tsconfig.json`. Also adds public→internal git.soma mirror sync skill/script.

## Test plan
- [ ] Settings → Machines: relaunch harness on the primary/local machine and confirm the host comes back.
- [ ] Extensions Hub: uninstall a non-builtin plugin and confirm it leaves Installed; leftover disk entries are removed; compiled built-ins stay hidden unless installed.
- [ ] Open a split-workspace plugin panel with no `navPanel` and confirm the compiled module panel fallback renders.
- [ ] Confirm Installed row chevron is a clickable button.