### PR TITLE
fix(plugin-build): resolve plugin SDK from source so Mac release packaging can run

### DIFF
--- a/packages/plugin-build/src/build-plugin-host.test.ts
+++ b/packages/plugin-build/src/build-plugin-host.test.ts
@@ -12,6 +12,11 @@ describe('plugin host build', () => {
     await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
+  it('resolves the plugin SDK from source so packaging does not need dist/', async () => {
+    const source = await readFile(new URL('./build-plugin-host.ts', import.meta.url), 'utf8');
+    expect(source).toMatch(/conditions:\s*\[\s*'source'\s*\]/);
+  });
+
   it('builds a self-contained Node artifact with identity and digest metadata', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'zcc-host-build-test-'));
     tempDirs.push(dir);

--- a/packages/plugin-build/src/build-plugin-host.ts
+++ b/packages/plugin-build/src/build-plugin-host.ts
@@ -286,6 +286,10 @@ export async function buildPluginHost(
       format: 'esm',
       platform: 'node',
       target: 'node22',
+      // CI / a clean tree has no packages/plugin-sdk/dist. The SDK exports
+      // `source` → src/*.ts; without this condition esbuild follows
+      // `import` → dist/*.js and `build-plugin-hosts` fails the release.
+      conditions: ['source'],
       sourcemap: true,
       banner: { js: NODE_ESM_REQUIRE_BANNER },
       logLevel: 'error',


### PR DESCRIPTION
## Summary
- Dual-arch `v2.0.4` packaging failed in `scripts/build-plugin-hosts.mjs`: esbuild could not resolve `@zana-ai/zcc-plugin-sdk/provider-bridge` because a clean CI tree has no `packages/plugin-sdk/dist`.
- Host bundling now uses the `source` export condition (same as the SDK's own `build-runtime.mjs`) so provider hosts bundle from TypeScript on a fresh checkout.

Smoke already passed on this tag. After merge, move the unpublished `v2.0.4` tag and re-run Release. Do not publish drafts.

## Test plan
- [x] `pnpm exec vitest run packages/plugin-build/src/build-plugin-host.test.ts packages/plugin-build/src/builtin-host-artifacts.test.ts`
- [ ] Required CI typecheck+test green
- [ ] After retag: arm64 + x64 `Build and package` succeed, drafts titled `2.0.4` on both feeds (leave as drafts)