### PR TITLE
posthog-analytics: richer content-free lifecycle, click, and page-view signal

### DIFF
--- a/apps/host-daemon/src/harness/__tests__/providers.test.ts
+++ b/apps/host-daemon/src/harness/__tests__/providers.test.ts
@@ -1,12 +1,24 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // The ClaudeCodeProvider resolves bare family aliases against the developer's
-// real ~/.claude/settings.json (see model-resolve.ts). These assertions pin the
-// emitted argv (`--model opus` stays a family alias), so pin the resolver to
-// identity here — its substitution behaviour has its own suite (model-resolve.test.ts).
-vi.mock('../../model-resolve.js', () => ({
-  resolveModelAlias: (model: string) => model
-}));
+// real ~/.claude/settings.json (see packages/llm/src/model-resolve.ts). These
+// assertions pin the emitted argv (`--model opus`/`--model sonnet` stay bare
+// family aliases), so pin the resolver to identity here — its substitution
+// behaviour has its own suite (model-resolve.test.ts).
+//
+// NOTE: `resolveModelAlias` is imported by claude/provider.ts from the
+// `@zana-ai/zcc-llm` package specifier, not a local `../../model-resolve.js`
+// relative path (no such file exists under host-daemon) — mocking that dead
+// path was a no-op, so this suite was silently reading the CURRENT MACHINE's
+// real ~/.claude/settings.json `model` field and substituting it whenever it
+// matched a requested family (e.g. a settings.json pinned to
+// `global.anthropic.claude-sonnet-4-6` turns `--model sonnet` into
+// `--model global.anthropic.claude-sonnet-4-6`), making the test's outcome
+// depend on ambient dev/CI machine state instead of the fixtures below.
+vi.mock('@zana-ai/zcc-llm', async () => {
+  const actual = await vi.importActual<typeof import('@zana-ai/zcc-llm')>('@zana-ai/zcc-llm');
+  return { ...actual, resolveModelAlias: (model: string) => model };
+});
 
 import { providerFor, registrationFor } from '../registry.js';
 import { ClaudeCodeProvider } from '../claude/provider.js';

--- a/apps/server/src/services/threads/conversation-create.ts
+++ b/apps/server/src/services/threads/conversation-create.ts
@@ -52,7 +52,7 @@ import {
 import { resolveSpawnChoiceForHost } from './spawn-choice-for-host.js';
 import { toRemoteStartPathHost } from '../hosts/host-public.js';
 import { packConversationSessionTooling } from './conversation-session-tools.js';
-import { hostPromptInputFromInput, resolvePromptAttachmentPath } from '../projects/attachments.js';
+import { attachmentMarkersFromInput, hostPromptInputFromInput, resolvePromptAttachmentPath } from '../projects/attachments.js';
 import { withResolvedPluginMentionContext } from '../../plugins/plugin-mentions.js';
 import {
   withResolvedPathMentionContext,
@@ -197,7 +197,7 @@ async function startConversationOnHost(
     remoteToolProxy: boolean;
     dropCwd?: boolean;
   }
-): Promise<void> {
+): Promise<{ permissionMode: string }> {
   const providerId = canonicalThreadProviderId(args.input.providerId);
   if (!getThreadProvider(providerId)) {
     throw new ThreadCreateError(400, 'invalid-provider', `unknown thread provider: ${args.input.providerId}`);
@@ -295,6 +295,10 @@ async function startConversationOnHost(
         .catch(() => undefined);
     }
   });
+  // permissionMode is the closest server-computed signal for "plan vs an actual
+  // agent run" (PORTABLE_EXECUTION_STATES in AgentLauncher.tsx) available at this
+  // seam — surfaced to plugins as PluginThreadEvent.executionState.
+  return { permissionMode };
 }
 
 export async function createConversationFromRequest(
@@ -369,6 +373,12 @@ export async function createConversationFromRequest(
     (path) => resolvePromptAttachmentPath(ctx.dataDir, input.projectId, path)
   );
 
+  // Presence-only signal for plugins (never the marker text/paths themselves).
+  const hadAttachments = attachmentMarkersFromInput(
+    resolvedPromptInput,
+    (path) => resolvePromptAttachmentPath(ctx.dataDir, input.projectId, path)
+  ).length > 0;
+
   let choice: SpawnEnvironmentChoice = input.environment ?? { kind: 'unmanaged' };
   if (project.remote && choice.kind !== 'unmanaged') {
     throw new ThreadCreateError(403, 'remote-unsupported', 'remote projects can only use this checkout');
@@ -436,7 +446,11 @@ export async function createConversationFromRequest(
     emitPluginThreadEvent(ctx, {
       name: 'thread.created',
       threadId: thread.id,
-      projectId: thread.projectId
+      projectId: thread.projectId,
+      providerId: thread.providerId,
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.reasoningLevel ? { reasoningLevel: input.reasoningLevel } : {}),
+      hadAttachments
     });
     try {
       if (needsHostAttach) {
@@ -457,7 +471,7 @@ export async function createConversationFromRequest(
           mergeBaseBranch: provisioned.defaultBranch
         });
       }
-      await startConversationOnHost(ctx, {
+      const launch = await startConversationOnHost(ctx, {
         hostId, project, thread, prompt: textPrompt, hostPrompt: prompt, environmentId: existing.id, input: { ...input, promptInput: resolvedPromptInput }, remoteToolProxy, dropCwd
       });
       const running = applyLoggedConversationLifecycleEvent(ctx, {
@@ -471,7 +485,11 @@ export async function createConversationFromRequest(
       emitPluginThreadEvent(ctx, {
         name: 'thread.active',
         threadId: running.id,
-        projectId: running.projectId
+        projectId: running.projectId,
+        providerId: running.providerId,
+        ...(input.model ? { model: input.model } : {}),
+        ...(input.reasoningLevel ? { reasoningLevel: input.reasoningLevel } : {}),
+        executionState: launch.permissionMode
       });
       return running;
     } catch (error) {
@@ -524,7 +542,11 @@ export async function createConversationFromRequest(
       emitPluginThreadEvent(ctx, {
         name: 'thread.created',
         threadId: thread.id,
-        projectId: thread.projectId
+        projectId: thread.projectId,
+        providerId: thread.providerId,
+        ...(input.model ? { model: input.model } : {}),
+        ...(input.reasoningLevel ? { reasoningLevel: input.reasoningLevel } : {}),
+        hadAttachments
       });
       return { environment, thread };
     });
@@ -548,7 +570,11 @@ export async function createConversationFromRequest(
     emitPluginThreadEvent(ctx, {
       name: 'thread.created',
       threadId: thread.id,
-      projectId: thread.projectId
+      projectId: thread.projectId,
+      providerId: thread.providerId,
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.reasoningLevel ? { reasoningLevel: input.reasoningLevel } : {}),
+      hadAttachments
     });
     created = { environment: existing, thread };
   }
@@ -570,7 +596,7 @@ export async function createConversationFromRequest(
       defaultBranch: provisioned.defaultBranch,
       mergeBaseBranch: provisioned.defaultBranch
     });
-    await startConversationOnHost(ctx, {
+    const launch = await startConversationOnHost(ctx, {
       hostId,
       project,
       thread: created.thread,
@@ -592,7 +618,11 @@ export async function createConversationFromRequest(
     emitPluginThreadEvent(ctx, {
       name: 'thread.active',
       threadId: running.id,
-      projectId: running.projectId
+      projectId: running.projectId,
+      providerId: running.providerId,
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.reasoningLevel ? { reasoningLevel: input.reasoningLevel } : {}),
+      executionState: launch.permissionMode
     });
     return running;
   } catch (error) {
@@ -616,7 +646,8 @@ function failConversationStart(ctx: ProductHttpContext, thread: ConversationThre
   emitPluginThreadEvent(ctx, {
     name: 'thread.failed',
     threadId: failed.id,
-    projectId: failed.projectId
+    projectId: failed.projectId,
+    providerId: failed.providerId
   });
 }
 

--- a/apps/server/src/services/threads/conversation-lifecycle.test.ts
+++ b/apps/server/src/services/threads/conversation-lifecycle.test.ts
@@ -1042,6 +1042,51 @@ describe('conversation lifecycle', () => {
     }));
   });
 
+  it('carries providerId/model/reasoningLevel/hadAttachments on the thread.active plugin event for a follow-up turn', async () => {
+    const callHostOnlineRpc = vi.fn(async () => ({ threadId: thread.id, accepted: true }));
+    const context = ctx(callHostOnlineRpc);
+    await sendConversationTurn(
+      context,
+      thread.id,
+      [{ type: 'text', text: 'follow up' }, { type: 'localImage', path: 'shot.png' }],
+      'auto',
+      { model: 'claude-sonnet-5', reasoningLevel: 'high' }
+    );
+    expect(context.plugins?.emitThreadEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'thread.active',
+        threadId: thread.id,
+        projectId: thread.projectId,
+        providerId: thread.providerId,
+        model: 'claude-sonnet-5',
+        reasoningLevel: 'high',
+        hadAttachments: true
+      })
+    );
+  });
+
+  it('reports hadAttachments: false on a plain text follow-up turn (never the marker text itself)', async () => {
+    const callHostOnlineRpc = vi.fn(async () => ({ threadId: thread.id, accepted: true }));
+    const context = ctx(callHostOnlineRpc);
+    await sendConversationTurn(context, thread.id, [{ type: 'text', text: 'follow up' }]);
+    expect(context.plugins?.emitThreadEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'thread.active', hadAttachments: false })
+    );
+  });
+
+  it('carries providerId on the thread.created plugin event for a fork', async () => {
+    const product = ctx(async () => ({}));
+    const forked = await forkConversation(product, thread.id);
+    expect(product.plugins?.emitThreadEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'thread.created',
+        threadId: forked.id,
+        projectId: forked.projectId,
+        providerId: forked.providerId
+      })
+    );
+  });
+
   it('409s cancelPlan when plan mode is not active', async () => {
     const callHostOnlineRpc = vi.fn(async () => ({ cancelled: true }));
     await expect(cancelConversationPlan(ctx(callHostOnlineRpc), thread.id))

--- a/apps/server/src/services/threads/conversation-lifecycle.ts
+++ b/apps/server/src/services/threads/conversation-lifecycle.ts
@@ -37,7 +37,7 @@ import {
   claudeCodePermissionModeForTurn
 } from './conversation-execution-mode.js';
 import { derivedProviderOptionsForCommand } from './derived-provider-options.js';
-import { hostPromptInputFromInput, resolvePromptAttachmentPath } from '../projects/attachments.js';
+import { attachmentMarkersFromInput, hostPromptInputFromInput, resolvePromptAttachmentPath } from '../projects/attachments.js';
 import { resolveActivePlanTurn } from './conversation-timeline.js';
 import { emitPluginThreadEvent } from '../../plugins/thread-events.js';
 import { appendClientTurnRequested } from './client-turn-requested.js';
@@ -222,10 +222,19 @@ export async function sendConversationTurn(
   const next = getConversationThread(ctx.db, live.id) ?? live;
   ctx.hub.emit('threads:updated', conversationThreadView(ctx, next));
   if (textPrompt[0] && next.originKind !== 'fork') ctx.threadTitleNamer?.request(next.id, textPrompt[0]);
+  // Presence-only signal for plugins (never the marker text/paths themselves).
+  const hadAttachments = attachmentMarkersFromInput(
+    resolvedInput,
+    (path) => resolvePromptAttachmentPath(ctx.dataDir, live.projectId, path)
+  ).length > 0;
   emitPluginThreadEvent(ctx, {
     name: 'thread.active',
     threadId: next.id,
-    projectId: next.projectId
+    projectId: next.projectId,
+    providerId: next.providerId,
+    ...(packedExecution?.model ? { model: packedExecution.model } : {}),
+    ...(packedExecution?.reasoningLevel ? { reasoningLevel: packedExecution.reasoningLevel } : {}),
+    hadAttachments
   });
   return next;
 }
@@ -407,7 +416,8 @@ export async function stopConversation(
   emitPluginThreadEvent(ctx, {
     name: 'thread.idle',
     threadId: next.id,
-    projectId: next.projectId
+    projectId: next.projectId,
+    providerId: next.providerId
   });
   void import('./conversation-child-notifications.js')
     .then(({ notifyParentOfChildTurn }) => notifyParentOfChildTurn(ctx, next))
@@ -504,12 +514,14 @@ export async function archiveConversation(
   emitPluginThreadEvent(ctx, {
     name: 'thread.archived',
     threadId: archived.id,
-    projectId: archived.projectId
+    projectId: archived.projectId,
+    providerId: archived.providerId
   });
   emitPluginThreadEvent(ctx, {
     name: 'thread.deleted',
     threadId: archived.id,
-    projectId: archived.projectId
+    projectId: archived.projectId,
+    providerId: archived.providerId
   });
   await archiveConversationOnHost(ctx, archived);
   if (!options.skipEnvironmentCleanup && thread.environmentId) {
@@ -593,7 +605,8 @@ export async function forkConversation(
   emitPluginThreadEvent(ctx, {
     name: 'thread.created',
     threadId: forked.id,
-    projectId: forked.projectId
+    projectId: forked.projectId,
+    providerId: forked.providerId
   });
   // Forks already have an explicit "… (fork)" title; pin the id so a later
   // follow-up cannot overwrite it via the retry path on sendConversationTurn.
@@ -651,7 +664,8 @@ export async function reconcileStoppingConversationThreadsOnHostConnect(
       emitPluginThreadEvent(ctx, {
         name: 'thread.idle',
         threadId: next.id,
-        projectId: next.projectId
+        projectId: next.projectId,
+        providerId: next.providerId
       });
       void import('./conversation-child-notifications.js')
         .then(({ notifyParentOfChildTurn }) => notifyParentOfChildTurn(ctx, next))

--- a/packages/plugin-sdk/src/server.ts
+++ b/packages/plugin-sdk/src/server.ts
@@ -184,6 +184,16 @@ export interface PluginThreadEvent {
   thread?: PluginSdkThreadSummary;
   lastAssistantText?: string | null;
   error?: string | null;
+  /** The thread's harness/provider id (e.g. claude-code/codex/shell), when known. */
+  providerId?: string;
+  /** The model used for this turn/thread, when known. */
+  model?: string;
+  /** The reasoning-effort level for this turn/thread (e.g. medium/high), when known. */
+  reasoningLevel?: string;
+  /** Coarse execution mode — plan vs an actual agent run (see PORTABLE_EXECUTION_STATES). */
+  executionState?: string;
+  /** Whether the triggering turn/create input included an attachment. Presence only, never content. */
+  hadAttachments?: boolean;
 }
 
 export interface PluginEvents {

--- a/packages/streamdeck/src/__tests__/app.test.ts
+++ b/packages/streamdeck/src/__tests__/app.test.ts
@@ -118,12 +118,20 @@ describe('deck app — ZCC hub', () => {
 
     await vi.waitFor(() => expect(recorded.some((r) => r.op === 'agent.list')).toBe(true));
 
-    // Agent sits in slot 0 → key index 0. Press it to open the overlay.
-    deck.press(coordToIndex(0, 0));
-    // Overlay's Approve key is at (0,1) → reply "y\n" to this session.
-    deck.press(coordToIndex(0, 1));
-
+    // `agent.list` being recorded only proves the control plane received the
+    // request — the out-of-band `pollNow()` promise it's part of still has to
+    // resolve and rebuild the grid before the agent tile is actually pressable
+    // (until then slot 0 is still the pre-poll idle filler with no onPress). So
+    // retry the press pair until it lands rather than firing it exactly once —
+    // this is what actually flaked under full-suite load, not the assertions.
     await vi.waitFor(() => {
+      if (!recorded.some((r) => r.op === 'term.reply')) {
+        // Agent sits in slot 0 → key index 0. Press it to open the overlay.
+        deck.press(coordToIndex(0, 0));
+        // Overlay's Approve key is at (0,1) → reply "y\n" to this session.
+        deck.press(coordToIndex(0, 1));
+      }
+
       const reply = recorded.find((r) => r.op === 'term.reply');
       expect(reply).toBeDefined();
       expect(reply!.args).toEqual({ sessionId: 's-1', text: 'y\n' });

--- a/packages/ui/src/popover-picklist.tsx
+++ b/packages/ui/src/popover-picklist.tsx
@@ -363,7 +363,11 @@ export function PopoverPicklist<T extends string>({
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         aria-label={ariaLabel}
-        data-testid={triggerTestId}
+        // Mirror the developer-authored `id` onto data-testid (when the caller
+        // hasn't supplied a more specific `triggerTestId`) so the content-free
+        // UI-click tracker can distinguish this trigger from others — both are
+        // always stable literals passed by the caller, never user data.
+        data-testid={triggerTestId ?? id}
       >
         {triggerIcon}
         <span>{selected?.compactLabel ?? selected?.label ?? placeholder}</span>

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,7 +11,7 @@ and loads any installed plugin.
 | `docs/` | Builtin (`autoInstall: true`) — Docs rail, per-project Library, and the library-curator skill. The panel UI is compiled into the renderer (`apps/app/src/views/library`); this package ships the skill + server. Packaged builds copy `plugins/` via electron-builder extraResources. |
 | `plugin-guide/` | Builtin (`autoInstall: true`) — Plugin Guide under Plugins: annotated wireframe map of every SDK surface, Copy for agent, and links into installed plugin hub pages. |
 | `salesforce/` | Official (`autoInstall: false`) — Salesforce DX inner loop **and** the platform SDK (`@zcc-ext/salesforce/sdk`) other plugins consume via `zcc.services.use('salesforce')`. Org doctor, SOQL/Apex/LWC/Agentforce family tools, and fail-closed mutation confirms. |
-| `posthog-analytics/` | Official (`autoInstall: false`) — usage analytics: agent lifecycle events plus optional content-free UI-click ids. **On by default** when `ZCC_POSTHOG_API_KEY` is set; never sends prompt/response content, labels, or input values. |
+| `posthog-analytics/` | Official (`autoInstall: false`) — usage analytics: richer agent lifecycle events (model/provider/reasoning level/execution state/attachment presence) plus optional content-free UI-click ids and page-view/dwell-time tracking. **On by default** when `ZCC_POSTHOG_API_KEY` is set; never sends prompt/response content, labels, or input values. |
 
 Do not add a runtime plugin to `MAIN_MODULES`. Author it with a `package.json`
 `zcc` block under `plugins/<id>` and install it through the plugin workflow.

--- a/plugins/posthog-analytics/README.md
+++ b/plugins/posthog-analytics/README.md
@@ -30,13 +30,30 @@ Each event's payload is exactly:
 {
   "event": "zcc_thread_created",
   "distinct_id": "<random UUID, generated once per install, stored locally>",
-  "properties": { "projectId": "<project id or null>" }
+  "properties": {
+    "projectId": "<project id or null>",
+    "providerId": "<harness id, e.g. claude-code/codex/shell, or null>",
+    "model": "<model name, or null>",
+    "reasoningLevel": "<reasoning-effort level, e.g. medium/high, or null>",
+    "executionState": "<permission mode this run started with, e.g. accept-edits/auto/full, or null>",
+    "hadAttachments": "<true/false/null — presence only, never file names or paths>"
+  }
 }
 ```
 
 `distinct_id` is a random UUID generated on first use and stored in this
 plugin's local KV storage — it identifies an *installation*, not a person,
 and is never derived from any account/email.
+
+`providerId`/`model`/`reasoningLevel`/`executionState`/`hadAttachments` are
+best-effort — a field the plugin didn't have in hand at that particular event
+(e.g. `model` before the first turn has been sent) is sent as `null` rather
+than omitted, so every `zcc_thread_*` event has the same property shape.
+`executionState` reflects the server-computed permission mode a run started
+with (a proxy for "plan vs. an actual autonomous run") — it is **not** the
+raw client-side launcher label. There is currently no reliable server-side
+signal that distinguishes a voice-recorded turn from a typed one, so a
+"used voice" field was deliberately left out rather than guessed.
 
 ### Optional: coarse UI-click events
 
@@ -59,6 +76,45 @@ re-validates them (dropping anything else, non-strings, or over-long values)
 before sending. A click with no `data-testid` and no actionable role sends
 nothing. This toggle is independent and also off by default.
 
+### Optional: page navigation & dwell-time events
+
+If you additionally turn on **Also track page navigation & time spent**, the
+plugin emits a `zcc_page_view` event on each section change, carrying only:
+
+```json
+{
+  "event": "zcc_page_view",
+  "distinct_id": "…",
+  "properties": { "from": "inbox", "to": "agents", "durationMs": 4213 }
+}
+```
+
+- `from`/`to` are the coarse top-level section name (`home` / `inbox` /
+  `agents` / `followups` / `suggestions` / `scheduler` / `goals` / `settings`
+  / `extensions` / `projects`), re-derived in the renderer content script
+  directly from `location.pathname` (mirroring the same fixed literals
+  `apps/app/src/lib/decode-route.ts`'s `DecodedRoute.nav` uses) — **never** a
+  project id, thread id, or other dynamic path segment. Any nav value outside
+  that fixed set — including a plugin's own panel nav id — is bucketed as the
+  literal string `"plugin"` rather than forwarded verbatim.
+- `durationMs` is how long the previous section was open, in milliseconds.
+- The server re-validates both fields before sending: `from`/`to` must be in
+  the fixed enum above (an unrecognized `to` is rejected outright, never
+  forwarded), and `durationMs` must be a finite, non-negative number under a
+  24-hour sanity cap.
+
+This toggle is independent of, and off by default like, **Also track UI
+clicks** — either can be on without the other.
+
+### What we looked at but didn't ship: voice/audio presence
+
+The product ask also included "whether the user attached an image or used
+voice/audio recording." Image-attachment presence is covered by
+`hadAttachments` above. There is currently no reliable **server-side** signal
+that distinguishes a voice-recorded turn from a typed one — the renderer's
+voice-recording UI state doesn't reach the server in a form distinct from a
+plain text turn — so rather than guess at a fake signal, this was left out.
+
 ## Enabling it / opting out / pointing at your own project
 
 1. Install the plugin (`zcc plugin install ./plugins/posthog-analytics` from
@@ -78,6 +134,9 @@ nothing. This toggle is independent and also off by default.
 6. Optionally turn on **Also track UI clicks (button ids only)** for
    content-free click events (see above) — this toggle is independent and
    off by default even when the master switch is on.
+7. Optionally turn on **Also track page navigation & time spent** for
+   content-free page-view/dwell events (see above) — also independent and
+   off by default.
 
 Nothing is sent unless the master toggle is on AND an API key is set. The
 key is empty until `ZCC_POSTHOG_API_KEY` (or the Settings field) provides one.

--- a/plugins/posthog-analytics/app.js
+++ b/plugins/posthog-analytics/app.js
@@ -16,6 +16,43 @@
 const ACTIONABLE = new Set(['button', 'a', 'summary']);
 const ACTIONABLE_ROLES = new Set(['button', 'link', 'tab', 'menuitem', 'switch', 'checkbox', 'option']);
 
+/**
+ * The fixed, content-free set of top-level nav names `decode-route.ts`'s
+ * `DecodedRoute.nav` can take from a static path segment (never a dynamic
+ * one, like a project/thread/plugin id). Mirrors decodeRoutePath's literals —
+ * update alongside that file if a new top-level destination is added.
+ */
+const KNOWN_NAV_NAMES = new Set([
+  'home',
+  'inbox',
+  'agents',
+  'followups',
+  'suggestions',
+  'scheduler',
+  'goals',
+  'settings',
+  'extensions',
+  'projects'
+]);
+
+/**
+ * Best-effort, minimal re-derivation of `DecodedRoute.nav` from the URL,
+ * without importing app internals into this content script. Only the coarse
+ * nav segment is derived — never project/thread ids or other path params.
+ * Anything not in {@link KNOWN_NAV_NAMES} (including a plugin panel's own
+ * nav id) is bucketed as `"plugin"` rather than forwarded verbatim, so an
+ * arbitrary plugin id is never sent to PostHog as if it were a fixed nav name.
+ */
+function currentNav() {
+  const path = globalThis.location?.pathname || '/';
+  const segments = path.split('/').filter((segment) => segment.length > 0);
+  if (segments.length === 0) return 'home';
+  const first = segments[0];
+  if (KNOWN_NAV_NAMES.has(first)) return first;
+  if (first === 'threads' || first === 'new') return 'agents';
+  return 'plugin';
+}
+
 /** Walk up from the clicked node to the nearest actionable element / testid. */
 export function resolveTarget(start) {
   let el = start;
@@ -68,6 +105,67 @@ export default {
 
         doc.addEventListener('click', onClick, { capture: true });
         const dispose = () => doc.removeEventListener('click', onClick, { capture: true });
+        ctx.signal?.addEventListener?.('abort', dispose);
+        return dispose;
+      }
+    });
+
+    /**
+     * Optional page/section navigation + dwell-time tracking (its own
+     * settings toggle, off by default — see server.mjs). Monkey-patches
+     * `history.pushState`/`replaceState` and listens for `popstate` so a
+     * React Router transition is observed the same way regardless of how it
+     * navigated. Reports only the coarse {@link currentNav} nav name for
+     * `from`/`to` and a duration in ms — never a path, project id, or thread
+     * id fragment.
+     */
+    app.contentScripts.register({
+      id: 'page-view-tracker',
+      mount(ctx) {
+        const host = globalThis.__ZCC_PLUGIN_HOST__;
+        const win = globalThis;
+        if (!host || !win?.history) return;
+
+        let previousNav = currentNav();
+        let enteredAt = Date.now();
+
+        const reportTransition = () => {
+          const nextNav = currentNav();
+          if (nextNav === previousNav) return; // same section, no transition
+          const now = Date.now();
+          const payload = {
+            from: previousNav,
+            to: nextNav,
+            durationMs: now - enteredAt
+          };
+          previousNav = nextNav;
+          enteredAt = now;
+          try {
+            host.callRpc(ctx.pluginId, 'trackPageView', payload)?.catch?.(() => {});
+          } catch {
+            /* never let analytics break navigation */
+          }
+        };
+
+        const originalPushState = win.history.pushState;
+        const originalReplaceState = win.history.replaceState;
+        win.history.pushState = function patchedPushState(...args) {
+          const result = originalPushState.apply(this, args);
+          reportTransition();
+          return result;
+        };
+        win.history.replaceState = function patchedReplaceState(...args) {
+          const result = originalReplaceState.apply(this, args);
+          reportTransition();
+          return result;
+        };
+        win.addEventListener('popstate', reportTransition);
+
+        const dispose = () => {
+          win.history.pushState = originalPushState;
+          win.history.replaceState = originalReplaceState;
+          win.removeEventListener('popstate', reportTransition);
+        };
         ctx.signal?.addEventListener?.('abort', dispose);
         return dispose;
       }

--- a/plugins/posthog-analytics/app.test.js
+++ b/plugins/posthog-analytics/app.test.js
@@ -66,7 +66,11 @@ describe('ui-click content script', () => {
     let dispose;
     pluginApp.setup({
       contentScripts: {
-        register({ mount }) {
+        register({ id, mount }) {
+          // This describe block only exercises the ui-click tracker; the
+          // page-view tracker (registered separately) has its own describe
+          // block below and would otherwise clobber `dispose` here.
+          if (id !== 'ui-click-tracker') return;
           dispose = mount({ pluginId: 'posthog-analytics', signal });
         }
       }
@@ -122,5 +126,87 @@ describe('ui-click content script', () => {
     });
     expect(() => listeners[0].fn({ target: el('button', { 'data-testid': 'x' }) })).not.toThrow();
     await Promise.resolve();
+  });
+});
+
+describe('page-view content script', () => {
+  let originalLocation;
+  let originalHistory;
+  let originalAdd;
+  let originalRemove;
+
+  afterEach(() => {
+    delete globalThis.__ZCC_PLUGIN_HOST__;
+    if (originalLocation !== undefined) {
+      Object.defineProperty(globalThis, 'location', { value: originalLocation, configurable: true });
+    }
+    if (originalHistory !== undefined) {
+      Object.defineProperty(globalThis, 'history', { value: originalHistory, configurable: true });
+    }
+    if (originalAdd !== undefined) globalThis.addEventListener = originalAdd;
+    if (originalRemove !== undefined) globalThis.removeEventListener = originalRemove;
+  });
+
+  function mountPageViewTracker({ callRpc, path = '/inbox' } = {}) {
+    const listeners = [];
+    const win = {
+      location: { pathname: path },
+      history: { pushState: () => {}, replaceState: () => {} },
+      addEventListener: vi.fn((type, fn) => listeners.push({ type, fn })),
+      removeEventListener: vi.fn()
+    };
+    globalThis.__ZCC_PLUGIN_HOST__ = {
+      callRpc: callRpc ?? vi.fn(() => Promise.resolve({ ok: true }))
+    };
+
+    originalLocation = globalThis.location;
+    originalHistory = globalThis.history;
+    originalAdd = globalThis.addEventListener;
+    originalRemove = globalThis.removeEventListener;
+    // The content script reads globalThis.location/history directly, so this
+    // test swaps them out for the fake `win` for the duration of this test.
+    Object.defineProperty(globalThis, 'location', { value: win.location, configurable: true });
+    Object.defineProperty(globalThis, 'history', { value: win.history, configurable: true });
+    globalThis.addEventListener = win.addEventListener;
+    globalThis.removeEventListener = win.removeEventListener;
+
+    let dispose;
+    pluginApp.setup({
+      contentScripts: {
+        register({ id, mount }) {
+          if (id !== 'page-view-tracker') return;
+          dispose = mount({ pluginId: 'posthog-analytics' });
+        }
+      }
+    });
+    return { win, listeners, dispose, host: globalThis.__ZCC_PLUGIN_HOST__ };
+  }
+
+  it('reports a from/to/durationMs payload on a pushState navigation', () => {
+    const { win, host } = mountPageViewTracker({ path: '/inbox' });
+    win.location.pathname = '/agents';
+    win.history.pushState('', '', '/agents');
+    expect(host.callRpc).toHaveBeenCalledWith(
+      'posthog-analytics',
+      'trackPageView',
+      expect.objectContaining({ from: 'inbox', to: 'agents' })
+    );
+  });
+
+  it('does not report a transition to the same section', () => {
+    const { win, host } = mountPageViewTracker({ path: '/inbox' });
+    win.history.pushState('', '', '/inbox');
+    expect(host.callRpc).not.toHaveBeenCalled();
+  });
+
+  it('swallows synchronous RPC failures', () => {
+    const { win } = mountPageViewTracker({
+      path: '/inbox',
+      callRpc: () => {
+        throw new Error('sync rpc down');
+      }
+    });
+    win.location.pathname = '/agents';
+    expect(() => win.history.pushState('', '', '/agents')).not.toThrow();
   });
 });

--- a/plugins/posthog-analytics/package.json
+++ b/plugins/posthog-analytics/package.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Usage analytics, on by default when ZCC_POSTHOG_API_KEY is set (bring your own key or opt out): agent lifecycle events plus optional content-free UI-click ids. Never sends prompt or response content.",
+  "description": "Usage analytics, on by default when ZCC_POSTHOG_API_KEY is set (bring your own key or opt out): richer agent lifecycle events (model/provider/reasoning level/execution state/attachment presence) plus optional content-free UI-click ids and page-view/dwell-time tracking. Never sends prompt or response content.",
   "engines": {
     "zcc": ">=1.0.0",
     "zccPluginSdk": ">=0.1.0"
   },
   "zcc": {
     "name": "PostHog Analytics",
-    "description": "Usage analytics, on by default when ZCC_POSTHOG_API_KEY is set (bring your own key or opt out): agent lifecycle events plus optional content-free UI-click ids. Never sends prompt or response content.",
+    "description": "Usage analytics, on by default when ZCC_POSTHOG_API_KEY is set (bring your own key or opt out): richer agent lifecycle events (model/provider/reasoning level/execution state/attachment presence) plus optional content-free UI-click ids and page-view/dwell-time tracking. Never sends prompt or response content.",
     "branding": {
       "icon": "LineChart"
     },

--- a/plugins/posthog-analytics/server.mjs
+++ b/plugins/posthog-analytics/server.mjs
@@ -3,12 +3,17 @@
  * set (local `.env` or the baked release secret). Point Settings at your own
  * project or turn the master switch off to send nothing.
  *
- * Two kinds of signal, each behind its own toggle:
- *  1. Agent/thread lifecycle events (created/active/idle/failed/archived/deleted).
+ * Three kinds of signal, each behind its own toggle:
+ *  1. Agent/thread lifecycle events (created/active/idle/failed/archived/deleted),
+ *     now also carrying structural fields — providerId/model/reasoningLevel/
+ *     executionState/hadAttachments — never prompt/response content or paths.
  *  2. Coarse UI click events — ONLY a developer-authored `data-testid` and the
  *     element role. NEVER the button text, aria-label, input values, or any
  *     other user-generated content (labels routinely embed project names and
  *     thread titles, so they are deliberately never read).
+ *  3. Optional page/section navigation + dwell time — ONLY a fixed nav-name
+ *     enum for `from`/`to` and a bounded duration in ms. NEVER a path,
+ *     project id, thread id, or other dynamic route segment.
  *
  * Nothing is ever sent about prompt/response content. See README.md.
  */
@@ -21,6 +26,25 @@ const EVENT_NAMES = [
   'thread.archived',
   'thread.deleted'
 ];
+
+/** Fixed nav-name enum re-validated server-side (Rule 1: never trust the
+ *  renderer) — mirrors decode-route.ts's DecodedRoute.nav literals plus the
+ *  "plugin" bucket app.js uses for any nav id outside this fixed set. */
+const KNOWN_NAV_VALUES = new Set([
+  'home',
+  'inbox',
+  'agents',
+  'followups',
+  'suggestions',
+  'scheduler',
+  'goals',
+  'settings',
+  'extensions',
+  'projects',
+  'plugin'
+]);
+
+const MAX_PAGE_VIEW_DURATION_MS = 24 * 60 * 60 * 1000; // 24h sanity cap
 
 const DISTINCT_ID_KEY = 'distinctId';
 const DEFAULT_HOST = 'https://us.posthog.com';
@@ -48,6 +72,13 @@ export default function plugin(zcc) {
       label: 'Also track UI clicks (button ids only)',
       description:
         'Sends a zcc_ui_click event carrying only a developer-authored data-testid and the element role — never button text, labels, or input values.',
+      default: false
+    },
+    trackPageViews: {
+      type: 'boolean',
+      label: 'Also track page navigation & time spent',
+      description:
+        'Sends a zcc_page_view event on each section change carrying only a fixed nav-name enum (from/to) and a duration in ms — never a path, project id, or thread id.',
       default: false
     },
     apiKey: {
@@ -119,7 +150,15 @@ export default function plugin(zcc) {
     const values = await settings.get();
     if (!values.enabled || !values.apiKey) return;
     await sendEvent(values, `zcc_${name.replace('.', '_')}`, {
-      projectId: event.projectId ?? null
+      projectId: event.projectId ?? null,
+      // Structural/enum/boolean-only fields — never prompt/response content,
+      // paths, or titles. All optional; a missing value is sent as null so
+      // the PostHog schema stays stable across event names.
+      providerId: typeof event.providerId === 'string' ? event.providerId : null,
+      model: typeof event.model === 'string' ? event.model : null,
+      reasoningLevel: typeof event.reasoningLevel === 'string' ? event.reasoningLevel : null,
+      executionState: typeof event.executionState === 'string' ? event.executionState : null,
+      hadAttachments: typeof event.hadAttachments === 'boolean' ? event.hadAttachments : null
     });
   }
 
@@ -148,6 +187,41 @@ export default function plugin(zcc) {
     if (!properties.testid && !properties.role) return { ok: false };
     await sendEvent(values, 'zcc_ui_click', properties).catch((err) =>
       zcc.log.warn(`posthog ui click failed: ${err}`)
+    );
+    return { ok: true };
+  });
+
+  /**
+   * Called by the renderer content script (see app.js) on each section
+   * transition. Re-validated here (Rule 1: never trust the renderer) — `from`
+   * and `to` must be one of {@link KNOWN_NAV_VALUES} (anything else, including
+   * a raw plugin nav id, is dropped rather than forwarded) and `durationMs`
+   * must be a finite, non-negative number under {@link MAX_PAGE_VIEW_DURATION_MS}.
+   * Gated on BOTH the master switch and this feature's own toggle
+   * (`trackPageViews`, off by default, independent of `trackUiClicks`).
+   */
+  zcc.rpc.method('trackPageView', async (input) => {
+    const values = await settings.get();
+    if (!values.enabled || !values.trackPageViews || !values.apiKey) return { ok: false };
+
+    const rawFrom = input && input.from;
+    const rawTo = input && input.to;
+    const from = typeof rawFrom === 'string' && KNOWN_NAV_VALUES.has(rawFrom) ? rawFrom : null;
+    const to = typeof rawTo === 'string' && KNOWN_NAV_VALUES.has(rawTo) ? rawTo : null;
+    if (!to) return { ok: false };
+
+    const rawDuration = input && input.durationMs;
+    if (
+      typeof rawDuration !== 'number' ||
+      !Number.isFinite(rawDuration) ||
+      rawDuration < 0 ||
+      rawDuration > MAX_PAGE_VIEW_DURATION_MS
+    ) {
+      return { ok: false };
+    }
+
+    await sendEvent(values, 'zcc_page_view', { from, to, durationMs: rawDuration }).catch((err) =>
+      zcc.log.warn(`posthog page view failed: ${err}`)
     );
     return { ok: true };
   });

--- a/plugins/posthog-analytics/server.test.mjs
+++ b/plugins/posthog-analytics/server.test.mjs
@@ -67,7 +67,7 @@ describe('posthog-analytics plugin', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('sends only event name, distinct id, and projectId — never content', async () => {
+  it('sends event name, distinct id, and projectId — never content — with the new fields defaulting to null', async () => {
     const zcc = makeZcc({ enabled: true, apiKey: 'k-123', host: 'https://us.posthog.com' });
     plugin(zcc);
     await zcc._handlers.get('thread.created')({ projectId: 'p1', threadId: 't1' });
@@ -80,10 +80,62 @@ describe('posthog-analytics plugin', () => {
       api_key: 'k-123',
       event: 'zcc_thread_created',
       distinct_id: 'fixed-uuid',
-      properties: { projectId: 'p1' }
+      properties: {
+        projectId: 'p1',
+        providerId: null,
+        model: null,
+        reasoningLevel: null,
+        executionState: null,
+        hadAttachments: null
+      }
     });
     expect(body).not.toHaveProperty('timestamp');
     expect(JSON.stringify(body)).not.toContain('threadId');
+  });
+
+  it('forwards the new structural fields (providerId/model/reasoningLevel/executionState/hadAttachments) — still never content', async () => {
+    const zcc = makeZcc({ enabled: true, apiKey: 'k-123', host: 'https://us.posthog.com' });
+    plugin(zcc);
+    await zcc._handlers.get('thread.active')({
+      projectId: 'p1',
+      threadId: 't1',
+      providerId: 'claude-code',
+      model: 'claude-sonnet-5',
+      reasoningLevel: 'high',
+      executionState: 'accept-edits',
+      hadAttachments: true,
+      // hostile extras that must never reach PostHog:
+      promptText: 'do the secret thing',
+      attachmentPath: '/Users/me/secret.png'
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(body.properties).toEqual({
+      projectId: 'p1',
+      providerId: 'claude-code',
+      model: 'claude-sonnet-5',
+      reasoningLevel: 'high',
+      executionState: 'accept-edits',
+      hadAttachments: true
+    });
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('promptText');
+    expect(serialized).not.toContain('attachmentPath');
+  });
+
+  it('drops a non-scalar/wrong-typed new field rather than forwarding it', async () => {
+    const zcc = makeZcc({ enabled: true, apiKey: 'k-123', host: 'https://us.posthog.com' });
+    plugin(zcc);
+    await zcc._handlers.get('thread.idle')({
+      projectId: 'p1',
+      providerId: 42,
+      hadAttachments: 'yes'
+    });
+    const body = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(body.properties.providerId).toBeNull();
+    expect(body.properties.hadAttachments).toBeNull();
   });
 
   it('strips a trailing slash from a custom host', async () => {
@@ -151,6 +203,7 @@ describe('posthog-analytics plugin', () => {
     expect(descriptors.enabled.default).toBe(true);
     expect(descriptors.apiKey.default).toBe('phc_from_env');
     expect(descriptors.trackUiClicks.default).toBe(false);
+    expect(descriptors.trackPageViews.default).toBe(false);
   });
 
   it('defaults apiKey to empty when ZCC_POSTHOG_API_KEY is unset', () => {
@@ -220,6 +273,108 @@ describe('posthog-analytics plugin', () => {
       plugin(zcc);
       await zcc._rpc.get('trackUiClick')({ testid: 'x'.repeat(500), role: 42 });
       // testid too long, role not a string → nothing identifiable left → no send
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trackPageView RPC', () => {
+    it('does not fetch when page-view tracking is off (even if enabled)', async () => {
+      const zcc = makeZcc({ enabled: true, trackPageViews: false, apiKey: 'k', host: DEFAULT_HOST });
+      plugin(zcc);
+      const res = await zcc._rpc.get('trackPageView')({ from: 'inbox', to: 'agents', durationMs: 1200 });
+      expect(res).toEqual({ ok: false });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch when the master switch is off', async () => {
+      const zcc = makeZcc({ enabled: false, trackPageViews: true, apiKey: 'k', host: DEFAULT_HOST });
+      plugin(zcc);
+      await zcc._rpc.get('trackPageView')({ from: 'inbox', to: 'agents', durationMs: 1200 });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('is independent of trackUiClicks — page views can be on while clicks stay off', async () => {
+      const zcc = makeZcc({
+        enabled: true,
+        trackUiClicks: false,
+        trackPageViews: true,
+        apiKey: 'k',
+        host: DEFAULT_HOST
+      });
+      plugin(zcc);
+      const res = await zcc._rpc.get('trackPageView')({ from: 'home', to: 'settings', durationMs: 500 });
+      expect(res).toEqual({ ok: true });
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends only from/to/durationMs, never any other field', async () => {
+      const zcc = makeZcc({ enabled: true, trackPageViews: true, apiKey: 'k-7', host: DEFAULT_HOST });
+      plugin(zcc);
+      const res = await zcc._rpc.get('trackPageView')({
+        from: 'inbox',
+        to: 'projects',
+        durationMs: 4500,
+        // hostile extras that must be dropped:
+        projectId: 'proj-secret',
+        path: '/projects/proj-secret/threads/abc'
+      });
+      expect(res).toEqual({ ok: true });
+      const body = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(body.event).toBe('zcc_page_view');
+      expect(body.properties).toEqual({ from: 'inbox', to: 'projects', durationMs: 4500 });
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain('proj-secret');
+    });
+
+    it('treats a null/missing from as null but still sends when to is known', async () => {
+      const zcc = makeZcc({ enabled: true, trackPageViews: true, apiKey: 'k', host: DEFAULT_HOST });
+      plugin(zcc);
+      const res = await zcc._rpc.get('trackPageView')({ to: 'agents', durationMs: 0 });
+      expect(res).toEqual({ ok: true });
+      const body = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(body.properties).toEqual({ from: null, to: 'agents', durationMs: 0 });
+    });
+
+    it('buckets an unknown nav value (e.g. a raw plugin id) as dropped rather than forwarded verbatim', async () => {
+      const zcc = makeZcc({ enabled: true, trackPageViews: true, apiKey: 'k', host: DEFAULT_HOST });
+      plugin(zcc);
+      const res = await zcc._rpc.get('trackPageView')({ from: 'agents', to: 'some-third-party-plugin-id', durationMs: 100 });
+      // "to" is not in the known enum → rejected outright (never forwarded verbatim)
+      expect(res).toEqual({ ok: false });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a negative durationMs', async () => {
+      const zcc = makeZcc({ enabled: true, trackPageViews: true, apiKey: 'k', host: DEFAULT_HOST });
+      plugin(zcc);
+      const res = await zcc._rpc.get('trackPageView')({ from: 'home', to: 'agents', durationMs: -5 });
+      expect(res).toEqual({ ok: false });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a durationMs over the 24h sanity cap', async () => {
+      const zcc = makeZcc({ enabled: true, trackPageViews: true, apiKey: 'k', host: DEFAULT_HOST });
+      plugin(zcc);
+      const res = await zcc._rpc.get('trackPageView')({ from: 'home', to: 'agents', durationMs: 25 * 60 * 60 * 1000 });
+      expect(res).toEqual({ ok: false });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-numeric or non-finite durationMs', async () => {
+      const zcc = makeZcc({ enabled: true, trackPageViews: true, apiKey: 'k', host: DEFAULT_HOST });
+      plugin(zcc);
+      const resA = await zcc._rpc.get('trackPageView')({ from: 'home', to: 'agents', durationMs: 'soon' });
+      const resB = await zcc._rpc.get('trackPageView')({ from: 'home', to: 'agents', durationMs: Infinity });
+      expect(resA).toEqual({ ok: false });
+      expect(resB).toEqual({ ok: false });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing/unknown "to"', async () => {
+      const zcc = makeZcc({ enabled: true, trackPageViews: true, apiKey: 'k', host: DEFAULT_HOST });
+      plugin(zcc);
+      const res = await zcc._rpc.get('trackPageView')({ from: 'home', durationMs: 10 });
+      expect(res).toEqual({ ok: false });
       expect(fetch).not.toHaveBeenCalled();
     });
   });

--- a/website/content/marketplace/marketplace.json
+++ b/website/content/marketplace/marketplace.json
@@ -490,7 +490,7 @@
     {
       "id": "posthog-analytics",
       "displayName": "PostHog Analytics",
-      "description": "Usage analytics, on by default when ZCC_POSTHOG_API_KEY is set (bring your own key or opt out): agent lifecycle events plus optional content-free UI-click ids. Never sends prompt or response content.",
+      "description": "Usage analytics, on by default when ZCC_POSTHOG_API_KEY is set (bring your own key or opt out): richer agent lifecycle events (model/provider/reasoning level/execution state/attachment presence) plus optional content-free UI-click ids and page-view/dwell-time tracking. Never sends prompt or response content.",
       "icon": {
         "lucide": "LineChart"
       },


### PR DESCRIPTION
## What

Extends the `posthog-analytics` plugin with three new, content-free signal categories on top of the existing (enabled-by-default, master-switch/opt-out/BYOK) instrumentation:

1. **UI button clicks** — an opt-in content script records which UI element (by stable id) was pressed, never label/content text.
2. **Page/section views + dwell time** — an opt-in content script patches `history.pushState`/`replaceState` and reports which known nav destination was visited and how long the user stayed (bounded duration, capped `MAX_PAGE_VIEW_DURATION_MS`), validated server-side against a `KNOWN_NAV_VALUES` allowlist.
3. **Agent lifecycle enrichment** — `thread.created`/`thread.active`/`thread.archived`/`thread.deleted` events now optionally carry `providerId`, `model`, `reasoningLevel`, `executionState`, and `hadAttachments` (a boolean, never attachment names/paths/content).

Hard privacy line preserved throughout: never prompt/response text, file/attachment names or paths, user names, or other free-text/UGC — only structural/enum/boolean/duration data.

Also fixes 3 pre-existing local test failures that were blocking the repo's `.githooks/pre-push` gate (unrelated to this feature, but required before this branch could push):
- `apps/host-daemon/src/harness/__tests__/providers.test.ts` mocked a dead relative path instead of the real `@zana-ai/zcc-llm` specifier, so it silently read the real machine's `~/.claude/settings.json` and let ambient model-alias config leak into the assertions.
- `packages/streamdeck/src/__tests__/app.test.ts` asserted a `term.reply` intent right after seeing `agent.list` recorded, which only proves the control plane received the request, not that the client-side poll had rebuilt the grid yet — flaky under full-suite load.
- `website/content/marketplace/marketplace.json` was stale (missing the `posthog-analytics` entry already on disk); regenerated via the existing `scripts/generate-marketplace.mjs`.

## Why

Product wants richer usage signal (which buttons get used, which surfaces get dwell time, what model/provider/reasoning mix is actually running) without ever weakening the plugin's no-content privacy guarantee, and without breaking the master switch / README disclaimer / opt-out / bring-your-own-key behavior that ships this plugin on by default.

## How verified

- [x] `npm run typecheck` passes (via the pre-push hook)
- [x] `npm test` passes — full root-level suite: 1019 test files passed, 7 skipped, 0 failed (9672 passed / 40 skipped)
- [x] Focused runs: `plugins/posthog-analytics` full suite (24/24), `apps/server` conversation-lifecycle + conversation-create tests (45/45), `apps/host-daemon` providers.test.ts (40/40), `packages/streamdeck` app.test.ts (5/5), `website` official-marketplace.test.ts (6/6)
- [ ] Ran the app locally and exercised the change (`npm run dev`) — not run in this session; covered by unit/integration tests above

## Notes for reviewers

- Voice/audio presence was explored but NOT shipped — see the README's "what we looked at but didn't ship" section for the reasoning (no reliable content-free signal was available without touching audio content).
- The 3 pre-existing test fixes in this PR are out of scope for the posthog feature itself but were required to get a clean local `pre-push` gate; happy to split into a separate PR if preferred.