### PR TITLE
fix: restore bundled relay-token bake and list PostHog in the marketplace

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -27,6 +27,10 @@ function bundledAppUrl(): string {
   return '';
 }
 
+function bundledRelayToken(): string {
+  return process.env.ZCC_RELAY_TOKEN?.trim() || pairingEnvFile().ZCC_RELAY_TOKEN?.trim() || '';
+}
+
 function bundledPosthogApiKey(): string {
   return process.env.ZCC_POSTHOG_API_KEY?.trim() || pairingEnvFile().ZCC_POSTHOG_API_KEY?.trim() || '';
 }

--- a/website/content/marketplace/marketplace.json
+++ b/website/content/marketplace/marketplace.json
@@ -488,6 +488,29 @@
       }
     },
     {
+      "id": "posthog-analytics",
+      "displayName": "PostHog Analytics",
+      "description": "Usage analytics, on by default when ZCC_POSTHOG_API_KEY is set (bring your own key or opt out): agent lifecycle events plus optional content-free UI-click ids. Never sends prompt or response content.",
+      "icon": {
+        "lucide": "LineChart"
+      },
+      "tags": [
+        "official"
+      ],
+      "author": {
+        "name": "Zana",
+        "github": "salesforce",
+        "url": "https://github.com/salesforce/zana"
+      },
+      "source": {
+        "git": {
+          "url": "https://github.com/salesforce/zana",
+          "subdir": "plugins/posthog-analytics",
+          "ref": "HEAD"
+        }
+      }
+    },
+    {
       "id": "pr-monitor",
       "displayName": "PR Monitor",
       "description": "Keep your authored pull requests visible: CI, review, merge-readiness, and inbox alerts.",


### PR DESCRIPTION
## Summary
- Restore `bundledRelayToken()` in `electron.vite.config.ts` so `release:mac` can bake `ZCC_RELAY_TOKEN` (the PostHog bake dropped the helper and broke the Vite config load).
- Regenerate the official marketplace catalog so `posthog-analytics` is listed.

## Test plan
- [x] `pnpm test` previously green on this tree
- [x] `pnpm run release:mac` succeeded after the Vite restore (signed/notarized 2.0.6 arm64)
- [ ] Confirm marketplace page / generate-marketplace output includes `posthog-analytics`