### PR TITLE
feat(app): add Report a bug control and GitHub issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,20 @@
+name: Bug report
+description: Something in Zana does not work
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: What you saw, and what you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+  - type: input
+    id: version
+    attributes:
+      label: Zana version and OS
+      description: Settings → About

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/salesforce/zana/security/advisories/new
+    about: Report security issues privately. Do not file them as public GitHub issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,9 @@ and issue reports are welcome.
 ## Before You Start
 
 - Search [existing issues](https://github.com/salesforce/zana/issues) before
-  opening a new one.
+  opening a new one. Bug reports should use the
+  [Bug report](https://github.com/salesforce/zana/issues/new?template=bug.yml)
+  template (also available from the in-app **Report a bug** control).
 - Open an issue first for substantial features or behavioral changes so the
   maintainers and community can align on the approach.
 - For security vulnerabilities, follow the private reporting process in

--- a/apps/app/src/components/SidebarRail.tsx
+++ b/apps/app/src/components/SidebarRail.tsx
@@ -9,7 +9,8 @@ import {
 import { DndContext } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { Link } from 'react-router-dom';
-import { Settings } from 'lucide-react';
+import { Bug, Settings } from 'lucide-react';
+import { openBugReport } from '../lib/report-bug.js';
 import { useUi } from '../store.js';
 import { useRouteState } from '../hooks/useRouteState.js';
 import { useAppSettingsRouteMemory } from '../hooks/useAppSettingsRouteMemory.js';
@@ -179,6 +180,15 @@ export function SidebarRail({
         >
           <Settings size={18} />
         </Link>
+        <button
+          type="button"
+          className="sidebar-utility-button"
+          aria-label="Report a bug"
+          title="Report a bug"
+          onClick={() => openBugReport()}
+        >
+          <Bug size={18} aria-hidden="true" />
+        </button>
         {footerActions.map((action) => {
           const Icon = resolveIcon(action.icon);
           return (

--- a/apps/app/src/components/__tests__/ProjectScopedNav.test.tsx
+++ b/apps/app/src/components/__tests__/ProjectScopedNav.test.tsx
@@ -93,6 +93,7 @@ describe('ProjectScopedNav matches the global sidebar chrome', () => {
     expect(markup).toContain('class="sidebar-utility-bar"');
     expect(markup).toContain('class="sidebar-resizer"');
     expect(markup).toContain('aria-label="Settings"');
+    expect(markup).toContain('aria-label="Report a bug"');
     expect(markup).toContain('aria-label="Open this project in a new window"');
     expect(markup).not.toContain('>Settings<');
     expect(markup).not.toContain('>Open in new window<');
@@ -160,6 +161,7 @@ describe('ProjectScopedNav matches the global sidebar chrome', () => {
     expect(markup).not.toContain('project-focused-nav');
     expect(markup).not.toContain('aria-label="Open this project in a new window"');
     expect(markup).toContain('aria-label="Settings"');
+    expect(markup).toContain('aria-label="Report a bug"');
     expect(markup).not.toContain('aria-label="Go back"');
     expect(markup).not.toContain('class="settings-app-back"');
     expect(markup).not.toContain('>Back</button>');

--- a/apps/app/src/components/__tests__/Sidebar.test.tsx
+++ b/apps/app/src/components/__tests__/Sidebar.test.tsx
@@ -119,6 +119,7 @@ describe('Sidebar structure and compact accessibility', () => {
     expect(markup).toContain('class="sidebar-resizer"');
     expect(markup).toContain('aria-orientation="vertical"');
     expect(markup).toContain('aria-label="Settings"');
+    expect(markup).toContain('aria-label="Report a bug"');
     expect(markup).not.toContain('>Settings<');
     expect(markup).not.toContain('aria-label="Open Agents dashboard"');
     expect(markup).not.toContain('data-testid="sidebar-agents-heading"');

--- a/apps/app/src/components/__tests__/SidebarRail.test.tsx
+++ b/apps/app/src/components/__tests__/SidebarRail.test.tsx
@@ -87,6 +87,7 @@ describe('SidebarRail', () => {
     expect(markup).toContain('class="sidebar-nav sidebar-nav--sortable"');
     expect(markup).toContain('class="sidebar-utility-bar"');
     expect(markup).toContain('aria-label="Settings"');
+    expect(markup).toContain('aria-label="Report a bug"');
     expect(markup).toContain('href="/settings"');
     expect(markup).toContain('class="sidebar-resizer"');
     expect(markup).toContain('aria-orientation="vertical"');
@@ -142,6 +143,8 @@ describe('SidebarRail', () => {
     expect(source).toContain('{...rest}');
     expect(source).toContain('consumeNavClick()');
     expect(source).toContain('sidebar-utility-bar');
+    expect(source).toContain('openBugReport');
+    expect(source).toContain('Report a bug');
     expect(source).toContain('<DndContext');
     expect(source).toContain('onNavigate');
   });

--- a/apps/app/src/lib/__tests__/report-bug.test.ts
+++ b/apps/app/src/lib/__tests__/report-bug.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { openBugReport, REPORT_BUG_URL } from '../report-bug.js';
+
+describe('openBugReport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens the public GitHub bug form in a new tab', () => {
+    const open = vi.fn();
+    vi.stubGlobal('open', open);
+
+    openBugReport();
+
+    expect(REPORT_BUG_URL).toBe(
+      'https://github.com/salesforce/zana/issues/new?template=bug.yml'
+    );
+    expect(open).toHaveBeenCalledWith(REPORT_BUG_URL, '_blank', 'noopener');
+  });
+});

--- a/apps/app/src/lib/report-bug.ts
+++ b/apps/app/src/lib/report-bug.ts
@@ -1,0 +1,8 @@
+import { REPORT_BUG_URL } from '@zana-ai/zcc-domain/product';
+
+export { REPORT_BUG_URL };
+
+/** Open the public GitHub bug form in the OS browser (main window-open → shell.openExternal). */
+export function openBugReport(): void {
+  globalThis.open(REPORT_BUG_URL, '_blank', 'noopener');
+}

--- a/apps/desktop/src/host.ts
+++ b/apps/desktop/src/host.ts
@@ -132,7 +132,7 @@ import { createAgentMessageLog, type IAgentMessageLog } from '@zana-ai/zcc-serve
 import { killLocalTmuxSession, listLocalTmuxSessionIds, reapOrphanTmuxSessions, verifyTmux } from '@zana-ai/zcc-host-daemon/tmux';
 import { exportInboxPdf } from './native/inbox-pdf.js';
 import { createSavedStore, type ISavedStore } from '@zana-ai/zcc-server';
-import { ABOUT_CREDITS, type SavedRecord, type SavedRecordInput } from '@zana-ai/zcc-domain/product';
+import { ABOUT_CREDITS, REPORT_BUG_URL, type SavedRecord, type SavedRecordInput } from '@zana-ai/zcc-domain/product';
 import type { ConversationHistorySnapshot } from '@zana-ai/zcc-domain/product';
 import type { CancelTeamLaunchResult, LaunchTeamResult, TeamLaunchAuthorizationInputSlot, TeamLaunchAuthorizationResult, TeamLaunchRequestInput, TeamFailedWorkerSlot, TeamLaunchedWorker } from '@zana-ai/zcc-domain/product';
 import type { SubagentChild } from '@zana-ai/zcc-domain/product';
@@ -5128,6 +5128,10 @@ function buildAppMenu() {
           click: () => sendToFocused('app:openShortcuts')
         },
         { type: 'separator' },
+        {
+          label: 'Report a bug',
+          click: () => void shell.openExternal(REPORT_BUG_URL)
+        },
         {
           label: 'View on GitHub',
           click: () => shell.openExternal('https://github.com/grebmann/zana-command-center')

--- a/packages/domain/src/about-credits.test.ts
+++ b/packages/domain/src/about-credits.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { ABOUT_CREDITS, BB_IDE_URL } from './about-credits.js';
+import { ABOUT_CREDITS, BB_IDE_URL, REPORT_BUG_URL } from './about-credits.js';
 
 describe('ABOUT_CREDITS', () => {
   it('credits the bb IDE rebase and the products that inspired Zana', () => {
     expect(ABOUT_CREDITS).toContain('rebased on the awesome bb IDE');
     expect(ABOUT_CREDITS).toContain('Inspired by bb, Cursor, Codex, and Claude Code.');
     expect(BB_IDE_URL).toBe('https://github.com/get-bb/bb');
+  });
+
+  it('points bug reports at the public GitHub bug form', () => {
+    expect(REPORT_BUG_URL).toBe(
+      'https://github.com/salesforce/zana/issues/new?template=bug.yml'
+    );
   });
 });

--- a/packages/domain/src/about-credits.ts
+++ b/packages/domain/src/about-credits.ts
@@ -6,6 +6,9 @@ export const BB_IDE_URL = 'https://github.com/get-bb/bb';
 export const CURSOR_URL = 'https://cursor.com';
 export const CODEX_URL = 'https://openai.com/codex';
 export const CLAUDE_CODE_URL = 'https://claude.com/product/claude-code';
+/** Public GitHub bug form opened by the sidebar “Report a bug” control. */
+export const REPORT_BUG_URL =
+  'https://github.com/salesforce/zana/issues/new?template=bug.yml';
 
 export const ABOUT_CREDITS =
   'Zana’s architecture is rebased on the awesome bb IDE.\n\n' +

--- a/packages/domain/src/product.ts
+++ b/packages/domain/src/product.ts
@@ -13,7 +13,8 @@ export {
   BB_IDE_URL,
   CLAUDE_CODE_URL,
   CODEX_URL,
-  CURSOR_URL
+  CURSOR_URL,
+  REPORT_BUG_URL
 } from './about-credits.js';
 
 export type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,8 +158,8 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.6)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       microsandbox:
-        specifier: 0.6.8
-        version: 0.6.8
+        specifier: 0.6.10
+        version: 0.6.10
 
   apps/app:
     dependencies:
@@ -922,7 +922,7 @@ importers:
         specifier: ^7.1.2
         version: 7.6.3(@julusian/jpeg-turbo@3.0.1)
       '@napi-rs/canvas':
-        specifier: ^1.0.5
+        specifier: ^1.0.7
         version: 1.0.7
 
   packages/thread-view:
@@ -1214,7 +1214,7 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       next:
-        specifier: ^16.3.0
+        specifier: ^16.3.1
         version: 16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg:
         specifier: ^8.23.0
@@ -3051,34 +3051,34 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@superradcompany/microsandbox-darwin-arm64@0.6.8':
-    resolution: {integrity: sha512-SbPo2mb5sEWY7Sry9lxlh762oX5G4RI4Xq2i6U9covTe+4MIFznNSCPIntoCcpzVwt4VNIukvEdyTsI9kITJLw==}
+  '@superradcompany/microsandbox-darwin-arm64@0.6.10':
+    resolution: {integrity: sha512-TfuRQqEsB+rdW/MZm+U+idNnJoDv8oqluvZWFpIvaC55uEZgBy7tIrmroBWbglJzGrLIPUMZWE03jVsswUNpng==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@superradcompany/microsandbox-linux-arm64-gnu@0.6.8':
-    resolution: {integrity: sha512-cMgS/pE6N2LTbdGYMNiSzfxlsD0F1fhVuCFuIULxGfGyK+zmrYHgTgV0K6n9UQY+PjseOvNn//T7FJQ7SwyJ3g==}
+  '@superradcompany/microsandbox-linux-arm64-gnu@0.6.10':
+    resolution: {integrity: sha512-cHTy3391ztl3CPcKEAqQgbL7UmExAArtWnsFkHpbIenyQ02zGPuDo5ort6M7wetlul0kMQ4JVl9j3GRyJHVHLg==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@superradcompany/microsandbox-linux-x64-gnu@0.6.8':
-    resolution: {integrity: sha512-JCYgBsCf00bX2RA7YhdFdNOQHsWJFXYM3WJi1ONx3jLdUpiMKAVRZxCSPJe/UrFoRiqfj49AmgIBNtvs+2Ns9g==}
+  '@superradcompany/microsandbox-linux-x64-gnu@0.6.10':
+    resolution: {integrity: sha512-ETLUA69JraJV3m/fubZPxoPBUfrZFgN8E0/zzZ2fQ1lkI6mJ6iY2VzLWm5/EmTUnPlMeg4P+yWb2eo1oxJjgtA==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@superradcompany/microsandbox-win32-arm64-msvc@0.6.8':
-    resolution: {integrity: sha512-cWXaHBleVZbTddVYiUSuChNbHWhzTnNkgBqhisSDcFa1FBa0g5sBzTBlcC0RAseMzs4F+6YqLbD040QOe/6deQ==}
+  '@superradcompany/microsandbox-win32-arm64-msvc@0.6.10':
+    resolution: {integrity: sha512-03YzZsRbGJFQ+sEwaBkl0CFepoMuEssUCoovdFu2AsrTZ1aVa+MzB8wbZQK1+30NeGkhRg4jNIuBN4N+W1ycrw==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [win32]
 
-  '@superradcompany/microsandbox-win32-x64-msvc@0.6.8':
-    resolution: {integrity: sha512-Asfn+8+CplKh05MyJIoRJzLCl1Z05B/n6Lc6+tpfFKmHjMkQw976L67AqqBQq4AxfkakBcpZYVHZQqUDxl5Fow==}
+  '@superradcompany/microsandbox-win32-x64-msvc@0.6.10':
+    resolution: {integrity: sha512-PYbiHtgJoxW369qyBn6m4fz9WcNvEYl6zS67sRnOireCaRidHnCmn5iJZhYBufw8IID6yR+KYsuUqHaJZv3B4w==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [win32]
@@ -5487,8 +5487,8 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  microsandbox@0.6.8:
-    resolution: {integrity: sha512-N9sqwUFjeRisBJPyu3uV0f+BFsWQmrxogGoZw0jXuLY9+ey0cgPTzQBLhjKyCbe6rq8joGtefvyS3J4vEW7DBQ==}
+  microsandbox@0.6.10:
+    resolution: {integrity: sha512-aEURaWtSsc2gwlUHpzfkfzRBBhFcAgcmfL432b/uVtogHHF3N/84iH3SV++h3uEypVyvSzFzMUwUWAx4hhxpvw==}
     engines: {node: '>= 22'}
     hasBin: true
 
@@ -8559,19 +8559,19 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@superradcompany/microsandbox-darwin-arm64@0.6.8':
+  '@superradcompany/microsandbox-darwin-arm64@0.6.10':
     optional: true
 
-  '@superradcompany/microsandbox-linux-arm64-gnu@0.6.8':
+  '@superradcompany/microsandbox-linux-arm64-gnu@0.6.10':
     optional: true
 
-  '@superradcompany/microsandbox-linux-x64-gnu@0.6.8':
+  '@superradcompany/microsandbox-linux-x64-gnu@0.6.10':
     optional: true
 
-  '@superradcompany/microsandbox-win32-arm64-msvc@0.6.8':
+  '@superradcompany/microsandbox-win32-arm64-msvc@0.6.10':
     optional: true
 
-  '@superradcompany/microsandbox-win32-x64-msvc@0.6.8':
+  '@superradcompany/microsandbox-win32-x64-msvc@0.6.10':
     optional: true
 
   '@swc/helpers@0.5.23':
@@ -11390,13 +11390,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  microsandbox@0.6.8:
+  microsandbox@0.6.10:
     optionalDependencies:
-      '@superradcompany/microsandbox-darwin-arm64': 0.6.8
-      '@superradcompany/microsandbox-linux-arm64-gnu': 0.6.8
-      '@superradcompany/microsandbox-linux-x64-gnu': 0.6.8
-      '@superradcompany/microsandbox-win32-arm64-msvc': 0.6.8
-      '@superradcompany/microsandbox-win32-x64-msvc': 0.6.8
+      '@superradcompany/microsandbox-darwin-arm64': 0.6.10
+      '@superradcompany/microsandbox-linux-arm64-gnu': 0.6.10
+      '@superradcompany/microsandbox-linux-x64-gnu': 0.6.10
+      '@superradcompany/microsandbox-win32-arm64-msvc': 0.6.10
+      '@superradcompany/microsandbox-win32-x64-msvc': 0.6.10
     optional: true
 
   mime-db@1.52.0: {}


### PR DESCRIPTION
## Summary
- Add a **Report a bug** button next to Settings in the sidebar dock (and a matching Help menu item) that opens the public GitHub bug form.
- Add a light GitHub issue form (what happened, how to reproduce, version/OS) and turn off blank issues so New issue is not an empty composer.
- Point the in-app control at `issues/new?template=bug.yml`.

## Test plan
- [ ] After merge to `main`, open https://github.com/salesforce/zana/issues/new?template=bug.yml and confirm the three form fields render
- [ ] In the app, click the sidebar bug icon and Help → Report a bug; both open that URL
- [ ] `npx vitest run packages/domain/src/about-credits.test.ts apps/app/src/lib/__tests__/report-bug.test.ts apps/app/src/components/__tests__/SidebarRail.test.tsx apps/app/src/components/__tests__/Sidebar.test.tsx apps/app/src/components/__tests__/ProjectScopedNav.test.tsx`