### PR TITLE
test(execution): use one clock for overdue deadline status

### DIFF
--- a/apps/server/src/services/execution/__tests__/execution-service.test.ts
+++ b/apps/server/src/services/execution/__tests__/execution-service.test.ts
@@ -383,9 +383,11 @@ describe('SquadExecutionService', () => {
   }));
 
   it('stops an overdue execution and cancels its Team lifecycle', async () => fixture(async (filePath) => {
-    let now = Date.now();
+    let now = 1_000_000;
+    const store = createExecutionStore({ filePath, id: () => 'execution-1', now: () => now });
     const cancelTeamLaunch = vi.fn(async () => ({ ok: true, value: { canceledSessionIds: ['worker-1'], pendingSessionIds: [] } }));
     const service = new SquadExecutionService(deps(filePath, {
+      store,
       now: () => now,
       cancelTeamLaunch,
       getTeamLaunch: async () => ({ workers: [{ slotId: 'slot-1', sessionId: 'worker-1', projectId: 'project-1', process: 'running' }] })


### PR DESCRIPTION
## Summary
- Align the overdue-execution unit test so the store and service share one `now` clock.
- A slow `start()` previously stamped `createdAt` with real `Date.now()` while the service used a captured fake time, so status never reached `STOPPED` and blocked the 2.1.0 tag push.

## Test plan
- [x] `npx vitest run apps/server/src/services/execution/__tests__/execution-service.test.ts -t 'stops an overdue execution'`
- [x] Full `npm test` via pre-push (12106 passed)