### PR TITLE
fix(e2e): boot Electron smoke on Ubuntu 24.04 so v2.0.4 can publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,11 @@ jobs:
           sudo apt-get install -y xvfb
           npx playwright install-deps chromium
 
+      # ubuntu-24.04 blocks Chromium's sandbox via AppArmor; Electron never
+      # creates a window without this (microsoft/playwright#34251).
+      - name: Allow unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Build app
         run: pnpm run build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,13 @@ jobs:
           sudo apt-get install -y xvfb
           npx playwright install-deps chromium
 
+      # ubuntu-24.04 (ubuntu-latest) sets
+      # kernel.apparmor_restrict_unprivileged_userns=1, which blocks Chromium's
+      # sandbox even with --no-sandbox. Electron then never creates a window and
+      # Playwright's firstWindow times out (microsoft/playwright#34251).
+      - name: Allow unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Build app
         run: pnpm run build
         env:

--- a/apps/desktop/src/__tests__/e2e-linux-electron-launch.test.ts
+++ b/apps/desktop/src/__tests__/e2e-linux-electron-launch.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  linuxCiElectronArgs,
+  linuxCiElectronEnv,
+} from '../../../../e2e/fixtures/linux-electron-launch.js';
+
+const fixture = readFileSync(join(process.cwd(), 'e2e/fixtures/app.ts'), 'utf8');
+const workflow = readFileSync(join(process.cwd(), '.github/workflows/release.yml'), 'utf8');
+
+describe('linux CI Electron launch', () => {
+  it('emits sandbox + X11 ozone flags only on linux', () => {
+    expect(linuxCiElectronArgs('linux')).toEqual([
+      '--no-sandbox',
+      '--disable-gpu',
+      '--ozone-platform=x11',
+    ]);
+    expect(linuxCiElectronArgs('darwin')).toEqual([]);
+    expect(linuxCiElectronArgs('win32')).toEqual([]);
+  });
+
+  it('pins ozone + sandbox env only on linux', () => {
+    expect(linuxCiElectronEnv('linux')).toEqual({
+      ELECTRON_OZONE_PLATFORM_HINT: 'x11',
+      ELECTRON_DISABLE_SANDBOX: '1',
+    });
+    expect(linuxCiElectronEnv('darwin')).toEqual({});
+  });
+
+  it('launchApp uses the repo Electron binary and linux CI flags', () => {
+    expect(fixture).toContain('executablePath: projectElectronBinary()');
+    expect(fixture).toContain('linuxCiElectronArgs()');
+    expect(fixture).toContain('linuxCiElectronEnv()');
+    expect(fixture).toMatch(/createRequire\(import\.meta\.url\)\('electron'\)/);
+  });
+
+  it('release smoke relaxes Ubuntu 24.04 AppArmor userns before xvfb', () => {
+    expect(workflow).toContain('kernel.apparmor_restrict_unprivileged_userns=0');
+    const sysctlAt = workflow.indexOf('kernel.apparmor_restrict_unprivileged_userns=0');
+    const smokeAt = workflow.indexOf('xvfb-run -a pnpm run test:smoke:only');
+    expect(sysctlAt).toBeGreaterThan(0);
+    expect(smokeAt).toBeGreaterThan(sysctlAt);
+  });
+});

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -39,13 +39,20 @@ import {
 } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { startLocalRegistry, type LocalRegistry, type DummyExtensionSpec } from './registry.js';
 import { EventRecorder } from '../sdk/events.js';
+import { linuxCiElectronArgs, linuxCiElectronEnv } from './linux-electron-launch.js';
 
 const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
 const MAIN_ENTRY = join(REPO_ROOT, 'out/main/index.js');
 const PACKAGE_VERSION = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).version as string;
+
+/** This repo's Electron binary — ABI-matched to node-pty / better-sqlite3. */
+function projectElectronBinary(): string {
+  return createRequire(import.meta.url)('electron') as string;
+}
 
 export interface RegistryConfig {
   enabled: boolean;
@@ -207,6 +214,7 @@ export async function launchApp(home: string, opts: LaunchOptions = {}): Promise
     ZCC_E2E_APP_VERSION: PACKAGE_VERSION,
     ...(opts.e2e ? { ZCC_E2E: '1' } : {}),
     ...opts.env,
+    ...linuxCiElectronEnv(),
   };
   // A parent `electron-vite dev` / leftover diagnostic must not steal this
   // unpackaged E2E boot onto the live renderer or product server.
@@ -217,14 +225,28 @@ export async function launchApp(home: string, opts: LaunchOptions = {}): Promise
   if (opts.caCertPath) env.NODE_EXTRA_CA_CERTS = opts.caCertPath;
 
   const app = await electron.launch({
-    args: [`--user-data-dir=${userDataDir}`, MAIN_ENTRY],
+    // Without this, Playwright downloads its own Electron (log: "Downloading
+    // Electron binary...") which will not load this repo's native addons.
+    executablePath: projectElectronBinary(),
+    args: [...linuxCiElectronArgs(), `--user-data-dir=${userDataDir}`, MAIN_ENTRY],
     env,
     timeout: 60_000
   });
-  const window = await appWindow(app);
-  await window.waitForSelector('#root', { timeout: 30_000 });
-  await dismissConsentOverlays(window);
-  return { electron: app, window, home };
+  const stderrChunks: string[] = [];
+  app.process()?.stderr?.on('data', (chunk: Buffer | string) => {
+    stderrChunks.push(String(chunk));
+  });
+  try {
+    const window = await appWindow(app);
+    await window.waitForSelector('#root', { timeout: 30_000 });
+    await dismissConsentOverlays(window);
+    return { electron: app, window, home };
+  } catch (err) {
+    const stderr = stderrChunks.join('').trim();
+    if (!stderr) throw err;
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`${message}\n\nmain stderr:\n${stderr}`);
+  }
 }
 
 /**

--- a/e2e/fixtures/linux-electron-launch.ts
+++ b/e2e/fixtures/linux-electron-launch.ts
@@ -1,0 +1,26 @@
+/**
+ * Linux CI launch flags for unpackaged Electron under xvfb.
+ *
+ * Ubuntu 24.04 GitHub runners (ubuntu-latest) block Chromium's sandbox via
+ * AppArmor (`kernel.apparmor_restrict_unprivileged_userns=1`) and Electron 38+
+ * prefers Wayland/Ozone, which never creates a window under Xvfb. Playwright's
+ * `firstWindow` then times out even though `electron.launch` connected.
+ *
+ * Flags must be argv (Chromium reads ozone before any JS). Pair with the
+ * workflow `sysctl` that relaxes userns — `--no-sandbox` alone is not enough
+ * on noble. See microsoft/playwright#34251.
+ */
+export function linuxCiElectronArgs(platform: NodeJS.Platform = process.platform): string[] {
+  if (platform !== 'linux') return [];
+  return ['--no-sandbox', '--disable-gpu', '--ozone-platform=x11'];
+}
+
+export function linuxCiElectronEnv(
+  platform: NodeJS.Platform = process.platform
+): Record<string, string> {
+  if (platform !== 'linux') return {};
+  return {
+    ELECTRON_OZONE_PLATFORM_HINT: 'x11',
+    ELECTRON_DISABLE_SANDBOX: '1',
+  };
+}


### PR DESCRIPTION
## Summary
- Release `v2.0.4` smoke (`e2e/smoke.spec.ts`) never created a window on `ubuntu-latest` (24.04): AppArmor blocks Chromium userns, Electron 43 hangs under xvfb without X11 ozone, and Playwright was downloading its own Electron instead of this repo's ABI-matched binary.
- Pin `executablePath` to `require('electron')`, pass `--no-sandbox --disable-gpu --ozone-platform=x11` on Linux, and relax `kernel.apparmor_restrict_unprivileged_userns` in the release (and informational CI e2e) workflow before `xvfb-run`.

This is the gate that blocked dual-arch drafts after tagging `v2.0.4`. After merge, the unpublished tag will be moved to the new `main` SHA and pushed again. Drafts stay drafts; do not publish.

## Test plan
- [x] `pnpm exec vitest run apps/desktop/src/__tests__/e2e-linux-electron-launch.test.ts`
- [x] Pre-push typecheck + full unit suite
- [ ] Required `ci.yml` typecheck+test green on this PR
- [ ] After merge + retag: `release.yml` smoke passes, then arm64 + x64 builds, then draft `2.0.4` on salesforce/zana and grebmann1/zcc-releases (do not undraft)