### PR TITLE
fix(e2e): rebuild sqlite for Electron so release smoke can boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
           # on GitHub-hosted runners.
           NODE_OPTIONS: --max-old-space-size=6144
 
+      - name: Rebuild native modules for Electron
+        run: pnpm run rebuild:electron
+
       - name: E2E tests
         run: xvfb-run -a pnpm run test:e2e:only
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,13 @@ jobs:
           ZCC_APP_URL: ${{ secrets.ZCC_APP_URL }}
           ZCC_RELAY_TOKEN: ${{ secrets.ZCC_RELAY_TOKEN }}
 
+      # `pnpm run build` → prebuild → ensure-better-sqlite3 compiles SQLite for
+      # Node (vitest / listen.ts). Unpackaged Electron forks a utilityProcess
+      # that loads the same .node with Electron's ABI (148 vs Node 22's 127),
+      # so rebuild for Electron before the smoke launch.
+      - name: Rebuild native modules for Electron
+        run: pnpm run rebuild:electron
+
       - name: Smoke test (boot + IPC round-trip)
         run: xvfb-run -a pnpm run test:smoke:only
 

--- a/apps/desktop/src/__tests__/e2e-linux-electron-launch.test.ts
+++ b/apps/desktop/src/__tests__/e2e-linux-electron-launch.test.ts
@@ -42,4 +42,12 @@ describe('linux CI Electron launch', () => {
     expect(sysctlAt).toBeGreaterThan(0);
     expect(smokeAt).toBeGreaterThan(sysctlAt);
   });
+
+  it('release smoke rebuilds native addons for Electron after the Node-ABI build', () => {
+    expect(workflow).toContain('pnpm run rebuild:electron');
+    const rebuildAt = workflow.indexOf('pnpm run rebuild:electron');
+    const smokeAt = workflow.indexOf('xvfb-run -a pnpm run test:smoke:only');
+    expect(rebuildAt).toBeGreaterThan(0);
+    expect(smokeAt).toBeGreaterThan(rebuildAt);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:smoke:only": "playwright test e2e/smoke.spec.ts",
     "test:codex:live": "ZCC_LIVE_CODEX=1 vitest run apps/host-daemon/src/harness/__tests__/codex-provider.live.test.ts",
     "rebuild": "electron-rebuild -f -w node-pty && node scripts/ensure-better-sqlite3.mjs",
+    "rebuild:electron": "electron-rebuild -f -w node-pty -w better-sqlite3",
     "check:release-notes": "node scripts/check-release-notes.mjs",
     "dist": "pnpm --filter @zana-ai/zcc-desktop package",
     "dist:mac": "pnpm --filter @zana-ai/zcc-desktop package:mac",

--- a/scripts/ensure-better-sqlite3.test.ts
+++ b/scripts/ensure-better-sqlite3.test.ts
@@ -25,5 +25,7 @@ describe('ensure-better-sqlite3', () => {
     expect(pkg.scripts.prestart).toContain('ensure-better-sqlite3.mjs');
     expect(pkg.scripts.prepare).toContain('ensure-better-sqlite3.mjs');
     expect(pkg.scripts.rebuild).toBe('electron-rebuild -f -w node-pty && node scripts/ensure-better-sqlite3.mjs');
+    expect(pkg.scripts['rebuild:electron']).toBe('electron-rebuild -f -w node-pty -w better-sqlite3');
+    expect(pkg.scripts['rebuild:electron']).not.toContain('ensure-better-sqlite3');
   });
 });


### PR DESCRIPTION
## Summary
- Release smoke now launches Electron (AppArmor/ozone fixed in #118) but the runtime supervisor dies: `better-sqlite3` was compiled for Node 22 (ABI 127) by `prebuild` / `ensure-better-sqlite3`, while Electron 43's utilityProcess needs ABI 148. `createWindow` never runs, so `firstWindow` times out.
- Add `rebuild:electron` (`electron-rebuild -f -w node-pty -w better-sqlite3`) and run it after `pnpm run build` in the release smoke job (and the optional CI e2e job). It must not call `ensure-better-sqlite3`, which would flip sqlite back to Node.

After merge, move the unpublished `v2.0.4` tag to the new `main` SHA and re-run the dual-arch draft. Do not publish.

## Test plan
- [x] Focused vitest for the new script + workflow guard
- [ ] Required `ci.yml` typecheck+test green
- [ ] After merge + retag: smoke passes, then arm64 + x64 drafts titled `2.0.4` on both feeds (leave as drafts)