### PR TITLE
ci: publish dual-arch macOS releases from version tags

### DIFF
--- a/.cursor/rules/publish-release.mdc
+++ b/.cursor/rules/publish-release.mdc
@@ -10,7 +10,13 @@ Every app release must be published to **both** feeds. Do not treat one as optio
 - Public product / auto-update: https://github.com/salesforce/zana/releases
 - Mirror feed: https://github.com/grebmann1/zcc-releases/releases
 
-`electron-builder` (`npm run release:mac`, `publish.owner`/`repo` in `apps/desktop/electron-builder.yml`) only writes **salesforce/zana**. After that succeeds, create or update the matching release on **grebmann1/zcc-releases** with the same tag, body, and artifacts (`*.dmg`, `*.zip`, `*.blockmap`, `latest-mac.yml`).
+## Tag push is the publisher
+
+Cut a release by tagging `vx.y.z` and pushing it. `.github/workflows/release.yml` builds **Apple Silicon (arm64)** on `macos-15` and **Intel (x64)** on `macos-15-intel`, merges `latest-mac.yml`, and publishes both architectures to **salesforce/zana**. The same job then mirrors the tag, title, body, and artifacts (`*.dmg`, `*.zip`, `*.blockmap`, `latest-mac.yml`) to **grebmann1/zcc-releases**.
+
+Local `pnpm run release:mac` only packages the **host** architecture (`electron-builder --publish never`). It must not upload — a laptop arm64 publish would replace the dual-arch feed.
+
+Repo secret `ZCC_RELEASES_TOKEN` (a PAT with `contents: write` on `grebmann1/zcc-releases`) is required for the mirror. Signing/notarization still uses `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`.
 
 ## Release name is `x.y.z` only
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,28 @@
 name: Release
 
-# Build and publish a macOS release when a version tag is pushed.
+# Build and publish a dual-arch macOS release when a version tag is pushed.
 #
 #   git tag v0.2.0
 #   git push origin v0.2.0
 #
+# This workflow is the only publisher. Local `pnpm run release:mac` packages
+# the host arch with --publish never and must not upload to GitHub.
+#
 # node-pty is a native module, so each architecture is built on a runner of
-# that architecture (no reliable cross-compile): macos-13 = Intel/x64,
-# macos-14 = Apple Silicon/arm64. Both .dmg artifacts attach to one Release.
+# that architecture (no reliable cross-compile): macos-15-intel = Intel/x64,
+# macos-15 = Apple Silicon/arm64. Both .dmg/.zip artifacts attach to one
+# Release. Per-arch latest-mac.yml files are merged so electron-updater can
+# serve the right build per machine.
 #
 # The app is signed with an Apple Developer ID certificate and notarized so that
 # electron-updater can auto-update one build to the next — Squirrel.Mac refuses
 # to update an unsigned app. The signing cert is imported from the CSC_LINK +
 # CSC_KEY_PASSWORD repo secrets; notarization requires APPLE_ID,
-# APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID (see docs/auto-update-setup.md).
-# With Developer ID + notarization, fresh installs open without Gatekeeper prompts.
+# APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID. With Developer ID +
+# notarization, fresh installs open without Gatekeeper prompts.
+#
+# After salesforce/zana is published, the same tag/title/assets are mirrored to
+# grebmann1/zcc-releases via ZCC_RELEASES_TOKEN.
 
 on:
   push:
@@ -113,12 +121,12 @@ jobs:
       matrix:
         include:
           # node-pty can't cross-compile, so each arch is built on a runner of
-          # that arch: macos-14 = Apple Silicon/arm64, macos-13 = Intel/x64.
-          # Both artifacts attach to one Release; latest-mac.yml lists both so
-          # electron-updater serves the right build per machine.
-          - os: macos-14
+          # that arch: macos-15 = Apple Silicon/arm64, macos-15-intel = Intel/x64.
+          # Both artifacts attach to one Release; a merged latest-mac.yml lists
+          # both so electron-updater serves the right build per machine.
+          - os: macos-15
             arch: arm64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x64
     runs-on: ${{ matrix.os }}
     steps:
@@ -142,9 +150,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build and package
-        # electron-builder rebuilds node-pty for the bundled Electron's ABI
-        # automatically (npmRebuild defaults to true). Build only this runner's
-        # arch so the native binary matches.
+        # Same pre-electron-builder chain as local package:mac / release:mac
+        # (fetch:opencode, plugin hosts, join-cli). electron-builder rebuilds
+        # node-pty for the bundled Electron's ABI automatically (npmRebuild
+        # defaults to true). Build only this runner's arch so the native binary
+        # matches.
         #
         # Signing + notarization: when CSC_LINK is present electron-builder imports
         # the cert (Developer ID Application) and signs (required for
@@ -162,10 +172,17 @@ jobs:
         # For unsigned builds, pass --config.mac.notarize=false to override the
         # config's notarize: true (electron-builder 25.x CLI flag overrides config).
         run: |
+          pnpm run fetch:opencode
+          pnpm exec tsx scripts/build-plugin-hosts.mjs
+          pnpm exec node apps/host-daemon/scripts/build-join.mjs
           pnpm run build
+          case "$ZCC_MAC_ARCH" in
+            arm64|x64) ;;
+            *) echo "ERROR: unexpected ZCC_MAC_ARCH=$ZCC_MAC_ARCH" >&2; exit 1 ;;
+          esac
           if [ -n "$CSC_LINK_SECRET" ]; then
             # Fail-fast: signing enabled but missing notarization secrets
-            : "${APPLE_ID_SECRET:?ERROR: CSC_LINK is set but APPLE_ID secret is missing. Add all 5 secrets (see docs/auto-update-setup.md).}"
+            : "${APPLE_ID_SECRET:?ERROR: CSC_LINK is set but APPLE_ID secret is missing.}"
             : "${APPLE_APP_SPECIFIC_PASSWORD_SECRET:?ERROR: CSC_LINK is set but APPLE_APP_SPECIFIC_PASSWORD secret is missing.}"
             : "${APPLE_TEAM_ID_SECRET:?ERROR: CSC_LINK is set but APPLE_TEAM_ID secret is missing.}"
             echo "Signing + notarization enabled (all secrets present)."
@@ -174,14 +191,16 @@ jobs:
             export APPLE_ID="$APPLE_ID_SECRET"
             export APPLE_APP_SPECIFIC_PASSWORD="$APPLE_APP_SPECIFIC_PASSWORD_SECRET"
             export APPLE_TEAM_ID="$APPLE_TEAM_ID_SECRET"
-            pnpm exec electron-builder --mac --${{ matrix.arch }} --publish never
+            pnpm exec electron-builder --mac "--$ZCC_MAC_ARCH" --publish never
           else
             echo "No signing cert — building UNSIGNED (auto-update disabled, notarization disabled)."
             export CSC_IDENTITY_AUTO_DISCOVERY=false
             # Override config's notarize: true for unsigned builds (would fail without Apple secrets)
-            pnpm exec electron-builder --mac --${{ matrix.arch }} --publish never --config.mac.notarize=false
+            pnpm exec electron-builder --mac "--$ZCC_MAC_ARCH" --publish never --config.mac.notarize=false
           fi
+          mv dist/latest-mac.yml "dist/latest-mac-${ZCC_MAC_ARCH}.yml"
         env:
+          ZCC_MAC_ARCH: ${{ matrix.arch }}
           # The renderer bundle pulls in the heavy monaco-vscode packages, which
           # blow past Node's default ~2 GB heap during `electron-vite build`
           # (FATAL: JavaScript heap out of memory). Raise the limit; macos
@@ -191,8 +210,7 @@ jobs:
           ZCC_RELAY_TOKEN: ${{ secrets.ZCC_RELAY_TOKEN }}
           # Passed in under *_SECRET names; the script promotes them to the real
           # env vars only when non-empty (see above). To enable signed +
-          # notarized auto-updating builds, add these repo secrets per
-          # docs/auto-update-setup.md:
+          # notarized auto-updating builds, add these repo secrets:
           #   CSC_LINK                      = base64 of the Developer ID Application .p12 export
           #   CSC_KEY_PASSWORD              = the .p12 export password
           #   APPLE_ID                      = your Apple ID email (e.g., dev@example.com)
@@ -208,13 +226,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.arch }}
-          # dmg = first install; zip + latest-mac.yml = the auto-update feed
-          # electron-updater reads. blockmaps enable differential downloads.
+          # dmg = first install; zip + per-arch yml = inputs to the merged
+          # auto-update feed. blockmaps enable differential downloads.
           path: |
             dist/*.dmg
             dist/*.zip
             dist/*.blockmap
-            dist/latest-mac.yml
+            dist/latest-mac-${{ matrix.arch }}.yml
           if-no-files-found: error
 
   release:
@@ -224,11 +242,24 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
           path: artifacts
-          merge-multiple: true
+
+      - name: Merge update feed and stage assets
+        id: meta
+        run: |
+          mkdir -p merged
+          cp artifacts/release-arm64/*.dmg artifacts/release-arm64/*.zip artifacts/release-arm64/*.blockmap merged/
+          cp artifacts/release-x64/*.dmg artifacts/release-x64/*.zip artifacts/release-x64/*.blockmap merged/
+          node scripts/merge-latest-mac-yml.mjs \
+            artifacts/release-arm64/latest-mac-arm64.yml \
+            artifacts/release-x64/latest-mac-x64.yml \
+            merged/latest-mac.yml
+          echo "title=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -239,15 +270,16 @@ jobs:
           # dmg + zip + blockmap + latest-mac.yml must all be attached:
           # electron-updater reads latest-mac.yml to detect a new version and
           # downloads the zip (the dmg is for first-install only).
+          name: ${{ steps.meta.outputs.title }}
           files: |
-            artifacts/*.dmg
-            artifacts/*.zip
-            artifacts/*.blockmap
-            artifacts/latest-mac.yml
+            merged/*.dmg
+            merged/*.zip
+            merged/*.blockmap
+            merged/latest-mac.yml
           generate_release_notes: true
           fail_on_unmatched_files: true
           body: |
-            ### Zana Command Center ${{ github.ref_name }}
+            ### Zana Command Center ${{ steps.meta.outputs.title }}
 
             macOS builds (Apple Silicon + Intel), signed with Developer ID and
             notarized. First launch should open without Gatekeeper prompts.
@@ -260,10 +292,26 @@ jobs:
             > auto-update is disabled and you will need to bypass Gatekeeper manually:
             > **System Settings → Privacy & Security → Open Anyway**, or run
             > `xattr -dr com.apple.quarantine` on the app. Once signing + notarization
-            > secrets are configured (see `docs/auto-update-setup.md`), builds will be
-            > fully notarized and auto-update seamlessly.
+            > secrets are configured, builds will be fully notarized and auto-update
+            > seamlessly.
 
             | Mac | Download |
             | --- | --- |
             | Apple Silicon (M-series) | `*-arm64.dmg` |
             | Intel | `*-x64.dmg` |
+
+      - name: Mirror to grebmann1/zcc-releases
+        env:
+          GH_TOKEN: ${{ secrets.ZCC_RELEASES_TOKEN }}
+          RELEASE_TITLE: ${{ steps.meta.outputs.title }}
+        run: |
+          : "${GH_TOKEN:?ERROR: ZCC_RELEASES_TOKEN secret is missing. Add a PAT with contents:write on grebmann1/zcc-releases.}"
+          NOTES="$(gh release view "$GITHUB_REF_NAME" --json body --jq .body)"
+          if gh release view "$GITHUB_REF_NAME" --repo grebmann1/zcc-releases >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" --repo grebmann1/zcc-releases --clobber \
+              merged/*.dmg merged/*.zip merged/*.blockmap merged/latest-mac.yml
+            gh release edit "$GITHUB_REF_NAME" --repo grebmann1/zcc-releases --title "$RELEASE_TITLE" --notes "$NOTES"
+          else
+            gh release create "$GITHUB_REF_NAME" --repo grebmann1/zcc-releases --title "$RELEASE_TITLE" --notes "$NOTES" \
+              merged/*.dmg merged/*.zip merged/*.blockmap merged/latest-mac.yml
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,8 +392,10 @@ Core rules. Rationale: `docs/review-consensus-2026-06.md`.
   distributed extension, never in the app source tree.
 
 - **Release artifacts are published to the configured public GitHub release feed.**
-  The auto-updater reads that feed anonymously. When cutting a release, publish
-  the new build with `npm run release:mac` so the auto-updater can offer it.
+  The auto-updater reads that feed anonymously. When cutting a release, push a
+  `vx.y.z` tag so `.github/workflows/release.yml` builds Apple Silicon + Intel
+  and publishes both feeds. Local `pnpm run release:mac` packages the host arch
+  only (`--publish never`) and must not upload.
 
 - **The local-spawn argv/env assembly lives in `PtyManager.create()` and
   dispatches through the per-profile `LaunchProvider`; `@zana-ai/zcc-spawn-plan` is now the

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -138,7 +138,7 @@ mac:
     NSMicrophoneUsageDescription: "Zana Command Center uses the microphone to transcribe voice input for agent prompts."
   # Arch is selected per build via the CLI flag (e.g. `electron-builder --mac
   # --arm64`). node-pty is a native module, so each arch must be packaged on a
-  # runner of that arch — the release workflow uses a macos-13/macos-14 matrix.
+  # runner of that arch — the release workflow uses a macos-15 / macos-15-intel matrix.
   # Listing arch here would override the flag and force a cross-rebuild.
   #
   # dmg = first-install artifact; zip = the artifact Squirrel.Mac swaps in for

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "test": "pnpm --dir ../.. exec vitest run --config apps/desktop/vitest.config.ts",
     "package": "pnpm --dir ../.. run check:release-notes && pnpm --dir ../.. run build:cli && pnpm --dir ../.. run fetch:opencode && pnpm --dir ../.. exec tsx scripts/build-plugin-hosts.mjs && pnpm --dir ../.. exec node apps/host-daemon/scripts/build-join.mjs && pnpm run build && pnpm --dir ../.. exec electron-builder --config apps/desktop/electron-builder.yml",
     "package:mac": "pnpm run package -- --mac",
-    "release:mac": "pnpm --dir ../.. run check:release-notes && pnpm --dir ../.. run build:cli && pnpm --dir ../.. run fetch:opencode && pnpm --dir ../.. exec tsx scripts/build-plugin-hosts.mjs && pnpm --dir ../.. exec node apps/host-daemon/scripts/build-join.mjs && GH_TOKEN=$(GH_HOST=github.com gh auth token) pnpm run build && GH_TOKEN=$(GH_HOST=github.com gh auth token) pnpm --dir ../.. exec electron-builder --config apps/desktop/electron-builder.yml --mac --publish always"
+    "release:mac": "pnpm --dir ../.. run check:release-notes && pnpm --dir ../.. run build:cli && pnpm --dir ../.. run fetch:opencode && pnpm --dir ../.. exec tsx scripts/build-plugin-hosts.mjs && pnpm --dir ../.. exec node apps/host-daemon/scripts/build-join.mjs && pnpm run build && pnpm --dir ../.. exec electron-builder --config apps/desktop/electron-builder.yml --mac --publish never"
   },
   "dependencies": {
     "@zana-ai/zcc-contracts": "workspace:*",

--- a/apps/server/src/services/extensions/__tests__/core-extension-separation.guard.test.ts
+++ b/apps/server/src/services/extensions/__tests__/core-extension-separation.guard.test.ts
@@ -225,6 +225,21 @@ describe('Core-extension separation guard', () => {
     expect(scripts.build).toBe('electron-vite build');
   });
 
+  it('tag-push CI publishes dual-arch macOS; local release:mac does not upload', () => {
+    const desktopPkg = JSON.parse(
+      readFileSync(join(repoRoot, 'apps/desktop/package.json'), 'utf8'),
+    ) as { scripts: Record<string, string> };
+    expect(desktopPkg.scripts['release:mac']).toContain('--publish never');
+    expect(desktopPkg.scripts['release:mac']).not.toContain('--publish always');
+
+    const workflow = readFileSync(join(repoRoot, '.github/workflows/release.yml'), 'utf8');
+    expect(workflow).toContain('macos-15-intel');
+    expect(workflow).not.toMatch(/macos-13\b/);
+    expect(workflow).toContain('merge-latest-mac-yml.mjs');
+    expect(workflow).toContain('grebmann1/zcc-releases');
+    expect(workflow).toContain('ZCC_RELEASES_TOKEN');
+  });
+
   it('electron.vite.config.ts watches plugins/* (built-ins) but NOT extensions/* (runtime)', () => {
     // The vite config explicitly watches `plugins/**` (built-in modules that ARE
     // bundled) but does NOT watch `extensions/**` (runtime-loaded disk extensions).

--- a/docs/multiple-devices.md
+++ b/docs/multiple-devices.md
@@ -30,8 +30,9 @@ the public Heroku origin and relay token (inlined at `electron-vite build` from
 Precedence: runtime env, then the values baked into that build. Settings and
 the repo `public-app-url` file are not used. Do not commit the token; set the
 same `ZCC_RELAY_TOKEN` on Heroku and in the release/CI environment (GitHub
-secrets `ZCC_APP_URL` / `ZCC_RELAY_TOKEN`, or export them before
-`pnpm run release:mac`).
+secrets `ZCC_APP_URL` / `ZCC_RELAY_TOKEN`, or export them before a local
+`pnpm run release:mac` package). The public dual-arch build is produced by
+pushing a `vx.y.z` tag.
 
 The token authenticates a laptop to open a session. Isolation between laptops
 is the session URL (`/t/<sessionId>`), not a personal key. Join/enroll through

--- a/packages/provider-bridge-protocol/src/bridge-kit/bridge-harness.test.ts
+++ b/packages/provider-bridge-protocol/src/bridge-kit/bridge-harness.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createBridgeIo } from "./bridge-harness.js";
+
+describe("createBridgeIo", () => {
+  it("omits error.data when sendError is called with three arguments", () => {
+    const lines: string[] = [];
+    const { sendError } = createBridgeIo({ write: (line) => lines.push(line) });
+    sendError(1, -32000, "boom");
+    expect(JSON.parse(lines[0] ?? "")).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32000, message: "boom" },
+    });
+  });
+
+  it("attaches error.data when sendError is given a recovery payload", () => {
+    const lines: string[] = [];
+    const { sendError } = createBridgeIo({ write: (line) => lines.push(line) });
+    sendError(2, -32000, "archived", {
+      recovery: {
+        kind: "sessionArchived",
+        message: "unarchive and retry",
+        retryable: true,
+      },
+    });
+    expect(JSON.parse(lines[0] ?? "")).toEqual({
+      jsonrpc: "2.0",
+      id: 2,
+      error: {
+        code: -32000,
+        message: "archived",
+        data: {
+          recovery: {
+            kind: "sessionArchived",
+            message: "unarchive and retry",
+            retryable: true,
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/provider-bridge-protocol/src/bridge-kit/bridge-harness.ts
+++ b/packages/provider-bridge-protocol/src/bridge-kit/bridge-harness.ts
@@ -1,3 +1,5 @@
+import type { BridgeErrorData } from "../errors.js";
+
 export type BridgeJsonRpcId = string | number;
 
 type BridgeJsonRpcResponse =
@@ -9,23 +11,25 @@ type BridgeJsonRpcResponse =
   | {
       jsonrpc: "2.0";
       id: BridgeJsonRpcId;
-      error: { code: number; message: string; data?: unknown };
+      error: { code: number; message: string; data?: BridgeErrorData };
     };
 
 interface CreateBridgeIoArgs {
   write?: (line: string) => void;
 }
 
+export type BridgeSendError = (
+  id: BridgeJsonRpcId,
+  code: number,
+  message: string,
+  data?: BridgeErrorData,
+) => void;
+
 export function createBridgeIo<TMessage>({
   write = (line) => process.stdout.write(line),
 }: CreateBridgeIoArgs = {}): {
   send: (message: TMessage | BridgeJsonRpcResponse) => void;
-  sendError: (
-    id: BridgeJsonRpcId,
-    code: number,
-    message: string,
-    data?: unknown,
-  ) => void;
+  sendError: BridgeSendError;
   sendResult: (id: BridgeJsonRpcId, result: unknown) => void;
 } {
   const send = (message: TMessage | BridgeJsonRpcResponse): void => {
@@ -34,7 +38,11 @@ export function createBridgeIo<TMessage>({
   return {
     send,
     sendError: (id, code, message, data) => {
-      send({ jsonrpc: "2.0", id, error: { code, message, data } });
+      send({
+        jsonrpc: "2.0",
+        id,
+        error: data === undefined ? { code, message } : { code, message, data },
+      });
     },
     sendResult: (id, result) => {
       send({ jsonrpc: "2.0", id, result });
@@ -66,7 +74,7 @@ export function runBridgeRequest<
 >(args: {
   handleRequest: (request: TRequest) => Promise<void>;
   request: TRequest;
-  sendError: (id: BridgeJsonRpcId, code: number, message: string) => void;
+  sendError: BridgeSendError;
 }): void {
   void args.handleRequest(args.request).catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);

--- a/plugins/provider-codex/src/delta-translation.ts
+++ b/plugins/provider-codex/src/delta-translation.ts
@@ -350,6 +350,8 @@ function getProviderErrorCategory(
         return "sandbox";
       case "other":
         return "unknown";
+      default:
+        return assertNever(errorInfo);
     }
   }
   if ("httpConnectionFailed" in errorInfo) {

--- a/plugins/provider-codex/src/event-translation.ts
+++ b/plugins/provider-codex/src/event-translation.ts
@@ -115,10 +115,9 @@ function mergeCodexRateLimitSnapshot(
     credits: update.credits ?? previous?.credits ?? null,
     individualLimit:
       update.individualLimit ?? previous?.individualLimit ?? null,
+    spendControlReached: update.spendControlReached ?? null,
     planType: update.planType ?? previous?.planType ?? null,
     rateLimitReachedType: update.rateLimitReachedType ?? null,
-    spendControlReached:
-      update.spendControlReached ?? previous?.spendControlReached ?? null,
   };
   if (
     merged.rateLimitReachedType === null &&
@@ -275,11 +274,14 @@ function getProviderErrorCategory(
     switch (errorInfo) {
       case "contextWindowExceeded":
         return "context-window-exceeded";
+      case "sessionBudgetExceeded":
+        return "budget-exceeded";
       case "usageLimitExceeded":
         return "rate-limit";
       case "serverOverloaded":
         return "overloaded";
       case "cyberPolicy":
+      case "misalignmentPolicyViolation":
         return "policy";
       case "internalServerError":
         return "internal";
@@ -291,12 +293,10 @@ function getProviderErrorCategory(
         return "thread-rollback-failed";
       case "sandboxError":
         return "sandbox";
-      case "sessionBudgetExceeded":
-        return "budget-exceeded";
-      case "misalignmentPolicyViolation":
-        return "policy";
       case "other":
         return "unknown";
+      default:
+        return assertNever(errorInfo);
     }
   }
   if ("httpConnectionFailed" in errorInfo) {

--- a/plugins/provider-codex/src/interactive-requests.ts
+++ b/plugins/provider-codex/src/interactive-requests.ts
@@ -264,7 +264,6 @@ export function buildCodexInteractiveResponse(
       throw new ProviderResponseEncodeError(
         "Codex plan-review interactive requests are unsupported",
       );
-    // Generic tool-use approvals are raised by other bridges; Codex never does.
     case "tool_use":
       throw new ProviderResponseEncodeError(
         "Codex tool-use interactive requests are unsupported",

--- a/plugins/provider-codex/src/schemas.ts
+++ b/plugins/provider-codex/src/schemas.ts
@@ -479,8 +479,8 @@ const codexErrorHttpStatusSchema = z
 
 const codexErrorInfoSchema = z.union([
   z.literal("contextWindowExceeded"),
-  z.literal("usageLimitExceeded"),
   z.literal("sessionBudgetExceeded"),
+  z.literal("usageLimitExceeded"),
   z.literal("serverOverloaded"),
   z.literal("cyberPolicy"),
   z.literal("misalignmentPolicyViolation"),

--- a/plugins/provider-retry/app.tsx
+++ b/plugins/provider-retry/app.tsx
@@ -8,18 +8,23 @@ import {
 
 const REALTIME_CHANNEL = "provider-retry";
 
-function hostReact() {
-  return (globalThis as { __ZCC_HOST_REACT__?: typeof import("react") })
-    .__ZCC_HOST_REACT__;
+type HostReact = typeof import("react");
+
+function hostReact(): HostReact | undefined {
+  return (globalThis as { __ZCC_HOST_REACT__?: HostReact }).__ZCC_HOST_REACT__;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function payloadThreadId(payload: unknown): string | null {
-  if (typeof payload !== "object" || payload === null) return null;
-  const threadId = (payload as { threadId?: unknown }).threadId;
+  if (!isRecord(payload)) return null;
+  const threadId = payload.threadId;
   return typeof threadId === "string" ? threadId : null;
 }
 
-function retryLabel(retryAtMs: number) {
+function retryLabel(retryAtMs: number): string {
   return new Intl.DateTimeFormat(undefined, {
     weekday: "short",
     hour: "numeric",
@@ -36,9 +41,9 @@ function ProviderRetryBanner() {
   });
 }
 
-function hostReactCreate<P extends Record<string, unknown>>(
-  component: ComponentType<P>,
-  props: P & { key?: string },
+function hostReactCreate(
+  component: ComponentType<{ threadId: string }>,
+  props: { key: string; threadId: string },
 ) {
   const React = hostReact();
   if (!React) return null;
@@ -55,26 +60,15 @@ function ProviderRetryBannerForThread({ threadId }: { threadId: string }) {
 
   const load = useCallback(async () => {
     const result = await rpc.call("providerRetryStatus", { threadId });
-    const nextView =
-      result && typeof result === "object"
-        ? (result as { view?: unknown }).view
-        : null;
-    setView(
-      nextView && typeof nextView === "object"
-        ? (nextView as Record<string, unknown>)
-        : null,
-    );
+    const nextView = isRecord(result) ? result.view : null;
+    setView(isRecord(nextView) ? nextView : null);
   }, [rpc, threadId]);
 
   const cancel = useCallback(async () => {
     setCancelling(true);
     try {
       const result = await rpc.call("providerRetryCancel", { threadId });
-      if (
-        result &&
-        typeof result === "object" &&
-        (result as { cancelled?: unknown }).cancelled
-      ) {
+      if (isRecord(result) && result.cancelled) {
         setView(null);
       } else {
         await load();
@@ -96,7 +90,7 @@ function ProviderRetryBannerForThread({ threadId }: { threadId: string }) {
     }
   });
 
-  if (view === null || typeof view !== "object") return null;
+  if (view === null) return null;
   const retryAtMs = view.retryAtMs;
   const providerId = typeof view.providerId === "string" ? view.providerId : "Provider";
   const retry =

--- a/plugins/salesforce/app.tsx
+++ b/plugins/salesforce/app.tsx
@@ -1,9 +1,5 @@
 import type { ComponentType, ReactNode } from 'react';
-import {
-  definePluginApp,
-  useZccNavigate,
-  type PluginPendingInteractionProps,
-} from '@zana-ai/zcc-plugin-sdk/app';
+import { definePluginApp, useZccNavigate, type PluginPendingInteractionProps } from '@zana-ai/zcc-plugin-sdk/app';
 import { AgentScriptPanel } from './src/app/AgentScriptPanel.js';
 
 function hostReact() {
@@ -133,8 +129,12 @@ function SalesforceGuardrailForm(props: PluginPendingInteractionProps) {
     React.createElement(
       'div',
       { style: { display: 'flex', gap: 8 } },
-      React.createElement('button', { type: 'button', onClick: () => props.submit({ approved: true }) }, 'Allow this action'),
-      React.createElement('button', { type: 'button', onClick: () => props.cancel() }, 'Deny')
+      React.createElement(
+        'button',
+        { type: 'button', onClick: () => void props.submit({ approved: true }) },
+        'Allow this action'
+      ),
+      React.createElement('button', { type: 'button', onClick: () => void props.cancel() }, 'Deny')
     )
   );
 }

--- a/plugins/salesforce/lib/plugin.ts
+++ b/plugins/salesforce/lib/plugin.ts
@@ -71,7 +71,6 @@ import {
   type ResolvedOrg,
   type SafetyEnvelope,
   type SalesforceDeps,
-  type ToolFailure,
   type ToolResult
 } from './types.js';
 
@@ -396,7 +395,7 @@ async function confirmEnvelope(
   return approved ? { approved: true, reason: 'submitted' } : { approved: false, reason: 'denied' };
 }
 
-function fail(code: string, error: string): ToolFailure {
+function fail(code: string, error: string): ToolResult {
   return { ok: false, code, error };
 }
 
@@ -714,7 +713,7 @@ async function runAgent(
 async function requireDxRoot(
   snapshot: PluginSettingsValues,
   deps: SalesforceDeps
-): Promise<{ ok: true; projectRoot: string } | ToolFailure> {
+): Promise<{ ok: true; projectRoot: string } | ToolResult> {
   if (!snapshot.projectRoot || !isDxProject(snapshot.projectRoot, deps.exists)) {
     return fail('not_configured', 'Set DX project root to a folder that contains sfdx-project.json.');
   }
@@ -795,7 +794,7 @@ async function loadAgentBundles(
   deps: SalesforceDeps
 ): Promise<
   | { ok: true; projectRoot: string; bundles: ReturnType<typeof scanAgentBundles>; bundle: ReturnType<typeof findAgentBundle> }
-  | ToolFailure
+  | ToolResult
 > {
   const root = await requireDxRoot(snapshot, deps);
   if (!('projectRoot' in root)) return root;
@@ -845,7 +844,7 @@ async function runAgentPreview(
 ): Promise<ToolResult> {
   const verb = plan.action === 'preview.start' ? 'start' : plan.action === 'preview.send' ? 'send' : 'end';
   const resolved = await resolvePreviewIdentity(plan, snapshot, deps, verb === 'start');
-  if ('code' in resolved) return resolved;
+  if ('ok' in resolved) return resolved;
   const label = resolved.identity?.apiName ?? plan.sessionId ?? '';
   const { org, mediated } = await mediateOrgRead(
     ctx,
@@ -1021,7 +1020,7 @@ async function pollEvalRun(
       apiVersion: EVAL_API_VERSION
     });
     if (response.status >= 400) {
-      return fail('api_error', compactError(response.status, response.json, response.text));
+      return { ok: false, code: 'api_error', error: compactError(response.status, response.json, response.text) };
     }
     payload = response.json;
     if (isEvalTerminal(evalRunStatus(payload))) {
@@ -1029,7 +1028,7 @@ async function pollEvalRun(
     }
     if (attempt < EVAL_POLL_MAX_ATTEMPTS - 1) await sleep(EVAL_POLL_INTERVAL_MS);
   }
-  return fail('eval_timeout', `Eval run ${runId} did not complete.`);
+  return { ok: false, code: 'eval_timeout', error: `Eval run ${runId} did not complete.` };
 }
 
 async function runAgentList(
@@ -1151,7 +1150,7 @@ async function resolvePreviewIdentity(
   snapshot: PluginSettingsValues,
   deps: SalesforceDeps,
   requireIdentity: boolean
-): Promise<{ identity?: AgentPreviewIdentity; projectRoot?: string } | ToolFailure> {
+): Promise<{ identity?: AgentPreviewIdentity; projectRoot?: string } | ToolResult> {
   if (plan.published) {
     const apiName = plan.apiName;
     if (!apiName) return fail('invalid_input', 'published preview requires apiName.');

--- a/scripts/merge-latest-mac-yml.mjs
+++ b/scripts/merge-latest-mac-yml.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Merge two per-arch electron-builder `latest-mac.yml` feeds into one.
+ *
+ * The Release workflow builds arm64 and x64 on separate runners; each
+ * electron-builder invocation writes a feed that lists only that arch.
+ * electron-updater clients read a single `latest-mac.yml`, so publishing
+ * either file as-is points every Mac at one architecture.
+ *
+ * Usage: node scripts/merge-latest-mac-yml.mjs <a.yml> <b.yml> <out.yml>
+ *
+ * Fails if the versions differ, or if the merged `files:` list is missing
+ * either `*-arm64.zip` or `*-x64.zip`.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export class MergeLatestMacYmlError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'MergeLatestMacYmlError';
+  }
+}
+
+function die(msg) {
+  throw new MergeLatestMacYmlError(msg);
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * @typedef {{ url: string, sha512: string, size: number }} FeedFile
+ * @typedef {{ version: string, files: FeedFile[], path: string, sha512: string, releaseDate: string }} MacFeed
+ */
+
+/** @param {string} text @param {string} source */
+export function parseLatestMacYml(text, source = 'latest-mac.yml') {
+  const version = /^version:\s*(.+)$/m.exec(text)?.[1]?.trim();
+  if (!version) die(`${source}: missing version`);
+
+  const path = /^path:\s*(.+)$/m.exec(text)?.[1]?.trim();
+  if (!path) die(`${source}: missing path`);
+
+  const releaseDateRaw = /^releaseDate:\s*(.+)$/m.exec(text)?.[1];
+  if (!releaseDateRaw) die(`${source}: missing releaseDate`);
+  const releaseDate = unquote(releaseDateRaw);
+
+  const files = [];
+  const lines = text.split(/\r?\n/);
+  let current = null;
+  let inFiles = false;
+  for (const line of lines) {
+    if (/^files:\s*$/.test(line)) {
+      inFiles = true;
+      continue;
+    }
+    if (inFiles && /^[^\s]/.test(line)) {
+      inFiles = false;
+      if (current) files.push(current);
+      current = null;
+    }
+    if (!inFiles) continue;
+    const url = /^\s+- url:\s+(\S+)\s*$/.exec(line);
+    if (url) {
+      if (current) files.push(current);
+      current = { url: url[1], sha512: '', size: 0 };
+      continue;
+    }
+    if (!current) continue;
+    const sha = /^\s+sha512:\s+(\S+)\s*$/.exec(line);
+    if (sha) {
+      current.sha512 = sha[1];
+      continue;
+    }
+    const size = /^\s+size:\s+(\d+)\s*$/.exec(line);
+    if (size) current.size = Number(size[1]);
+  }
+  if (current) files.push(current);
+
+  if (files.length === 0) die(`${source}: no files: entries`);
+  for (const file of files) {
+    if (!file.sha512) die(`${source}: ${file.url} is missing sha512`);
+    if (!file.size) die(`${source}: ${file.url} is missing size`);
+  }
+
+  // Top-level sha512 is the last `sha512:` that is not nested under files.
+  // electron-builder emits it after the files block, same value as the zip.
+  let topSha = '';
+  inFiles = false;
+  for (const line of lines) {
+    if (/^files:\s*$/.test(line)) {
+      inFiles = true;
+      continue;
+    }
+    if (inFiles && /^[^\s]/.test(line)) inFiles = false;
+    if (inFiles) continue;
+    const sha = /^sha512:\s+(\S+)\s*$/.exec(line);
+    if (sha) topSha = sha[1];
+  }
+  if (!topSha) die(`${source}: missing top-level sha512`);
+
+  return { version, files, path, sha512: topSha, releaseDate };
+}
+
+/** @param {MacFeed} feed */
+export function serializeLatestMacYml(feed) {
+  const filesBlock = feed.files
+    .map(
+      (file) =>
+        `  - url: ${file.url}\n    sha512: ${file.sha512}\n    size: ${file.size}`,
+    )
+    .join('\n');
+  return [
+    `version: ${feed.version}`,
+    'files:',
+    filesBlock,
+    `path: ${feed.path}`,
+    `sha512: ${feed.sha512}`,
+    `releaseDate: '${feed.releaseDate}'`,
+    '',
+  ].join('\n');
+}
+
+function hasArchZip(files, arch) {
+  const suffix = `-${arch}.zip`;
+  return files.some((file) => file.url.endsWith(suffix));
+}
+
+/** @param {MacFeed} a @param {MacFeed} b */
+export function mergeLatestMacFeeds(a, b) {
+  if (a.version !== b.version) {
+    die(`version mismatch: ${a.version} vs ${b.version}`);
+  }
+
+  const seen = new Set();
+  const files = [];
+  for (const file of [...a.files, ...b.files]) {
+    if (seen.has(file.url)) continue;
+    seen.add(file.url);
+    files.push(file);
+  }
+  files.sort((left, right) => left.url.localeCompare(right.url));
+
+  if (!hasArchZip(files, 'arm64')) {
+    die('merged feed is missing *-arm64.zip — Intel-only publish is not allowed');
+  }
+  if (!hasArchZip(files, 'x64')) {
+    die('merged feed is missing *-x64.zip — arm64-only publish is not allowed');
+  }
+
+  const arm64Primary = hasArchZip(a.files, 'arm64') ? a : b;
+  const releaseDate = a.releaseDate >= b.releaseDate ? a.releaseDate : b.releaseDate;
+
+  return {
+    version: a.version,
+    files,
+    path: arm64Primary.path,
+    sha512: arm64Primary.sha512,
+    releaseDate,
+  };
+}
+
+export function mergeLatestMacYmlFiles(leftPath, rightPath, outPath) {
+  const left = parseLatestMacYml(readFileSync(leftPath, 'utf8'), leftPath);
+  const right = parseLatestMacYml(readFileSync(rightPath, 'utf8'), rightPath);
+  const merged = mergeLatestMacFeeds(left, right);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, serializeLatestMacYml(merged));
+  return merged;
+}
+
+const invokedDirectly =
+  Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  const [left, right, out] = process.argv.slice(2);
+  if (!left || !right || !out) {
+    console.error('Usage: node scripts/merge-latest-mac-yml.mjs <a.yml> <b.yml> <out.yml>');
+    process.exit(2);
+  }
+  try {
+    const merged = mergeLatestMacYmlFiles(resolve(left), resolve(right), resolve(out));
+    console.log(
+      `merge-latest-mac-yml: ${merged.version} (${merged.files.length} files) → ${out}`,
+    );
+  } catch (error) {
+    console.error(`merge-latest-mac-yml: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+}

--- a/scripts/merge-latest-mac-yml.test.ts
+++ b/scripts/merge-latest-mac-yml.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  MergeLatestMacYmlError,
+  mergeLatestMacFeeds,
+  mergeLatestMacYmlFiles,
+  parseLatestMacYml,
+  serializeLatestMacYml,
+} from './merge-latest-mac-yml.mjs';
+
+const ARM64 = `version: 2.0.3
+files:
+  - url: Zana-Command-Center-2.0.3-arm64.zip
+    sha512: armzip
+    size: 100
+  - url: Zana-Command-Center-2.0.3-arm64.dmg
+    sha512: armdmg
+    size: 110
+path: Zana-Command-Center-2.0.3-arm64.zip
+sha512: armzip
+releaseDate: '2026-08-31T16:02:34.538Z'
+`;
+
+const X64 = `version: 2.0.3
+files:
+  - url: Zana-Command-Center-2.0.3-x64.zip
+    sha512: x64zip
+    size: 200
+  - url: Zana-Command-Center-2.0.3-x64.dmg
+    sha512: x64dmg
+    size: 210
+path: Zana-Command-Center-2.0.3-x64.zip
+sha512: x64zip
+releaseDate: '2026-08-31T16:10:00.000Z'
+`;
+
+describe('merge-latest-mac-yml', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('unions files, keeps arm64 path/sha512, and uses the newer releaseDate', () => {
+    const arm = parseLatestMacYml(ARM64, 'arm');
+    const intel = parseLatestMacYml(X64, 'x64');
+    const merged = mergeLatestMacFeeds(arm, intel);
+    expect(merged.version).toBe('2.0.3');
+    expect(merged.path).toBe('Zana-Command-Center-2.0.3-arm64.zip');
+    expect(merged.sha512).toBe('armzip');
+    expect(merged.releaseDate).toBe('2026-08-31T16:10:00.000Z');
+    expect(merged.files.map((file) => file.url)).toEqual([
+      'Zana-Command-Center-2.0.3-arm64.dmg',
+      'Zana-Command-Center-2.0.3-arm64.zip',
+      'Zana-Command-Center-2.0.3-x64.dmg',
+      'Zana-Command-Center-2.0.3-x64.zip',
+    ]);
+  });
+
+  it('round-trips a merged feed through serialize + parse', () => {
+    const merged = mergeLatestMacFeeds(parseLatestMacYml(ARM64, 'arm'), parseLatestMacYml(X64, 'x64'));
+    const again = parseLatestMacYml(serializeLatestMacYml(merged), 'out');
+    expect(again).toEqual(merged);
+  });
+
+  it('writes the merged feed to disk', () => {
+    const root = mkdtempSync(join(tmpdir(), 'merge-mac-yml-'));
+    roots.push(root);
+    const left = join(root, 'arm.yml');
+    const right = join(root, 'x64.yml');
+    const out = join(root, 'out', 'latest-mac.yml');
+    writeFileSync(left, ARM64);
+    writeFileSync(right, X64);
+    mergeLatestMacYmlFiles(left, right, out);
+    const text = readFileSync(out, 'utf8');
+    expect(text).toContain('Zana-Command-Center-2.0.3-arm64.zip');
+    expect(text).toContain('Zana-Command-Center-2.0.3-x64.zip');
+  });
+
+  it('fails when versions differ', () => {
+    const intel = parseLatestMacYml(X64.replaceAll('2.0.3', '2.0.4'), 'x64');
+    expect(() => mergeLatestMacFeeds(parseLatestMacYml(ARM64, 'arm'), intel)).toThrow(
+      MergeLatestMacYmlError,
+    );
+    expect(() => mergeLatestMacFeeds(parseLatestMacYml(ARM64, 'arm'), intel)).toThrow(
+      /version mismatch/,
+    );
+  });
+
+  it('fails when the Intel zip is missing', () => {
+    expect(() =>
+      mergeLatestMacFeeds(parseLatestMacYml(ARM64, 'arm'), parseLatestMacYml(ARM64, 'arm-dup')),
+    ).toThrow(/missing \*-x64\.zip/);
+  });
+
+  it('fails when the Apple Silicon zip is missing', () => {
+    expect(() =>
+      mergeLatestMacFeeds(parseLatestMacYml(X64, 'x64'), parseLatestMacYml(X64, 'x64-dup')),
+    ).toThrow(/missing \*-arm64\.zip/);
+  });
+});

--- a/website/README.md
+++ b/website/README.md
@@ -42,8 +42,8 @@ door binds `0.0.0.0:$PORT`. Pairing paths (`/install.sh`, enroll, host ws) are
 relayed only while a laptop is connected to `/_zcc/relay`. Set `ZCC_RELAY_TOKEN`
 in the platform config (never in the image). Official desktop releases inline
 the same origin (`ZCC_APP_URL`) and token at `electron-vite build` time — set
-GitHub secrets `ZCC_APP_URL` and `ZCC_RELAY_TOKEN` (never commit them), or
-export them before local `pnpm run release:mac`.
+GitHub secrets `ZCC_APP_URL` and `ZCC_RELAY_TOKEN` (never commit them). Local
+`pnpm run release:mac` still reads those env vars but does not publish.
 
 `NEXT_PUBLIC_*` values are inlined at **build time**, so pass feed URLs as Docker
 build arguments rather than runtime environment variables. Set `PUBLIC_BASE_URL`

--- a/website/content/docs/multiple-devices.md
+++ b/website/content/docs/multiple-devices.md
@@ -30,8 +30,9 @@ the public Heroku origin and relay token (inlined at `electron-vite build` from
 Precedence: runtime env, then the values baked into that build. Settings and
 the repo `public-app-url` file are not used. Do not commit the token; set the
 same `ZCC_RELAY_TOKEN` on Heroku and in the release/CI environment (GitHub
-secrets `ZCC_APP_URL` / `ZCC_RELAY_TOKEN`, or export them before
-`pnpm run release:mac`).
+secrets `ZCC_APP_URL` / `ZCC_RELAY_TOKEN`, or export them before a local
+`pnpm run release:mac` package). The public dual-arch build is produced by
+pushing a `vx.y.z` tag.
 
 The token authenticates a laptop to open a session. Isolation between laptops
 is the session URL (`/t/<sessionId>`), not a personal key. Join/enroll through


### PR DESCRIPTION
## Summary
- Tag-push CI is now the only publisher: native Apple Silicon (`macos-15`) and Intel (`macos-15-intel`) builds, a merged `latest-mac.yml` that fails if either arch zip is missing, and an automatic mirror to `grebmann1/zcc-releases`.
- Local `pnpm run release:mac` packages the host arch with `--publish never`, so a laptop arm64 upload can no longer overwrite the dual-arch feed.
- Unblocks the Release verify gate with the plugin/typecheck fixes that previously stopped the matrix before Intel ever built.

## Test plan
- [x] `pnpm run typecheck` on this branch
- [x] Focused tests: merge script, release guards, bridge-harness, Codex delta/interactive-requests
- [x] Pre-push test suite
- [ ] After merge: add repo secret `ZCC_RELEASES_TOKEN` (PAT with `contents: write` on `grebmann1/zcc-releases`)
- [ ] `workflow_dispatch` on Release (dry run — artifacts only, no GitHub Release)
- [ ] Next `vX.Y.Z` tag is the first dual-arch publish (do not backfill Intel for 2.0.3)