### PR TITLE
test(e2e): quarantine home-composer worktree-provisioning specs (#112)

### DIFF
--- a/e2e/worktree-environment.spec.ts
+++ b/e2e/worktree-environment.spec.ts
@@ -278,7 +278,12 @@ test('launcher offers a workspace picker instead of an isolation checkbox', asyn
   }
 });
 
-test('New worktree lands under ~/.zcc/worktrees and typing reaches the host PTY', async ({ app }) => {
+// Quarantined: the home composer's "New worktree" choice is dropped before it
+// reaches managed-environment provisioning, so no managed worktree/thread is
+// created. Fixing it is a cross-stack change (route the legacy home composer
+// through the threads/environments stack). Tracked in
+// https://github.com/salesforce/zana/issues/112 — un-skip when that lands.
+test.skip('New worktree lands under ~/.zcc/worktrees and typing reaches the host PTY', async ({ app }) => {
   const { window, home } = app;
   const agent = makeFakeAgentBinary({ profile: 'claude', sequence: 'work-then-idle' });
   const { dir: projectDir, name: projectName } = initGitProject('zcc-wt-life-', home);
@@ -365,7 +370,11 @@ test('New worktree lands under ~/.zcc/worktrees and typing reaches the host PTY'
   }
 });
 
-test('worktreeinclude copies .env and a failing setup script rolls back', async ({ app }) => {
+// Quarantined: depends on managed-environment provisioning (.worktreeinclude
+// copy + .zcc-env-setup.sh rollback) that the home composer's "New worktree"
+// launch never reaches — the workspace choice is dropped. Tracked in
+// https://github.com/salesforce/zana/issues/112 — un-skip when that lands.
+test.skip('worktreeinclude copies .env and a failing setup script rolls back', async ({ app }) => {
   const { window, home } = app;
   const agent = makeFakeAgentBinary({ profile: 'claude', sequence: 'work-then-idle' });
   const { dir: includeDir, name: includeName } = initGitProject('zcc-wt-inc-', home);


### PR DESCRIPTION
Quarantines the two `e2e/worktree-environment.spec.ts` tests that assert managed-environment provisioning from the home composer's **"New worktree"** launch, so the local + CI test suites are honestly green while the underlying regression is tracked separately.

## Why

The home composer (`LegacyAgentHomeComposer`) passes a `SpawnEnvironmentChoice` as `workspace`, but `store.createTerminal` drops it and the desktop `terminals.create` stack has no managed-worktree provisioning anyway (it only knows the legacy `~/zcc-worktrees` mechanism and the `TerminalSession` model). The specs expect the **managed environments / threads** stack — a product `Thread`, `~/.zcc/worktrees/<envId>/<repo>`, `.worktreeinclude`/setup-rollback, env git-actions, prune-on-archive. Bridging that into the home composer is a cross-stack change (route it through `product.threads.create`, which today lacks `personaId`/`frameworkIds`/`extraArgs`/`harnessRouting`/`profile`/`isolateScratch`).

Full diagnosis + acceptance criteria: salesforce/zana#112.

## Scope

- `test.skip` the two provisioning-dependent specs with an inline reference to #112.
- The UI-only "launcher offers a workspace picker" spec is untouched and still runs.
- No source changes; `verify` (typecheck + vitest) is unaffected.

Closes nothing — #112 stays open until the real fix lands and the specs are un-skipped.