### PR TITLE
fix: restore Node better-sqlite3 after Electron E2E without re-dlopen

### DIFF
--- a/scripts/ensure-better-sqlite3.mjs
+++ b/scripts/ensure-better-sqlite3.mjs
@@ -33,6 +33,31 @@ export function tryLoadBetterSqlite3() {
   }
 }
 
+/**
+ * Native addons cannot be re-dlopen'd in the same Node process after a failed
+ * load. Probe and post-rebuild verify in a child so restore never maps the
+ * Electron-built .node (that was failing smoke teardown with
+ * "Module did not self-register").
+ */
+export function probeBetterSqlite3InChild() {
+  const script = `
+    const { createRequire } = require('node:module');
+    const requireFrom = createRequire(${JSON.stringify(import.meta.url)});
+    const Database = requireFrom('better-sqlite3');
+    const db = new Database(':memory:');
+    db.close();
+  `;
+  const result = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+  if (result.status === 0) return { ok: true };
+  const message = `${result.stderr || ''}${result.stdout || ''}`.trim()
+    || 'better-sqlite3 failed to load in child process';
+  const error = new Error(message);
+  if (/ERR_DLOPEN_FAILED|NODE_MODULE_VERSION|did not self-register/.test(message)) {
+    error.code = 'ERR_DLOPEN_FAILED';
+  }
+  return { ok: false, error };
+}
+
 export function rebuildBetterSqlite3ForNode() {
   const cwd = sqlitePackageRoot();
   const nodeGyp = require.resolve('node-gyp/bin/node-gyp.js', { paths: [cwd, process.cwd()] });
@@ -50,11 +75,11 @@ export function rebuildBetterSqlite3ForNode() {
 }
 
 export function ensureBetterSqlite3ForNode() {
-  const loaded = tryLoadBetterSqlite3();
+  const loaded = probeBetterSqlite3InChild();
   if (loaded.ok) return;
   if (!isNativeAbiMismatch(loaded.error)) throw loaded.error;
   rebuildBetterSqlite3ForNode();
-  const retry = tryLoadBetterSqlite3();
+  const retry = probeBetterSqlite3InChild();
   if (!retry.ok) throw retry.error;
 }
 

--- a/scripts/ensure-better-sqlite3.test.ts
+++ b/scripts/ensure-better-sqlite3.test.ts
@@ -2,7 +2,12 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { isNativeAbiMismatch, sqlitePackageRoot } from './ensure-better-sqlite3.mjs';
+import {
+  isNativeAbiMismatch,
+  probeBetterSqlite3InChild,
+  sqlitePackageRoot,
+  tryLoadBetterSqlite3
+} from './ensure-better-sqlite3.mjs';
 
 const repoRoot = dirname(fileURLToPath(new URL('.', import.meta.url)));
 
@@ -15,6 +20,18 @@ describe('ensure-better-sqlite3', () => {
 
   it('resolves the workspace better-sqlite3 install', () => {
     expect(sqlitePackageRoot()).toContain('better-sqlite3');
+  });
+
+  it('can load better-sqlite3 in a fresh child after this process has already required it', () => {
+    expect(tryLoadBetterSqlite3()).toEqual({ ok: true });
+    expect(probeBetterSqlite3InChild()).toEqual({ ok: true });
+  });
+
+  it('never dlopens better-sqlite3 in the restore process, before or after rebuild', () => {
+    const src = readFileSync(join(repoRoot, 'scripts/ensure-better-sqlite3.mjs'), 'utf8');
+    expect(src).toMatch(/const loaded = probeBetterSqlite3InChild\(\);/);
+    expect(src).toMatch(/rebuildBetterSqlite3ForNode\(\);\s*const retry = probeBetterSqlite3InChild\(\);/);
+    expect(src).not.toMatch(/ensureBetterSqlite3ForNode[\s\S]*tryLoadBetterSqlite3/);
   });
 
   it('runs before local Node servers so Electron rebuilds cannot empty pnpm dev', () => {


### PR DESCRIPTION
## Summary
- The v2.1.0 release smoke job passed `e2e/smoke.spec.ts`, then failed in teardown while restoring Node's `better-sqlite3` ABI.
- `node-gyp rebuild` succeeded, but the same process had already `dlopen`'d the Electron-built addon, so the retry failed with `Module did not self-register`.
- Probe and post-rebuild verify now run in a child process so restore never maps the Electron `.node`.

## Test plan
- [x] `pnpm exec vitest run scripts/ensure-better-sqlite3.test.ts`
- [x] Local repro: `pnpm run rebuild:electron && node scripts/ensure-better-sqlite3.mjs` exits 0
- [ ] Release smoke job on the retagged `v2.1.0` after this lands